### PR TITLE
Wands Mappening

### DIFF
--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -22862,10 +22862,6 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
-"gFt" = (
-/turf/open/floor/greenscreen,
-/turf/open/floor/greenscreen,
-/area/vtm/interior)
 "gFJ" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -37542,10 +37538,6 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
-"lbT" = (
-/turf/closed/wall/vampwall/painted,
-/turf/closed/wall/vampwall/painted,
-/area/vtm/interior)
 "lbV" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -38499,7 +38491,6 @@
 /obj/structure/chair/sofa/corp/corner{
 	color = "#CD5C5C"
 	},
-/turf/open/floor/wood/smooth,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "lro" = (
@@ -188872,7 +188863,7 @@ iog
 hfy
 knX
 uuy
-gFt
+uuy
 uuy
 mrm
 hfy
@@ -189640,7 +189631,7 @@ fQP
 rFS
 iog
 iog
-lbT
+hfy
 aYu
 lVM
 lVM

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -123,6 +123,10 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
+"abX" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/carpet/darkpack/old,
+/area/vtm/interior/giovanni)
 "aca" = (
 /mob/living/basic/mouse/vampire,
 /turf/open/floor/plating/sidewalk/poor,
@@ -1474,7 +1478,7 @@
 /obj/effect/decal/shadow,
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 5
 	},
 /turf/open/water,
 /area/vtm/interior/jazzclub)
@@ -4523,9 +4527,6 @@
 /turf/open/floor/wood,
 /area/vtm/interior/church/haven)
 "bot" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -8607,6 +8608,10 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "cwZ" = (
@@ -9467,7 +9472,7 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 7
+	pixel_y = 1
 	},
 /obj/machinery/light/prince/directional/north,
 /turf/open/openspace,
@@ -10893,9 +10898,6 @@
 "dfu" = (
 /obj/structure/hedge{
 	pixel_y = 6
-	},
-/obj/structure/railing{
-	dir = 4
 	},
 /obj/structure/flora/bush/lavendergrass/style_random{
 	pixel_y = 13
@@ -13697,6 +13699,10 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "dZo" = (
@@ -15432,7 +15438,7 @@
 /obj/structure/stairs/east,
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 1
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
@@ -17879,6 +17885,13 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights/old)
+"flD" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/setite)
 "flL" = (
 /obj/item/storage/basket,
 /obj/item/gun/ballistic/automatic/pistol/darkpack/m1911,
@@ -18415,7 +18428,7 @@
 /obj/effect/decal/support,
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 5
 	},
 /turf/open/water,
 /area/vtm/interior/jazzclub)
@@ -18937,7 +18950,7 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 1
 	},
 /obj/structure/curtain/cloth/fancy/mechanical{
 	id = 2005
@@ -20921,6 +20934,11 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
+"gdA" = (
+/obj/structure/chair,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/clinic)
 "gdQ" = (
 /obj/machinery/light/prince/directional/east,
 /turf/open/water,
@@ -25724,6 +25742,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
+"hzQ" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/vtm/interior/jazzclub)
 "hAa" = (
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
@@ -25743,12 +25765,12 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/glasswalker)
 "hAj" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 12
-	},
 /obj/effect/decal/shadow,
 /obj/effect/decal/support,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/water,
 /area/vtm/interior/jazzclub)
 "hAn" = (
@@ -25772,6 +25794,10 @@
 	},
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
@@ -26104,6 +26130,10 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
+"hFM" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/giovanni)
 "hFR" = (
 /obj/structure/stairs/north,
 /turf/open/floor/wood/smooth/old,
@@ -28532,6 +28562,10 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"iue" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/supply)
 "iug" = (
 /obj/structure/railing{
 	dir = 1;
@@ -29359,14 +29393,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
-"iGA" = (
-/obj/structure/hedge,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/jazzclub)
 "iGD" = (
 /obj/structure/vampdoor/glass{
 	dir = 4
@@ -30348,6 +30374,10 @@
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
 "iVw" = (
@@ -30778,6 +30808,10 @@
 /obj/item/food/cake/lemon,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/tzimisce_manor)
+"jbv" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/carpet,
+/area/vtm/interior/anarch)
 "jby" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/dirt,
@@ -34778,6 +34812,11 @@
 /obj/structure/platform/lowwall/painted,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop)
+"kmN" = (
+/obj/effect/decal/graffiti,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/anarch)
 "kmO" = (
 /obj/structure/roadsign/busstop{
 	pixel_y = -8
@@ -34898,6 +34937,10 @@
 "koz" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
 /obj/structure/table/wood/fancy/green,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
 "koE" = (
@@ -41982,6 +42025,12 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/ventrue)
+"mwm" = (
+/obj/effect/decal/wallpaper/paper/darkred,
+/obj/structure/table/wood,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/vtm/interior/jazzclub)
 "mwq" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/reagent_containers/blood,
@@ -43503,6 +43552,10 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"mRu" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/supply)
 "mRv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -45106,6 +45159,14 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
+"npF" = (
+/obj/structure/table/wood/fancy/green,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/giovanni)
 "npH" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
@@ -47929,6 +47990,10 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
+"ofk" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/anarch)
 "ofl" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/vampdoor/simple,
@@ -48546,6 +48611,10 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/theatre)
+"opx" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/carpet/darkpack/old,
+/area/vtm/interior/giovanni)
 "opy" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -53649,11 +53718,11 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/effect/decal/shadow,
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 5
 	},
-/obj/effect/decal/shadow,
 /turf/open/misc/grass,
 /area/vtm/interior/jazzclub)
 "pJu" = (
@@ -55014,6 +55083,10 @@
 	pixel_x = -7;
 	pixel_y = 12
 	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "qdt" = (
@@ -55267,12 +55340,12 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
 "qgG" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 12
-	},
 /obj/effect/decal/shadow,
 /obj/structure/flora/rock/darkpack_big,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/water,
 /area/vtm/interior/jazzclub)
 "qgK" = (
@@ -56539,6 +56612,11 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"qyU" = (
+/obj/structure/chair,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/clinic)
 "qza" = (
 /turf/open/floor/carpet,
 /area/vtm/interior/tzimisce_manor)
@@ -58721,7 +58799,7 @@
 "ree" = (
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 5
 	},
 /turf/open/misc/grass,
 /area/vtm/interior/jazzclub)
@@ -59439,7 +59517,7 @@
 "ror" = (
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 1
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -62338,24 +62416,6 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/financialdistrict)
-"sej" = (
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/jazzclub)
 "sel" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -63033,6 +63093,15 @@
 /obj/structure/flora/tree/vamp,
 /turf/open/misc/grass,
 /area/vtm/interior/library)
+"soN" = (
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/water{
+	color = "#483C32"
+	},
+/area/vtm/interior/giovanni/basement)
 "soO" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/blood/vitae,
@@ -63348,7 +63417,7 @@
 /obj/structure/chair/wood/wings,
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 1
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/theatre)
@@ -63400,6 +63469,10 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/chinatown)
+"stx" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/city/bacotell,
+/area/vtm/interior/shop)
 "stS" = (
 /turf/open/floor/iron/dark,
 /area/vtm/interior/shop)
@@ -63421,9 +63494,6 @@
 /area/vtm)
 "stX" = (
 /obj/effect/turf_decal/siding/white,
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/giovanni/basement)
 "suf" = (
@@ -63978,9 +64048,6 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "sDj" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -67436,12 +67503,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
-"tGX" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/openspace,
-/area/vtm/interior/giovanni)
 "tHd" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/instrument/guitar,
@@ -67933,6 +67994,10 @@
 "tOY" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf/ghetto)
+"tPf" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/carpet/darkpack/old,
+/area/vtm/interior/giovanni)
 "tPi" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/roadsign/warningpedestrian,
@@ -68125,7 +68190,7 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 7
+	pixel_y = 1
 	},
 /obj/machinery/light/prince/directional/north,
 /turf/open/openspace,
@@ -70016,6 +70081,10 @@
 	pixel_x = -7;
 	pixel_y = 12
 	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "uxa" = (
@@ -70083,6 +70152,11 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/tzimisce_sanctum)
+"uxF" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/carpet,
+/area/vtm/interior/anarch)
 "uxV" = (
 /turf/closed/wall/vampwall/rock{
 	density = 0
@@ -70889,7 +70963,7 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 7
+	pixel_y = 1
 	},
 /turf/open/openspace,
 /area/vtm/interior/giovanni)
@@ -71827,9 +71901,6 @@
 "uYB" = (
 /obj/structure/hedge,
 /obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/structure/flora/bush/flowers_yw/style_random{
 	pixel_y = 10
 	},
@@ -73699,6 +73770,11 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior)
+"vCM" = (
+/mob/living/carbon/human/npc/guard,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/city/bacotell,
+/area/vtm/interior/shop)
 "vCQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -73974,9 +74050,6 @@
 /area/vtm/interior)
 "vGp" = (
 /obj/structure/stairs/east,
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
 "vGq" = (
@@ -74905,6 +74978,10 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "vUz" = (
@@ -75092,9 +75169,6 @@
 /obj/fusebox,
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
-"vXw" = (
-/turf/open/space/basic,
-/area/vtm/interior/shop)
 "vXx" = (
 /obj/structure/vampfence/corner/rich{
 	dir = 4;
@@ -77034,9 +77108,6 @@
 /area/vtm)
 "wCj" = (
 /obj/structure/stairs/west,
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
 "wCr" = (
@@ -77320,7 +77391,7 @@
 "wGw" = (
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 12
+	pixel_y = 1
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -77865,6 +77936,13 @@
 /obj/effect/turf_decal/asphaltline,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights)
+"wOO" = (
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior/giovanni/basement)
 "wOQ" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -77969,7 +78047,7 @@
 /obj/structure/stairs/west,
 /obj/structure/railing{
 	dir = 1;
-	pixel_y = 16
+	pixel_y = 1
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
@@ -78033,6 +78111,10 @@
 /obj/structure/chair/wood/wings{
 	dir = 8;
 	pixel_y = 6
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
@@ -82634,6 +82716,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
+"yiQ" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/setite)
 "yiU" = (
 /obj/structure/vampipe{
 	icon_state = "piping35";
@@ -92593,7 +92679,7 @@ xMx
 mHl
 apK
 stX
-ihq
+soN
 ihq
 wqI
 mHl
@@ -92850,7 +92936,7 @@ jse
 pxk
 fjz
 stX
-ihq
+soN
 xqZ
 ihq
 mHl
@@ -93107,7 +93193,7 @@ jse
 mHl
 qhX
 stX
-ihq
+soN
 ihq
 ihq
 mHl
@@ -93617,7 +93703,7 @@ lcf
 rhf
 wQa
 wCj
-rhf
+wOO
 lcf
 mHl
 mHl
@@ -94388,7 +94474,7 @@ nOu
 rhf
 eAB
 vGp
-rhf
+wOO
 nOu
 mHl
 mRd
@@ -150355,7 +150441,7 @@ dAV
 dAV
 kax
 iKo
-dAV
+yiQ
 dAV
 vNX
 vNX
@@ -151129,7 +151215,7 @@ nao
 dAV
 dAV
 oSB
-eFd
+flD
 eFd
 eFd
 eFd
@@ -155802,7 +155888,7 @@ gcL
 iSD
 kfr
 dFZ
-kyB
+hFM
 uJx
 gcL
 xNg
@@ -156063,7 +156149,7 @@ hlf
 hlf
 uNJ
 hlf
-hlf
+abX
 hlf
 hlf
 hlf
@@ -156936,8 +157022,8 @@ wEO
 wod
 cQR
 bzp
-bzp
 bpj
+bzp
 nGZ
 obM
 oWV
@@ -156946,7 +157032,7 @@ iEl
 asI
 stS
 asI
-stS
+bsp
 bvc
 xdS
 msq
@@ -157606,7 +157692,7 @@ dCT
 uJx
 gcL
 vqO
-hlf
+tPf
 uJx
 uJx
 uJx
@@ -158120,7 +158206,7 @@ hlf
 hlf
 uNJ
 hlf
-hlf
+opx
 uJx
 uJx
 uJx
@@ -158231,7 +158317,7 @@ bqg
 mzW
 stS
 asI
-bsp
+stS
 bgX
 lpX
 mPa
@@ -158488,7 +158574,7 @@ stS
 asI
 stS
 asI
-stS
+bsp
 bgX
 aIo
 aIo
@@ -159002,7 +159088,7 @@ bqg
 mzW
 stS
 asI
-bsp
+stS
 mgN
 ewI
 ewI
@@ -159259,7 +159345,7 @@ stS
 asI
 stS
 asI
-stS
+bsp
 bvc
 bvc
 bvc
@@ -159409,7 +159495,7 @@ hlf
 rwv
 gcL
 uJu
-tGX
+bqB
 koz
 kyB
 uJx
@@ -159666,8 +159752,8 @@ hlf
 rwv
 gcL
 uJu
-tGX
-puU
+bqB
+npF
 kyB
 uJx
 utD
@@ -159773,7 +159859,7 @@ nzX
 asN
 stS
 uCl
-bsp
+stS
 bvc
 dnN
 oWV
@@ -160030,7 +160116,7 @@ stS
 rSH
 stS
 kek
-stS
+bsp
 bvc
 nXI
 oWV
@@ -160544,7 +160630,7 @@ nzX
 uqa
 stS
 tPJ
-bsp
+stS
 bvc
 hGy
 oWV
@@ -160801,7 +160887,7 @@ stS
 yas
 stS
 jVB
-stS
+bsp
 bvc
 hGy
 oWV
@@ -161315,7 +161401,7 @@ nzX
 eIB
 stS
 qvp
-bsp
+stS
 bvc
 hGy
 oWV
@@ -161572,7 +161658,7 @@ stS
 iTs
 stS
 ldb
-stS
+bsp
 bvc
 hGy
 oWV
@@ -166173,7 +166259,7 @@ oZb
 bGN
 qLB
 qLB
-bGN
+uxF
 fkk
 rXs
 msq
@@ -166674,7 +166760,7 @@ rvo
 tbF
 pho
 kGg
-wsX
+ofk
 wsX
 wsX
 wsX
@@ -167458,7 +167544,7 @@ oZb
 pDs
 qLB
 qLB
-qLB
+jbv
 fkk
 nlc
 msq
@@ -168730,7 +168816,7 @@ aOU
 wLp
 htz
 kGg
-xnW
+kmN
 bLe
 bLe
 pMC
@@ -175508,7 +175594,7 @@ wbX
 wcJ
 fzQ
 bex
-sej
+dfu
 hnC
 ftr
 sjL
@@ -177309,7 +177395,7 @@ fzQ
 wsc
 uWo
 nLV
-iGA
+oGl
 tLz
 tLz
 tLz
@@ -179369,7 +179455,7 @@ xPY
 wsc
 geL
 wsc
-oPU
+mwm
 oPU
 wsc
 auB
@@ -179624,7 +179710,7 @@ sGe
 oVf
 dWa
 wsc
-cCY
+hzQ
 cCY
 tCE
 tCE
@@ -180541,7 +180627,7 @@ drP
 faX
 cTu
 bUt
-rHp
+gdA
 jcx
 sSW
 fZQ
@@ -181055,7 +181141,7 @@ fPs
 cnc
 tiS
 bUt
-rHp
+qyU
 jcx
 sSO
 grH
@@ -181600,7 +181686,7 @@ paa
 paa
 gwD
 bvQ
-udd
+vCM
 scR
 scR
 scR
@@ -184289,7 +184375,7 @@ pdi
 bUo
 oiT
 sQR
-vXw
+oHG
 ewI
 ewI
 ewI
@@ -184684,7 +184770,7 @@ ewI
 ewI
 ewI
 bvQ
-scR
+stx
 scR
 scR
 scR
@@ -205135,7 +205221,7 @@ xTh
 hME
 sAm
 fWk
-sAm
+iue
 sAm
 sAm
 wIj
@@ -207959,7 +208045,7 @@ sAm
 xTh
 xTh
 xTh
-sAm
+mRu
 pxg
 wIj
 wIj

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -525,13 +525,6 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
-"aig" = (
-/obj/structure/rack/wide/med_shelf,
-/obj/item/bouquet/sunflower{
-	desc = "A bright bouquet of sunflowers. It feels like you know who they are for. Attached is a letter: 'from R to M' "
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "aih" = (
 /mob/living/carbon/human/npc/hobo,
 /turf/open/floor/plating/sidewalk/poor,
@@ -662,6 +655,12 @@
 /obj/structure/lattice,
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer)
+"ajV" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/shop)
 "ajX" = (
 /obj/structure/railing{
 	dir = 8
@@ -1259,6 +1258,9 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"asI" = (
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "asJ" = (
 /obj/structure/lamppost/sidewalk,
 /obj/effect/landmark/npcability,
@@ -1292,6 +1294,11 @@
 /obj/structure/flora/tree/vamp,
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
+"asN" = (
+/obj/structure/rack/fruit_stand,
+/obj/item/food/grown/apple,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "asX" = (
 /obj/effect/decal/cleanable/cardboard,
 /obj/effect/turf_decal/weather/dirt{
@@ -1607,10 +1614,6 @@
 /obj/structure/transport/linear/public,
 /turf/open/floor/plating/elevatorshaft,
 /area/vtm/interior)
-"ayb" = (
-/obj/weapon_showcase,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "ayf" = (
 /mob/living/carbon/human/npc/shop{
 	resistant_to_disciplines = 1
@@ -1811,6 +1814,14 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/northbeach)
+"aAw" = (
+/obj/structure/vampdoor/wood{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/door/access/npc,
+/obj/effect/mapping_helpers/door/lock,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "aAG" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/city/toilet,
@@ -1879,6 +1890,12 @@
 	},
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
+"aBk" = (
+/obj/structure/vampdoor/glass{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "aBo" = (
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
@@ -2399,6 +2416,13 @@
 /obj/item/clothing/head/vampire/helmet,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
+"aIS" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/soil_sack{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "aIT" = (
 /obj/structure/vampfence/corner/rich{
 	dir = 8
@@ -2475,11 +2499,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
-"aKx" = (
-/obj/weapon_showcase,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "aKy" = (
 /obj/structure/chair/plastic{
 	dir = 8;
@@ -3268,6 +3287,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
+"aVk" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "aVm" = (
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
@@ -3322,9 +3345,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
-"aWe" = (
-/turf/open/space/basic,
-/area/vtm/interior/shop)
 "aWj" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -3637,10 +3657,6 @@
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/tzimisce_sanctum)
-"bbv" = (
-/obj/structure/vampdoor/glass,
-/turf/open/floor/plating/sidewalk/rich,
-/area/vtm/interior/shop)
 "bbB" = (
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
@@ -3754,11 +3770,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/theatre)
-"bcY" = (
-/obj/structure/rack/wide/med_shelf,
-/obj/item/bouquet,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "bde" = (
 /obj/structure/flora/rock/stalagmite,
 /turf/open/floor/plating/rough/cave,
@@ -4651,6 +4662,11 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"bqg" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "bqk" = (
 /obj/structure/table,
 /obj/structure/microscope,
@@ -4810,6 +4826,10 @@
 /obj/item/clothing/head/vampire/top,
 /turf/open/floor/city/saint,
 /area/vtm/interior/oldchurch)
+"bsp" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "bsr" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -4924,10 +4944,9 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
 "bux" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/barrels/rand,
 /obj/effect/spawner/random/occult/artifact,
-/turf/open/misc/grass,
+/turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/northbeach)
 "buz" = (
 /obj/effect/turf_decal/bordur{
@@ -5081,11 +5100,6 @@
 "bwN" = (
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
-"bwP" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/hedge,
-/turf/open/misc/grass,
-/area/vtm/outside/financialdistrict)
 "bwR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -5630,12 +5644,6 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
-"bEn" = (
-/obj/structure/table,
-/obj/structure/rack/wide/store_shelf,
-/obj/item/reagent_containers/condiment/olive_oil,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "bEo" = (
 /obj/transfer_point_vamp{
 	dir = 4;
@@ -5894,6 +5902,13 @@
 /obj/structure/stairs/west,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
+"bJp" = (
+/obj/structure/table,
+/obj/structure/retail/smoke_menu{
+	dir = 1
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "bJq" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -6408,15 +6423,6 @@
 /obj/item/camera/detective,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/police/fed)
-"bRa" = (
-/obj/item/gun/ballistic/automatic/darkpack/huntrifle{
-	pixel_y = 30;
-	layer = 4;
-	anchored = 1;
-	desc = "A semi-automatic hunting rifle, just like what your dad used to shoot. If your dad didn't go out to get milk, anyways. This one is just for display."
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "bRd" = (
 /obj/machinery/light/directional/west,
 /obj/weapon_showcase,
@@ -6972,11 +6978,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/baali)
-"bZL" = (
-/obj/structure/rack/wide/store_shelf,
-/obj/item/reagent_containers/cup/mixing_bowl,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "bZW" = (
 /obj/effect/decal/cleanable/litter,
 /obj/item/cigbutt,
@@ -8212,10 +8213,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/clinic/haven)
-"crs" = (
-/obj/item/reagent_containers/condiment/soysauce,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "crx" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -8918,8 +8915,9 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
 "cCn" = (
-/turf/closed/wall/vampwall/brick_old,
-/area/vtm/outside/fishermanswharf/lower)
+/obj/structure/vampdoor/glass,
+/turf/open/floor/plating/sidewalk/rich,
+/area/vtm/interior/shop)
 "cCs" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
@@ -9073,13 +9071,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"cEK" = (
-/obj/machinery/light/directional/south,
-/obj/structure/rack/food/rand{
-	dir = 4
-	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/shop)
 "cEO" = (
 /obj/structure/roofstuff/vent_end{
 	dir = 8
@@ -9481,10 +9472,6 @@
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
-"cJQ" = (
-/obj/structure/rack/wide/store_shelf,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "cJS" = (
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
@@ -10496,6 +10483,13 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
+"cZc" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/reagent_containers/cup/watering_can/metal{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "cZt" = (
 /obj/effect/decal/pallet,
 /obj/effect/decal/cleanable/litter,
@@ -11053,14 +11047,6 @@
 "dht" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/strip)
-"dhu" = (
-/obj/structure/rack/wide/med_shelf,
-/obj/item/secateurs{
-	anchored = 1
-	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "dhw" = (
 /obj/structure/fence/corner,
 /turf/open/floor/plating/asphalt,
@@ -11367,13 +11353,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"dmu" = (
-/obj/structure/retail/camping{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/shop)
 "dmz" = (
 /obj/effect/decal/cleanable/wrapping,
 /obj/structure/barrels/rand,
@@ -11434,10 +11413,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "dnv" = (
-/obj/item/shovel/vamp{
-	anchored = 1
-	},
-/turf/open/floor/city/plating,
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
 "dnx" = (
 /obj/structure/barricade/wooden,
@@ -11841,6 +11817,13 @@
 /obj/effect/mapping_helpers/door/access/primogen_malkavian,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic/haven)
+"dtl" = (
+/obj/effect/decal/wallpaper/paper/stripe,
+/obj/structure/fish_mount/bar{
+	name = "gun mount"
+	},
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/shop)
 "dtG" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -11858,6 +11841,10 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
+"dud" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "dug" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled,
@@ -11984,6 +11971,9 @@
 /obj/structure/platform/lowwall/market/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/trujah)
+"dvM" = (
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/northbeach)
 "dvN" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm)
@@ -12201,13 +12191,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
-"dzk" = (
-/obj/structure/table,
-/obj/structure/retail/smoke_menu{
-	dir = 1
-	},
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "dzm" = (
 /obj/structure/railing{
 	dir = 1;
@@ -12435,6 +12418,10 @@
 /obj/structure/platform/lowwall/old/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/ghetto)
+"dDh" = (
+/obj/structure/platform/lowwall/market/window/reinforced,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "dDz" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
@@ -12472,12 +12459,6 @@
 "dEo" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/forest)
-"dEt" = (
-/obj/item/cultivator{
-	anchored = 1
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "dEx" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/landmark/npcwall,
@@ -12927,11 +12908,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
-"dLu" = (
-/obj/structure/rack/wide/store_shelf,
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "dLx" = (
 /obj/structure/table,
 /obj/item/chair/stool/bar,
@@ -12968,16 +12944,6 @@
 /mob/living/basic/szlachta/fister/hostile,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"dMg" = (
-/obj/item/fish/darkpack/shark{
-	pixel_y = 31;
-	pixel_x = 16;
-	layer = 4;
-	anchored = 1;
-	desc = "A stuffed and taxidermied shark. Its' eyes stare at you lifelessly. This one doesn't make any noise."
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "dMj" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/rough/cave,
@@ -13214,10 +13180,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
-"dQI" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "dQN" = (
 /turf/closed/wall/vampwall/metal,
 /area/vtm/interior/endron_facility/restricted)
@@ -13822,6 +13784,12 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/oldchurch)
+"eaF" = (
+/obj/machinery/vending/snack/orange{
+	pixel_y = 20
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "eaG" = (
 /obj/effect/decal/shadow{
 	icon_state = "shadow-alt";
@@ -15020,13 +14988,6 @@
 /obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/plating/rough,
 /area/vtm/outside/forest)
-"esh" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/platform/lowwall/brick/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/shop)
 "esp" = (
 /obj/structure/table/countertop/bubway,
 /obj/item/ammo_box/darkpack/c556{
@@ -15474,10 +15435,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
-"eAV" = (
-/obj/effect/decal/wallpaper/paper/darkgreen,
-/turf/closed/wall/vampwall/brick,
-/area/vtm/interior/shop)
 "eAX" = (
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/library)
@@ -15909,6 +15866,10 @@
 "eHF" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/fed)
+"eHS" = (
+/obj/structure/hedge,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "eHT" = (
 /obj/structure/vampdoor/wood{
 	lock_id = "primBanu";
@@ -15967,23 +15928,14 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/financialdistrict)
 "eIB" = (
-/obj/effect/turf_decal/bordur{
-	dir = 1
-	},
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = -10
-	},
-/turf/open/floor/plating/sidewalk,
-/area/vtm/outside/fishermanswharf/lower)
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/cup/mixing_bowl,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "eIF" = (
 /obj/darkpack_car/retro/rand,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
-"eIH" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/shop)
 "eIR" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/rough/cave,
@@ -16595,10 +16547,6 @@
 /obj/structure/platform/lowwall/painted,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/bianchiBank)
-"eRR" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "eRS" = (
 /obj/structure/lattice/pentex,
 /obj/effect/turf_decal/plaque{
@@ -16930,6 +16878,11 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/bianchiBank)
+"eXz" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/hedge,
+/turf/open/misc/grass,
+/area/vtm/outside/financialdistrict)
 "eXF" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south{
 	max_integrity = 1000000
@@ -17739,11 +17692,6 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
-"fiP" = (
-/obj/structure/rack/wide/store_shelf,
-/obj/item/reagent_containers/condiment/bbqsauce,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "fiX" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/necropolis/air,
@@ -17885,6 +17833,10 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/interior/oldchurch)
+"fla" = (
+/obj/structure/hedge,
+/turf/open/misc/grass,
+/area/vtm/outside/financialdistrict)
 "fli" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -19390,6 +19342,11 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
+"fGz" = (
+/obj/structure/closet/secure_closet/freezer/commercial,
+/obj/item/reagent_containers/condiment/yoghurt,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "fGC" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
@@ -19459,9 +19416,11 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
-"fHT" = (
-/obj/effect/decal/kopatich,
-/turf/open/floor/wood/smooth/old,
+"fId" = (
+/obj/item/shovel/vamp{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
 /area/vtm/interior/shop)
 "fIi" = (
 /obj/effect/decal/graffiti,
@@ -19471,7 +19430,9 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
 "fIj" = (
-/obj/machinery/light/directional/north,
+/obj/machinery/atm{
+	pixel_y = 25
+	},
 /turf/open/floor/iron/dark,
 /area/vtm/interior/shop)
 "fIl" = (
@@ -20613,6 +20574,9 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
+"fZl" = (
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "fZm" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -21066,6 +21030,10 @@
 /obj/machinery/light/small/pink/directional/east,
 /turf/open/floor/carpet/black,
 /area/vtm/interior)
+"gfT" = (
+/obj/item/bouquet/poppy,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "gfW" = (
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/misc/dirt,
@@ -21541,12 +21509,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
-"glA" = (
-/obj/machinery/vending/cola/black{
-	pixel_y = 20
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/shop)
 "glF" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/city/circled,
@@ -21704,6 +21666,13 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
+"gom" = (
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "gos" = (
 /obj/structure/lamppost/sidewalk,
 /obj/effect/landmark/npcactivity,
@@ -21783,13 +21752,6 @@
 /obj/structure/platform/lowwall/rich/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/ventrue)
-"gpJ" = (
-/obj/structure/rack/food/rand{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "gpO" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/city/plating_mono,
@@ -22278,13 +22240,6 @@
 "gwI" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"gwN" = (
-/obj/structure/table,
-/obj/structure/retail/grocery_store{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "gxs" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/decal/cleanable/litter,
@@ -22377,11 +22332,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/ventrue)
-"gyZ" = (
-/obj/structure/rack/wide/store_shelf,
-/obj/item/reagent_containers/condiment/cornmeal,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "gzc" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/city/plating_mono,
@@ -22790,11 +22740,6 @@
 /obj/item/storage/box/ingredients/carnivore,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
-"gEf" = (
-/obj/machinery/light/directional/north,
-/obj/item/kirbyplants/random,
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "gEg" = (
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/brick_old,
@@ -23134,10 +23079,6 @@
 /obj/item/ammo_box/darkpack/c44/silver,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
-"gIV" = (
-/obj/structure/hedge,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "gJa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -23423,10 +23364,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating/granite,
 /area/vtm/interior/bianchiBank)
-"gNK" = (
-/obj/item/reagent_containers/condiment/cherryjelly,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "gNW" = (
 /obj/machinery/light/directional/east,
 /obj/structure/tank_holder/extinguisher,
@@ -24386,10 +24323,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
-"hck" = (
-/obj/structure/table,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "hcn" = (
 /obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/city/plating_mono,
@@ -24503,6 +24436,10 @@
 	},
 /turf/open/openspace,
 /area/vtm)
+"hep" = (
+/mob/living/carbon/human/npc/garden,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "heu" = (
 /obj/structure/table/wood,
 /obj/machinery/radio_tranceiver/camarilla,
@@ -24516,10 +24453,6 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/old)
-"heJ" = (
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "heK" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
@@ -26113,11 +26046,9 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "hED" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "hEJ" = (
 /obj/structure/vampdoor/simple{
 	dir = 4;
@@ -26141,6 +26072,11 @@
 /obj/structure/platform/lowwall/rich,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower)
+"hEY" = (
+/obj/structure/table,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "hFe" = (
 /obj/effect/decal/cleanable/trash{
 	icon_state = "trash7"
@@ -26272,10 +26208,6 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/fed)
-"hHo" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "hHu" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/rust,
@@ -26397,6 +26329,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/carpet/green,
 /area/vtm/interior)
+"hJS" = (
+/obj/structure/vampdoor/glass,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "hJV" = (
 /obj/transfer_point_vamp{
 	icon = 'icons/obj/stairs.dmi';
@@ -26735,12 +26671,6 @@
 /obj/structure/sink/directional/east,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/trujah)
-"hOQ" = (
-/obj/structure/vampdoor/wood,
-/obj/effect/mapping_helpers/door/access/npc,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/shop)
 "hOV" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcability,
@@ -26931,10 +26861,6 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"hSo" = (
-/obj/item/bouquet/poppy,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "hSs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -27514,13 +27440,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
-"ibD" = (
-/obj/effect/decal/wallpaper/paper/stripe,
-/obj/structure/fish_mount/bar{
-	name = "gun mount"
-	},
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/shop)
 "ibG" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/dresser,
@@ -27877,6 +27796,10 @@
 /mob/living/carbon/human/npc/business,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
+"iho" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "ihq" = (
 /turf/open/water{
 	color = "#483C32"
@@ -28186,10 +28109,6 @@
 /obj/effect/landmark/event_spawn/szlachta,
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
-"inr" = (
-/mob/living/carbon/human/npc/garden,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "inw" = (
 /obj/effect/landmark/start/darkpack/sabbat/priest,
 /turf/open/floor/carpet/darkpack/redsilver,
@@ -28723,6 +28642,10 @@
 /obj/effect/decal/wallpaper/paper/rich,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower)
+"ivP" = (
+/obj/structure/coclock,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "ivT" = (
 /obj/structure/coclock,
 /turf/open/floor/plating/rough,
@@ -28743,6 +28666,12 @@
 "iwr" = (
 /obj/structure/vampdoor/glass,
 /turf/open/floor/city/gummaguts,
+/area/vtm/interior/shop)
+"iww" = (
+/obj/machinery/vending/cola/black{
+	pixel_y = 20
+	},
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
 "iwJ" = (
 /obj/effect/turf_decal/siding/white{
@@ -28919,13 +28848,6 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
-"iAb" = (
-/obj/machinery/vending/snack{
-	pixel_y = 20;
-	density = 0
-	},
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "iAd" = (
 /obj/structure/vampfence/rich{
 	dir = 1
@@ -28943,10 +28865,13 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/jazzclub)
 "iAk" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/closet/secure_closet/freezer,
-/obj/item/reagent_containers/blood,
-/turf/open/floor/wood/smooth/old,
+/obj/structure/vampdoor/simple{
+	dir = 8;
+	lock_id = "tmr";
+	lockpick_difficulty = 15;
+	locked = 1
+	},
+/turf/open/floor/wood/old,
 /area/vtm/interior/trujah)
 "iAm" = (
 /obj/structure/bed/maint,
@@ -29021,11 +28946,9 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
 "iBm" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/machinery/light/directional/south,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "iBs" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/vjanitor)
@@ -29272,6 +29195,12 @@
 /obj/item/trash/chips,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"iEl" = (
+/obj/machinery/vending/cola/starkist{
+	pixel_y = 20
+	},
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "iEq" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/garbage{
@@ -29688,6 +29617,10 @@
 "iKD" = (
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sabbat_lair)
+"iKO" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "iLa" = (
 /obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/access/giovanni,
@@ -30078,10 +30011,6 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/supply)
-"iRF" = (
-/obj/item/reagent_containers/condiment/vinegar,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "iRJ" = (
 /obj/structure/vampfence/corner{
 	dir = 8
@@ -30230,6 +30159,10 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/supply)
+"iTs" = (
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "iTu" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/vending/boozeomat,
@@ -30476,12 +30409,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
-"iWC" = (
-/obj/item/soil_sack{
-	anchored = 1
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "iWE" = (
 /obj/structure/vampdoor/reinf{
 	dir = 8
@@ -31098,10 +31025,6 @@
 /obj/item/clothing/suit/hooded/robes/black,
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/endron_facility)
-"jgN" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "jgO" = (
 /obj/effect/turf_decal/stock{
 	dir = 8
@@ -31794,13 +31717,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"jrG" = (
-/obj/structure/table,
-/obj/structure/retail/junkfood_menu{
-	dir = 1
-	},
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "jrM" = (
 /obj/structure/vampdoor,
 /obj/effect/mapping_helpers/door/access/malkavian,
@@ -31864,11 +31780,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"jsF" = (
-/obj/structure/closet/secure_closet/freezer/commercial,
-/obj/item/reagent_containers/condiment/soymilk,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "jsG" = (
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/city/plating,
@@ -32949,10 +32860,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/church)
-"jII" = (
-/obj/item/reagent_containers/condiment/flour,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "jIL" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/smooth/old,
@@ -32993,10 +32900,6 @@
 "jJq" = (
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer/nosferatu_town)
-"jJt" = (
-/obj/item/storage/box/matches,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "jJA" = (
 /obj/effect/turf_decal/siding/wood,
 /mob/living/basic/corvid/crow,
@@ -33824,6 +33727,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
+"jVB" = (
+/obj/item/reagent_containers/condiment/cherryjelly,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "jVD" = (
 /obj/structure/vampipe{
 	icon_state = "piping38"
@@ -34391,6 +34298,11 @@
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/tzimisce_manor)
+"kek" = (
+/obj/structure/rack/fruit_stand,
+/obj/item/food/grown/bell_pepper,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "kem" = (
 /obj/structure/railing{
 	dir = 8
@@ -36050,6 +35962,10 @@
 /obj/item/toner/large,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"kFs" = (
+/obj/item/bouquet/rose,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "kFx" = (
 /obj/structure/chair/greyscale{
 	dir = 1
@@ -36315,10 +36231,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
-"kKG" = (
-/obj/structure/platform/lowwall/market/window,
-/turf/open/space/basic,
-/area/vtm/interior/shop)
 "kKI" = (
 /obj/structure/table,
 /obj/item/melee/vamp/tire{
@@ -37596,13 +37508,6 @@
 /obj/item/melee/vamp/tire,
 /turf/open/floor/plating/concrete,
 /area/vtm/graveyard/interior)
-"lcN" = (
-/obj/structure/rack/wide/med_shelf,
-/obj/item/scythe/vamp{
-	anchored = 1
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "lcY" = (
 /obj/item/clothing/suit/vampire/slickbackcoat,
 /obj/item/clothing/suit/vampire/fancy_gray,
@@ -37625,6 +37530,10 @@
 "lcZ" = (
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
+"ldb" = (
+/obj/item/reagent_containers/condiment/soysauce,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "ldd" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -40104,12 +40013,6 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
-"lPv" = (
-/obj/item/reagent_containers/cup/watering_can/metal{
-	anchored = 1
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "lPA" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood/smooth/old,
@@ -40880,10 +40783,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
-"mcq" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "mcr" = (
 /obj/effect/turf_decal/asphaltline/alt{
 	dir = 8;
@@ -41162,6 +41061,12 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
+"mgN" = (
+/obj/structure/vampdoor/wood,
+/obj/effect/mapping_helpers/door/access/npc,
+/obj/effect/mapping_helpers/door/lock,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/shop)
 "mgT" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -41465,6 +41370,13 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"mmr" = (
+/obj/structure/retail/camping{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "mms" = (
 /obj/structure/roadblock{
 	dir = 4
@@ -41592,11 +41504,6 @@
 	},
 /turf/open/floor/iron/stairs,
 /area/vtm/interior)
-"moM" = (
-/obj/structure/closet/secure_closet/freezer/commercial,
-/obj/item/reagent_containers/condiment/coconut_milk,
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "moQ" = (
 /obj/structure/food_cart,
 /turf/open/floor/plating/sidewalkalt,
@@ -42342,6 +42249,10 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/clinic)
+"mzW" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "mzY" = (
 /obj/effect/turf_decal/bordur{
 	dir = 6
@@ -42384,6 +42295,13 @@
 /obj/item/toy/crayon/spraycan,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"mAC" = (
+/obj/structure/table,
+/obj/structure/retail/junkfood_menu{
+	dir = 1
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "mAD" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -43495,6 +43413,10 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/shop)
+"mQg" = (
+/obj/structure/rack/wide/store_shelf,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "mQp" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -43557,9 +43479,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
-"mRu" = (
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "mRv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -44056,6 +43975,11 @@
 /obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"mXF" = (
+/obj/structure/fish_mount/bar,
+/obj/effect/decal/wallpaper/paper/stripe,
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/shop)
 "mXG" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall/vampwall/rich/old,
@@ -45549,11 +45473,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
-"nvu" = (
-/obj/structure/platform/lowwall/brick/window,
-/obj/effect/decal/wallpaper/paper/darkgreen/low,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/shop)
 "nvy" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/litter,
@@ -45872,6 +45791,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
+"nzX" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "nAa" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/lone,
@@ -45888,6 +45811,10 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"nAF" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "nAM" = (
 /obj/structure/bed/medical/emergency,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -46152,11 +46079,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
-"nEh" = (
-/obj/structure/closet/secure_closet/freezer/commercial,
-/obj/item/reagent_containers/condiment/yoghurt,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "nEm" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/darkpack/citizen/janitor,
@@ -46244,6 +46166,10 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/ghetto)
+"nFy" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "nFA" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -46470,6 +46396,10 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"nIM" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "nIQ" = (
 /obj/structure/sign/city/store/gummaguts/directional/north,
 /turf/open/floor/plating/sidewalk,
@@ -46612,6 +46542,11 @@
 /obj/item/melee/vamp/handsickle,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
+"nKd" = (
+/obj/machinery/light/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "nKi" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/rough,
@@ -47250,13 +47185,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
-"nTz" = (
-/obj/structure/rack/wide/med_shelf,
-/obj/item/reagent_containers/cup/watering_can/metal{
-	anchored = 1
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "nTA" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/light/small/directional/south,
@@ -48082,6 +48010,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
+"ohi" = (
+/obj/structure/table,
+/obj/structure/retail/grocery_store{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "ohk" = (
 /obj/structure/bed/maint{
 	pixel_y = 2
@@ -48196,12 +48131,6 @@
 	},
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
-"oiH" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/shop)
 "oiK" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -48676,6 +48605,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/vtm/interior/laundromat)
+"orE" = (
+/obj/item/reagent_containers/cup/watering_can/metal{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "orH" = (
 /obj/structure/fireplace{
 	dir = 8;
@@ -49124,6 +49059,10 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/techshop)
+"oxc" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "oxf" = (
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/sabbat_lair)
@@ -49426,6 +49365,10 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/carpet,
 /area/vtm/interior/bianchiBank)
+"oBw" = (
+/obj/weapon_showcase,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "oBy" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -49975,10 +49918,6 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
-"oIV" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "oJe" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -50206,12 +50145,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
-"oMq" = (
-/obj/machinery/vending/snack/orange{
-	pixel_y = 20
-	},
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "oMt" = (
 /obj/structure/sink/directional/south,
 /turf/open/floor/city/church,
@@ -50234,6 +50167,13 @@
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/city,
 /area/vtm/interior)
+"oMW" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/scythe/vamp{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "oMY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -50760,6 +50700,10 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
+"oTb" = (
+/obj/structure/barrels/rand,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/northbeach)
 "oTf" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/chair/wood,
@@ -51898,14 +51842,6 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
-"plk" = (
-/obj/structure/vampdoor/wood{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/door/access/npc,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "plm" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -52537,6 +52473,11 @@
 	},
 /turf/open/floor/iron/stairs/old,
 /area/vtm/interior/theatre)
+"pur" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/bouquet,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "puv" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/carpet,
@@ -52798,11 +52739,6 @@
 /obj/item/newspaper,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf)
-"pya" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "pyd" = (
 /obj/structure/roofstuff/vent_end{
 	dir = 8
@@ -52877,6 +52813,10 @@
 	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
+"pyU" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/northbeach)
 "pzc" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -53238,6 +53178,13 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer)
+"pDw" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/bouquet/sunflower{
+	desc = "A bright bouquet of sunflowers. It feels like you know who they are for. Attached is a letter: 'from R to M' "
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "pDy" = (
 /obj/structure/chair/sofa/corp/left{
 	alpha = 225;
@@ -53770,6 +53717,10 @@
 /obj/item/stack/dollar/hundred,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
+"pKC" = (
+/obj/effect/decal/kopatich,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "pKH" = (
 /obj/structure/hotelbanner,
 /turf/open/floor/plating/sidewalk,
@@ -53994,11 +53945,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/carpet,
 /area/vtm/interior/cog/caern)
-"pMQ" = (
-/obj/structure/table,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "pMW" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
@@ -54034,10 +53980,6 @@
 "pNH" = (
 /turf/open/misc/grass,
 /area/vtm/outside/park)
-"pNL" = (
-/obj/structure/platform/lowwall/market/window/reinforced,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/shop)
 "pNN" = (
 /obj/effect/landmark/npcbeacon,
 /obj/effect/landmark/npcability,
@@ -54582,6 +54524,13 @@
 	},
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer/nosferatu_town)
+"pVS" = (
+/obj/machinery/light/directional/south,
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/shop)
 "pWf" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/curtain/cloth/fancy,
@@ -54635,6 +54584,11 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
+"pXj" = (
+/obj/structure/platform/lowwall/brick/window,
+/obj/effect/decal/wallpaper/paper/darkgreen/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/shop)
 "pXm" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth/old,
@@ -55620,6 +55574,10 @@
 /obj/structure/platform/lowwall/bar/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/techshop)
+"qmo" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "qmO" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -56176,9 +56134,10 @@
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/endron_facility)
 "qvp" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/condiment/bbqsauce,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "qvq" = (
 /obj/structure/vampdoor/wood{
 	dir = 1;
@@ -56347,10 +56306,6 @@
 /obj/effect/landmark/start/darkpack/citizen/club_worker,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/strip)
-"qwO" = (
-/obj/structure/coclock,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "qwT" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/old,
@@ -56574,6 +56529,11 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
+"qzx" = (
+/obj/structure/closet/secure_closet/freezer/commercial,
+/obj/item/reagent_containers/condiment/soymilk,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "qzH" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8;
@@ -57563,10 +57523,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
-"qOB" = (
-/obj/structure/platform/lowwall/market/window/reinforced,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "qOE" = (
 /obj/structure/coclock,
 /turf/open/floor/city/saint,
@@ -57727,12 +57683,6 @@
 /obj/structure/roadsign/speedlimit25,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights)
-"qQT" = (
-/obj/machinery/vending/cola/starkist{
-	pixel_y = 20
-	},
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "qQX" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/sign/city/strip_club/directional/north,
@@ -57983,6 +57933,11 @@
 	},
 /turf/open/openspace,
 /area/vtm/interior/tzimisce_manor)
+"qTO" = (
+/obj/structure/closet/secure_closet/freezer/commercial,
+/obj/item/reagent_containers/condiment/coconut_milk,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "qTP" = (
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/police)
@@ -58258,6 +58213,10 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
+"qXJ" = (
+/obj/structure/table,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "qXL" = (
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/plating/concrete,
@@ -59327,6 +59286,10 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/clinic/haven)
+"rnh" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "rny" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 1
@@ -59608,9 +59571,6 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/giovanni/courtyard)
-"rqA" = (
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "rqE" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -59855,10 +59815,6 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
-"ruc" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "rug" = (
 /obj/effect/turf_decal/bordur{
 	dir = 5
@@ -60205,15 +60161,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
-"rzo" = (
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
-"rzu" = (
-/obj/machinery/vending/cola/blue{
-	pixel_y = 20
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/shop)
 "rzB" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth,
@@ -60480,10 +60427,6 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
-"rEG" = (
-/obj/structure/hedge,
-/turf/open/misc/grass,
-/area/vtm/outside/financialdistrict)
 "rEX" = (
 /obj/structure/hedge,
 /obj/structure/railing{
@@ -61217,9 +61160,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
-"rPn" = (
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "rPp" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -61257,10 +61197,6 @@
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/city,
 /area/vtm/interior/ghetto)
-"rPY" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "rQu" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
@@ -61462,6 +61398,11 @@
 /obj/item/reagent_containers/cup/bottle/morphine,
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
+"rSH" = (
+/obj/structure/rack/fruit_stand,
+/obj/item/food/grown/banana/bunch,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "rSK" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
@@ -61729,6 +61670,14 @@
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/banu/haven)
+"rWA" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/secateurs{
+	anchored = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "rWC" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /mob/living/basic/pet/cat/darkpack,
@@ -62121,17 +62070,12 @@
 /turf/open/floor/carpet,
 /area/vtm/interior)
 "saT" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/machinery/vending/snack{
+	pixel_y = 20;
+	density = 0
 	},
-/obj/structure/vampdoor/simple{
-	dir = 8;
-	lock_id = "tmr";
-	lockpick_difficulty = 15;
-	locked = 1
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/trujah)
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "sba" = (
 /obj/structure/flora/tree/vamp/pine,
 /turf/open/misc/grass,
@@ -62338,9 +62282,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
-"seo" = (
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/shop)
 "ser" = (
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/rich/old,
@@ -63051,6 +62992,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
+"spB" = (
+/obj/structure/vampdoor/glass,
+/turf/open/floor/plating/sidewalk,
+/area/vtm/interior/shop)
 "spD" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -63292,6 +63237,10 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
+"ssL" = (
+/obj/structure/platform/lowwall/market/window/reinforced,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "ssM" = (
 /obj/structure/closet/crate/large,
 /obj/item/food/grown/cannabis,
@@ -63351,23 +63300,20 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/church/staff)
 "stt" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/platform/lowwall/market/window,
+/turf/open/space/basic,
+/area/vtm/interior/shop)
 "stu" = (
 /mob/living/basic/pet/cat/darkpack,
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/chinatown)
 "stS" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "stT" = (
 /obj/vampgrave{
 	pixel_y = 7
@@ -63745,10 +63691,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/techshop)
-"szW" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "sAa" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/outside/forest)
@@ -64027,6 +63969,9 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough,
 /area/vtm/outside/forest)
+"sEj" = (
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "sEl" = (
 /obj/structure/table/wood,
 /obj/structure/platform/lowwall/painted,
@@ -64163,11 +64108,6 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
-"sGi" = (
-/obj/structure/fish_mount/bar,
-/obj/effect/decal/wallpaper/paper/stripe,
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/shop)
 "sGC" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/wood/old,
@@ -64228,6 +64168,13 @@
 /obj/structure/bed/dogbed,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"sHA" = (
+/mob/living/carbon/human/npc/campingstore,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "sHJ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/white{
@@ -64255,6 +64202,13 @@
 /obj/item/ammo_box/magazine/darkpack556,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/trujah)
+"sHW" = (
+/obj/structure/table,
+/obj/structure/retail/flower_shop{
+	dir = 8
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "sHZ" = (
 /obj/machinery/door/poddoor{
 	id = "pentexhq_heavycells"
@@ -64569,10 +64523,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
-"sNS" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "sNT" = (
 /obj/effect/decal/pallet,
 /obj/machinery/light/small/directional/south,
@@ -64589,6 +64539,13 @@
 /obj/item/food/drug/opium,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
+"sOl" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/platform/lowwall/brick/window,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/shop)
 "sOA" = (
 /obj/structure/flora/rock/darkpack_big,
 /obj/structure/ladder/manhole/down,
@@ -65362,10 +65319,6 @@
 	},
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
-"tbQ" = (
-/obj/structure/vampdoor/glass,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/shop)
 "tbS" = (
 /obj/structure/table/wood,
 /obj/underplate,
@@ -66481,12 +66434,6 @@
 /obj/vampire_computer,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/police/fed)
-"tsU" = (
-/obj/structure/rack/food/rand{
-	dir = 4
-	},
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "tsW" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/concrete,
@@ -67019,10 +66966,6 @@
 /obj/item/instrument/piano_synth/headphones,
 /turf/open/misc/sandy_dirt,
 /area/vtm/interior/bianchiBank)
-"tBK" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "tBS" = (
 /obj/structure/hedge,
 /obj/structure/railing{
@@ -67842,6 +67785,10 @@
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
+"tNP" = (
+/obj/structure/platform/lowwall/market/window,
+/turf/open/space/basic,
+/area/vtm/interior/shop)
 "tNQ" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -67922,6 +67869,11 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/techshop)
+"tPJ" = (
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/condiment/peanut_butter,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "tPP" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/white{
@@ -68012,6 +67964,16 @@
 /obj/structure/table,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
+"tRw" = (
+/obj/item/fish/darkpack/shark{
+	pixel_y = 31;
+	pixel_x = 16;
+	layer = 4;
+	anchored = 1;
+	desc = "A stuffed and taxidermied shark. Its' eyes stare at you lifelessly. This one doesn't make any noise."
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "tRL" = (
 /obj/effect/decal/cleanable/garbage{
 	pixel_y = 9
@@ -69498,6 +69460,11 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/five,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
+"uqa" = (
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/condiment/cornmeal,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "uqc" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/carpet,
@@ -70209,11 +70176,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
-"uAy" = (
-/obj/structure/rack/wide/store_shelf,
-/obj/item/reagent_containers/condiment/peanut_butter,
-/turf/open/floor/iron,
-/area/vtm/interior/shop)
 "uAD" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -70311,6 +70273,11 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
+"uCl" = (
+/obj/structure/rack/fruit_stand,
+/obj/item/food/grown/potato,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "uCp" = (
 /obj/structure/roadsign/busstop,
 /turf/open/floor/plating/sidewalk/poor,
@@ -70857,13 +70824,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/strip)
-"uJY" = (
-/obj/machinery/light/directional/south,
-/obj/structure/rack/food/rand{
-	dir = 4
-	},
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "uKh" = (
 /obj/structure/closet/crate/dumpster{
 	pixel_x = 3;
@@ -70904,6 +70864,10 @@
 	},
 /turf/open/floor/light,
 /area/vtm/interior)
+"uKA" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "uKE" = (
 /obj/structure/hedge,
 /obj/structure/railing{
@@ -71728,6 +71692,11 @@
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/trujah)
+"uYh" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "uYk" = (
 /turf/open/openspace,
 /area/vtm/interior/tzimisce_manor)
@@ -71838,12 +71807,6 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
-"uZR" = (
-/obj/structure/vampdoor/glass{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "uZV" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
@@ -72391,6 +72354,10 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
 /area/vtm/interior/banu/haven)
+"vhX" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/shop)
 "vib" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -73282,14 +73249,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
 "vvP" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
 /obj/effect/decal/shadow{
 	pixel_y = -32
 	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/turf/open/floor/plating/sidewalk,
+/area/vtm/outside/fishermanswharf/lower)
 "vvS" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -73446,13 +73410,6 @@
 /obj/structure/table,
 /turf/open/floor/city/plating,
 /area/vtm/outside/giovanni/courtyard)
-"vze" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/platform/lowwall/market/window,
-/turf/open/space/basic,
-/area/vtm/interior/shop)
 "vzi" = (
 /obj/structure/curtain/bounty,
 /obj/effect/decal/cleanable/food/egg_smudge,
@@ -73535,6 +73492,15 @@
 /obj/structure/chair/plastic,
 /turf/open/floor/wood/smooth,
 /area/vtm)
+"vBd" = (
+/obj/item/gun/ballistic/automatic/darkpack/huntrifle{
+	pixel_y = 30;
+	layer = 4;
+	anchored = 1;
+	desc = "A semi-automatic hunting rifle, just like what your dad used to shoot. If your dad didn't go out to get milk, anyways. This one is just for display."
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "vBf" = (
 /obj/structure/table,
 /obj/item/reagent_containers/blood,
@@ -75037,6 +75003,9 @@
 /obj/fusebox,
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
+"vXw" = (
+/turf/open/space/basic,
+/area/vtm/interior/shop)
 "vXx" = (
 /obj/structure/vampfence/corner/rich{
 	dir = 4;
@@ -75148,13 +75117,6 @@
 /obj/effect/landmark/npcbeacon/directed,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
-"vYI" = (
-/mob/living/carbon/human/npc/campingstore,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/shop)
 "vYU" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -75265,6 +75227,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"wae" = (
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "waf" = (
 /obj/structure/vampipe{
 	icon_state = "piping31"
@@ -75364,6 +75332,10 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/park)
+"wbe" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/outside/northbeach)
 "wbt" = (
 /obj/effect/decal/cleanable/cardboard,
 /mob/living/carbon/human/npc/hobo,
@@ -76191,6 +76163,12 @@
 /obj/item/gun/ballistic/shotgun/vampire,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/tzimisce_manor)
+"wpa" = (
+/obj/item/cultivator{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "wpo" = (
 /obj/effect/turf_decal/bordur,
 /obj/item/smartphone/payphone,
@@ -76315,13 +76293,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
-"wqT" = (
-/obj/structure/rack/wide/med_shelf,
-/obj/item/soil_sack{
-	anchored = 1
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "wqX" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -76335,10 +76306,6 @@
 "wra" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/cog/caern)
-"wrg" = (
-/obj/structure/vampdoor/glass,
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "wri" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -76742,10 +76709,6 @@
 	},
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
-"wyL" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "wyW" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/prince/directional/north,
@@ -77536,13 +77499,6 @@
 /obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
-"wKt" = (
-/obj/structure/table,
-/obj/structure/retail/flower_shop{
-	dir = 8
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "wKy" = (
 /mob/living/carbon/human/npc/guard,
 /turf/open/floor/plating/concrete,
@@ -78087,6 +78043,10 @@
 "wTq" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/sewer)
+"wTs" = (
+/obj/effect/decal/wallpaper/paper/darkgreen,
+/turf/closed/wall/vampwall/brick,
+/area/vtm/interior/shop)
 "wTx" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/rough/cave,
@@ -79260,6 +79220,12 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/carpet,
 /area/vtm/interior/millennium_tower/f4)
+"xkM" = (
+/obj/machinery/vending/cola/blue{
+	pixel_y = 20
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/shop)
 "xkN" = (
 /obj/structure/flora/tree/vamp/pine,
 /turf/open/misc/grass,
@@ -79622,10 +79588,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/two,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
-"xqC" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/shop)
 "xqD" = (
 /obj/structure/ladder/manhole/down,
 /turf/open/misc/grass,
@@ -80529,10 +80491,6 @@
 	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/ventrue)
-"xEZ" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark,
-/area/vtm/interior/shop)
 "xFe" = (
 /obj/structure/chair{
 	dir = 1
@@ -80641,6 +80599,12 @@
 /obj/structure/vampstatue/angel,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/church)
+"xGe" = (
+/obj/item/soil_sack{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "xGg" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 4
@@ -81958,10 +81922,6 @@
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/anarch)
-"xZl" = (
-/obj/item/bouquet/rose,
-/turf/open/floor/city/plating,
-/area/vtm/interior/shop)
 "xZq" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -82003,10 +81963,9 @@
 /turf/open/misc/grass,
 /area/vtm/outside/forest)
 "yas" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/item/reagent_containers/condiment/flour,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "yax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paperplane,
@@ -82303,6 +82262,13 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"yeP" = (
+/obj/machinery/light/directional/south,
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "yeS" = (
 /obj/effect/decal/cleanable/litter,
 /obj/effect/decal/cleanable/litter,
@@ -82420,7 +82386,8 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
 "yhi" = (
-/obj/machinery/light/small/directional/north,
+/obj/weapon_showcase,
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/shop)
 "yhk" = (
@@ -155081,7 +155048,7 @@ aUi
 aUi
 xeV
 aUi
-aUi
+dvM
 gye
 lVM
 lVM
@@ -155336,9 +155303,9 @@ ixM
 ixM
 nNo
 xeV
-xeV
-xeV
-nNo
+dvM
+dvM
+dvM
 xjt
 lVM
 lVM
@@ -155591,11 +155558,11 @@ aUi
 ixM
 ixM
 aUi
-aUi
-aUi
-ixM
-ixM
-aUi
+dvM
+dvM
+pyU
+dvM
+dvM
 xjt
 lVM
 lVM
@@ -155848,11 +155815,11 @@ ixM
 aUi
 ixM
 uAr
-aUi
-nNo
-aUi
-ixM
-wsh
+dvM
+dvM
+dvM
+dvM
+oTb
 xjt
 lio
 lVM
@@ -156104,11 +156071,11 @@ nNo
 xeV
 xeV
 aUi
-nNo
-aUi
-oXO
-aUi
-aTB
+wbe
+dvM
+dvM
+dvM
+oTb
 bux
 gye
 nJM
@@ -156355,8 +156322,8 @@ nGZ
 nGZ
 nGZ
 nGZ
-nGZ
-nGZ
+obM
+oWV
 bvc
 bvc
 bvc
@@ -156364,9 +156331,9 @@ bvc
 bvc
 bvc
 bvc
-cCn
-cCn
-cCn
+msq
+msq
+msq
 oOD
 oOD
 oOD
@@ -156611,15 +156578,15 @@ ovR
 byX
 bzp
 bzp
-bzp
-bzp
-qvp
+nGZ
+obM
+oWV
 bgX
-sNS
-nEh
-moM
-jsF
-sNS
+uYh
+fGz
+qTO
+qzx
+nFy
 bvc
 lFa
 msq
@@ -156868,15 +156835,15 @@ cQR
 bzp
 bzp
 bpj
-iBm
-bzp
-bzp
+nGZ
+obM
+oWV
 bgX
-qQT
-rzo
-mRu
-rzo
-mRu
+iEl
+asI
+stS
+asI
+stS
 bvc
 xdS
 msq
@@ -157123,17 +157090,17 @@ nGZ
 nGZ
 nGZ
 nGZ
-saT
 nGZ
-yas
-stS
-hED
+iAk
+nGZ
+obM
+oWV
 bgX
-iAb
-rzo
-mRu
-rzo
-mRu
+saT
+asI
+stS
+asI
+stS
 shy
 msq
 ulk
@@ -157381,16 +157348,16 @@ esa
 esa
 esa
 esa
+esa
 nGZ
-stS
-stS
+obM
 vvP
 bgX
 fIj
-rzo
-mRu
-rzo
-mRu
+asI
+stS
+asI
+stS
 shy
 msq
 nlc
@@ -157638,16 +157605,16 @@ esa
 mzr
 mzr
 esa
+esa
 nGZ
-stt
-stS
-iAk
+obM
+oWV
 bgX
 hWj
-rzo
-mRu
-rzo
-mRu
+asI
+stS
+asI
+stS
 bvc
 bvc
 bvc
@@ -157897,25 +157864,25 @@ aQs
 nGZ
 nGZ
 nGZ
-nGZ
-nGZ
+obM
+oWV
 bgX
 qTY
-gwN
-mRu
-rzo
-mRu
+ohi
+stS
+asI
+stS
 bgX
 wgU
 mDw
 fgd
 kMR
-xqC
+aVk
 bgX
 ePz
-dzk
-rPn
-rPn
+bJp
+fZl
+fZl
 bvc
 oWV
 qDW
@@ -158154,14 +158121,14 @@ bzp
 iGL
 kDz
 nGZ
-eIB
+obM
 oWV
 bgX
-pya
-dQI
-mRu
-rzo
-hHo
+bqg
+mzW
+stS
+asI
+bsp
 bgX
 lpX
 mPa
@@ -158170,10 +158137,10 @@ ewI
 ewI
 bgX
 sWm
-jrG
-rPn
-rPn
-vze
+mAC
+fZl
+fZl
+stt
 pHN
 vox
 hwp
@@ -158414,11 +158381,11 @@ nGZ
 obM
 oWV
 dAP
-mRu
-rzo
-mRu
-rzo
-mRu
+stS
+asI
+stS
+asI
+stS
 bgX
 aIo
 aIo
@@ -158426,11 +158393,11 @@ sTQ
 ewI
 ewI
 ajx
-rPn
-rPn
-rPn
-rPn
-kKG
+fZl
+fZl
+fZl
+fZl
+tNP
 oWV
 vox
 hwp
@@ -158672,10 +158639,10 @@ obM
 oWV
 dAP
 qTY
-gwN
-mRu
-rzo
-mRu
+ohi
+stS
+asI
+stS
 bgX
 ewI
 ofo
@@ -158683,10 +158650,10 @@ ofo
 ewI
 ewI
 bgX
-jgN
-rPn
-rPn
-oIV
+oxc
+fZl
+fZl
+iBm
 bvc
 oWV
 vox
@@ -158928,12 +158895,12 @@ nGZ
 obM
 oWV
 bgX
-pya
-dQI
-mRu
-rzo
-hHo
-hOQ
+bqg
+mzW
+stS
+asI
+bsp
+mgN
 ewI
 ewI
 pRj
@@ -158941,9 +158908,9 @@ ewI
 wEP
 bgX
 xbj
-rPn
-rPn
-rPn
+fZl
+fZl
+fZl
 bvc
 oWV
 vox
@@ -159185,11 +159152,11 @@ nGZ
 obM
 oWV
 dAP
-mRu
-rzo
-mRu
-rzo
-mRu
+stS
+asI
+stS
+asI
+stS
 bvc
 bvc
 bvc
@@ -159197,11 +159164,11 @@ bvc
 bvc
 bvc
 bgX
-rPn
-rPn
-rPn
-rPn
-wrg
+fZl
+fZl
+fZl
+fZl
+hJS
 oWV
 vox
 hwp
@@ -159442,11 +159409,11 @@ rPN
 fnj
 oWV
 dAP
-mRu
-rzo
-mRu
-rzo
-mRu
+stS
+asI
+stS
+asI
+stS
 bvc
 oWV
 oWV
@@ -159454,10 +159421,10 @@ oWV
 oWV
 oWV
 bgX
-jgN
-rPn
-rPn
-oIV
+oxc
+fZl
+fZl
+iBm
 bvc
 oWV
 vox
@@ -159699,11 +159666,11 @@ ech
 qua
 oWV
 bgX
-fIj
-bEn
-mRu
-dLu
-hHo
+nzX
+asN
+stS
+uCl
+bsp
 bvc
 dnN
 oWV
@@ -159711,10 +159678,10 @@ oWV
 oWV
 oWV
 bgX
-rPn
-rPn
-rPn
-rPn
+fZl
+fZl
+fZl
+fZl
 bvc
 oWV
 vox
@@ -159956,23 +159923,23 @@ hwp
 obM
 oWV
 dAP
-mRu
-iRF
-mRu
-jJt
-mRu
+stS
+rSH
+stS
+kek
+stS
 bvc
 nXI
 oWV
 oWV
 oWV
 oWV
-wrg
-rPn
-rPn
-rPn
-uJY
-kKG
+hJS
+fZl
+fZl
+fZl
+yeP
+tNP
 oWV
 vox
 hwp
@@ -160213,11 +160180,11 @@ hwp
 obM
 oWV
 dAP
-mRu
-rzo
-mRu
-rzo
-mRu
+stS
+asI
+stS
+asI
+stS
 bvc
 rdm
 oWV
@@ -160226,9 +160193,9 @@ oWV
 oWV
 bgX
 ruK
-rPn
-rPn
-rPn
+fZl
+fZl
+fZl
 wiu
 oWV
 vox
@@ -160470,11 +160437,11 @@ hwp
 obM
 oWV
 bgX
-fIj
-gyZ
-mRu
-uAy
-hHo
+nzX
+uqa
+stS
+tPJ
+bsp
 bvc
 hGy
 oWV
@@ -160483,9 +160450,9 @@ oWV
 oWV
 bgX
 whE
-rPn
-rPn
-gpJ
+fZl
+fZl
+gom
 bvc
 oWV
 vox
@@ -160727,11 +160694,11 @@ hwp
 obM
 oWV
 dAP
-mRu
-jII
-mRu
-gNK
-mRu
+stS
+yas
+stS
+jVB
+stS
 bvc
 hGy
 oWV
@@ -160739,11 +160706,11 @@ oWV
 oWV
 oWV
 bgX
-gEf
-rPn
-rPn
-oIV
-kKG
+nKd
+fZl
+fZl
+iBm
+tNP
 dnN
 vox
 hwp
@@ -160984,11 +160951,11 @@ hwp
 obM
 oWV
 dAP
-mRu
-rzo
-mRu
-rzo
-mRu
+stS
+asI
+stS
+asI
+stS
 bvc
 oWV
 oWV
@@ -160996,10 +160963,10 @@ oWV
 oWV
 oWV
 bgX
-oMq
-rPn
-rPn
-tsU
+eaF
+fZl
+fZl
+wae
 wiu
 oWV
 vox
@@ -161241,11 +161208,11 @@ hwp
 obM
 oWV
 bgX
-fIj
-bZL
-mRu
-fiP
-hHo
+nzX
+eIB
+stS
+qvp
+bsp
 bvc
 hGy
 oWV
@@ -161254,9 +161221,9 @@ oWV
 oWV
 bgX
 oWp
-rPn
-rPn
-rPn
+fZl
+fZl
+fZl
 bvc
 oWV
 vox
@@ -161498,11 +161465,11 @@ hwp
 obM
 oWV
 dAP
-mRu
-heJ
-mRu
-crs
-mRu
+stS
+iTs
+stS
+ldb
+stS
 bvc
 hGy
 oWV
@@ -161510,10 +161477,10 @@ gSI
 oWV
 oWV
 bgX
-rPn
-rPn
-rPn
-cEK
+fZl
+fZl
+fZl
+pVS
 bvc
 oWV
 vox
@@ -161755,11 +161722,11 @@ hwp
 obM
 oWV
 dAP
-mRu
-rzo
-mRu
-rzo
-mRu
+stS
+asI
+stS
+asI
+stS
 bvc
 oWV
 oWV
@@ -161768,10 +161735,10 @@ oWV
 oWV
 bgX
 gzD
-rPn
-rPn
-oIV
-oiH
+fZl
+fZl
+iBm
+ajV
 oWV
 vox
 hwp
@@ -162012,11 +161979,11 @@ hwp
 obM
 oWV
 bgX
-xEZ
-rzo
-mRu
-rzo
-mRu
+rnh
+asI
+stS
+asI
+stS
 bvc
 kjB
 oWV
@@ -162025,9 +161992,9 @@ oWV
 oWV
 bgX
 qdi
-rPn
-rPn
-rPn
+fZl
+fZl
+fZl
 bvc
 oWV
 vox
@@ -162271,7 +162238,7 @@ wwM
 bvc
 bvc
 bvc
-uZR
+aBk
 bvc
 bvc
 bvc
@@ -162281,9 +162248,9 @@ oWV
 oWV
 oWV
 bvc
-kKG
-kKG
-kKG
+tNP
+tNP
+tNP
 bvc
 bvc
 oWV
@@ -175638,11 +175605,11 @@ lVK
 wbX
 nrX
 nhT
-bwP
-rEG
+eXz
+fla
 iis
-bwP
-rEG
+eXz
+fla
 nrX
 nhT
 wbX
@@ -176151,12 +176118,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-mcq
-rqA
-tBK
-rqA
-eRR
+wTs
+uKA
+sEj
+iKO
+sEj
+nIM
 mAl
 nhT
 wbX
@@ -176408,12 +176375,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-qwO
-inr
-rqA
-rqA
-rqA
+wTs
+ivP
+hep
+sEj
+sEj
+sEj
 mAl
 qZE
 wbX
@@ -176665,12 +176632,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-pMQ
-wKt
-hck
-gIV
-rqA
+wTs
+hEY
+sHW
+qXJ
+eHS
+sEj
 mAl
 nhT
 wbX
@@ -176922,12 +176889,12 @@ wbX
 lVK
 wbX
 nrX
-nvu
-rqA
-seo
-rqA
-rqA
-rPY
+pXj
+sEj
+dnv
+sEj
+sEj
+dud
 hIT
 nhT
 wbX
@@ -177179,12 +177146,12 @@ wbX
 lVK
 wbX
 nrX
-nvu
-rzu
-seo
-rqA
-rqA
-rqA
+pXj
+xkM
+dnv
+sEj
+sEj
+sEj
 mAl
 nhT
 wbX
@@ -177436,12 +177403,12 @@ wbX
 lVK
 wbX
 nrX
-nvu
-glA
-seo
-seo
-seo
-rqA
+pXj
+iww
+dnv
+dnv
+dnv
+sEj
 mAl
 qZE
 wbX
@@ -177693,13 +177660,13 @@ wbX
 lVK
 wbX
 nrX
-eAV
-aig
-seo
-lcN
-seo
-rqA
-esh
+wTs
+pDw
+dnv
+oMW
+dnv
+sEj
+sOl
 nhT
 wbX
 lVK
@@ -177950,12 +177917,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-hSo
-seo
+wTs
+gfT
 dnv
-seo
-rPY
+fId
+dnv
+dud
 hIT
 nhT
 wbX
@@ -178207,12 +178174,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-bcY
-seo
-nTz
-seo
-rqA
+wTs
+pur
+dnv
+cZc
+dnv
+sEj
 hIT
 nhT
 wbX
@@ -178464,12 +178431,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-xZl
-seo
-lPv
-seo
-rqA
+wTs
+kFs
+dnv
+orE
+dnv
+sEj
 hIT
 qZE
 wbX
@@ -178721,13 +178688,13 @@ wbX
 lVK
 wbX
 nrX
-eAV
-dhu
-seo
-wqT
-seo
-seo
-bbv
+wTs
+rWA
+dnv
+aIS
+dnv
+dnv
+cCn
 nhT
 wbX
 lVK
@@ -178978,12 +178945,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-dEt
-seo
-iWC
-seo
-rqA
+wTs
+wpa
+dnv
+xGe
+dnv
+sEj
 hIT
 nhT
 wbX
@@ -179235,12 +179202,12 @@ wbX
 lVK
 wbX
 nrX
-eAV
-seo
-seo
-seo
-eIH
-rqA
+wTs
+dnv
+dnv
+dnv
+vhX
+sEj
 hIT
 nhT
 wbX
@@ -179493,7 +179460,7 @@ lVK
 wbX
 nrX
 hIT
-eAV
+wTs
 uEa
 hIT
 hIT
@@ -179749,7 +179716,7 @@ wbX
 lVK
 wbX
 nrX
-eAV
+wTs
 kMR
 ewI
 ewI
@@ -180006,7 +179973,7 @@ wbX
 lVK
 wbX
 nrX
-eAV
+wTs
 rAv
 ewI
 tYp
@@ -180263,7 +180230,7 @@ wbX
 lVK
 wbX
 nrX
-eAV
+wTs
 jYd
 ewI
 pRj
@@ -181392,11 +181359,11 @@ pdi
 bUo
 oiT
 sQR
-szW
-ayb
-aKx
-ayb
-szW
+qmo
+oBw
+yhi
+oBw
+qmo
 gEh
 tgt
 ddc
@@ -181648,8 +181615,8 @@ jMv
 pdi
 bUo
 oiT
-sGi
-dMg
+mXF
+tRw
 ewI
 ewI
 ewI
@@ -181905,8 +181872,8 @@ jMv
 pdi
 bUo
 oiT
-ibD
-bRa
+dtl
+vBd
 ewI
 ewI
 ewI
@@ -182163,11 +182130,11 @@ pdi
 bUo
 oiT
 sQR
-yhi
+iho
 ewI
 ewI
 ewI
-ruc
+hED
 gEh
 tgt
 nkL
@@ -182420,11 +182387,11 @@ pdi
 bUo
 oiT
 sQR
-cJQ
+mQg
 ewI
 ewI
 ewI
-cJQ
+mQg
 gEh
 tgt
 nkL
@@ -182934,11 +182901,11 @@ pdi
 svk
 oiT
 sQR
-yhi
+iho
 ewI
 ewI
 ewI
-ruc
+hED
 gEh
 tgt
 bfz
@@ -183190,10 +183157,10 @@ jMv
 pdi
 bUo
 oiT
-tbQ
+spB
 oHG
 ewI
-fHT
+pKC
 ewI
 oHG
 gEh
@@ -183447,7 +183414,7 @@ jMv
 pdi
 bUo
 oiT
-tbQ
+spB
 oHG
 ewI
 ewI
@@ -183705,11 +183672,11 @@ pdi
 bUo
 oiT
 sQR
-yhi
+iho
 ewI
 ewI
 ewI
-ruc
+hED
 gEh
 qGw
 qGw
@@ -183962,11 +183929,11 @@ pdi
 bUo
 oiT
 sQR
-cJQ
+mQg
 ewI
 ewI
 ewI
-cJQ
+mQg
 bvc
 lIb
 kpk
@@ -184219,7 +184186,7 @@ pdi
 bUo
 oiT
 sQR
-aWe
+vXw
 ewI
 ewI
 ewI
@@ -184476,11 +184443,11 @@ pdi
 bUo
 oiT
 sQR
-yhi
+iho
 ewI
 ewI
 ewI
-ruc
+hED
 bvc
 sWl
 kpk
@@ -184733,11 +184700,11 @@ pdi
 bUo
 oiT
 sQR
-qOB
-dmu
+dDh
+mmr
 ofo
-pNL
-plk
+ssL
+aAw
 bvc
 iIq
 kpk
@@ -184991,7 +184958,7 @@ bUo
 oiT
 sQR
 oHG
-vYI
+sHA
 ewI
 ewI
 oHG
@@ -185504,9 +185471,9 @@ pdi
 bUo
 oiT
 sQR
-szW
+qmo
 oHG
-wyL
+nAF
 oHG
 vAO
 bvc
@@ -245285,7 +245252,7 @@ ntq
 ntq
 ntq
 ntq
-eAV
+wTs
 iTZ
 iTZ
 iTZ
@@ -245542,7 +245509,7 @@ ntq
 ntq
 ntq
 ntq
-eAV
+wTs
 toK
 iTZ
 iTZ
@@ -245799,7 +245766,7 @@ ntq
 ntq
 ntq
 ntq
-eAV
+wTs
 had
 iTZ
 wKD

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -123,10 +123,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
-"abX" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/turf/open/floor/carpet/darkpack/old,
-/area/vtm/interior/giovanni)
 "aca" = (
 /mob/living/basic/mouse/vampire,
 /turf/open/floor/plating/sidewalk/poor,
@@ -15140,6 +15136,13 @@
 /obj/structure/toilet,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/ghetto)
+"euW" = (
+/obj/machinery/light/directional/south,
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "euZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -17878,6 +17881,10 @@
 	},
 /turf/open/floor/plating,
 /area/vtm/interior/clinic/haven)
+"flz" = (
+/obj/vampire_computer,
+/turf/open/floor/plating/sidewalk,
+/area/vtm/outside/fishermanswharf/lower)
 "flA" = (
 /turf/open/floor/city/toilet,
 /area/vtm/interior/ghetto)
@@ -26125,10 +26132,6 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
-"hFM" = (
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/giovanni)
 "hFR" = (
 /obj/structure/stairs/north,
 /turf/open/floor/wood/smooth/old,
@@ -26524,6 +26527,10 @@
 "hMA" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 12
 	},
 /obj/structure/hedge,
 /turf/open/floor/plating/sidewalk,
@@ -28705,7 +28712,9 @@
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/shop)
 "iww" = (
-/obj/machinery/vending/cola/black,
+/obj/machinery/vending/cola/black{
+	pixel_y = 20
+	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
 "iwJ" = (
@@ -64471,7 +64480,9 @@
 /area/vtm/interior/police)
 "sJv" = (
 /obj/effect/turf_decal/bordur,
-/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "sJy" = (
@@ -79393,7 +79404,9 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/millennium_tower/f4)
 "xkM" = (
-/obj/machinery/vending/cola/blue,
+/obj/machinery/vending/cola/blue{
+	pixel_y = 20
+	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
 "xkN" = (
@@ -82437,10 +82450,6 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"yeP" = (
-/obj/structure/railing,
-/turf/open/openspace,
-/area/vtm/outside/financialdistrict)
 "yeS" = (
 /obj/effect/decal/cleanable/litter,
 /obj/effect/decal/cleanable/litter,
@@ -155875,7 +155884,7 @@ gcL
 iSD
 kfr
 dFZ
-hFM
+kyB
 uJx
 gcL
 xNg
@@ -156136,7 +156145,7 @@ hlf
 hlf
 uNJ
 hlf
-abX
+hlf
 hlf
 hlf
 hlf
@@ -157037,8 +157046,8 @@ tmu
 oWV
 tmu
 oWV
-tmu
 oWV
+tmu
 oWV
 oWV
 oWV
@@ -157301,7 +157310,7 @@ oWV
 oWV
 oWV
 oWV
-oWV
+tmu
 oWV
 oWV
 oWV
@@ -157815,7 +157824,7 @@ oWV
 gSI
 oWV
 oWV
-oWV
+flz
 oWV
 dje
 pOb
@@ -160114,7 +160123,7 @@ hJS
 fZl
 fZl
 fZl
-wae
+euW
 wiu
 oWV
 vox
@@ -160885,7 +160894,7 @@ bgX
 nKd
 fZl
 fZl
-fZl
+iBm
 wiu
 dnN
 vox
@@ -171168,7 +171177,7 @@ rhL
 rhL
 edq
 edq
-yeP
+edq
 hMA
 nYX
 nYX
@@ -171682,7 +171691,7 @@ edq
 edq
 edq
 edq
-yeP
+edq
 hMA
 nYX
 nYX
@@ -172196,7 +172205,7 @@ edq
 edq
 edq
 edq
-yeP
+edq
 hMA
 nYX
 nYX

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -21792,10 +21792,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"gpS" = (
-/obj/vampire_computer,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/outside/fishermanswharf/lower)
 "gpX" = (
 /obj/structure/fluff/beach_umbrella/security,
 /turf/open/misc/beach/vamp,
@@ -26529,10 +26525,6 @@
 /obj/effect/turf_decal/bordur{
 	dir = 1
 	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 12
-	},
 /obj/structure/hedge,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
@@ -28713,9 +28705,7 @@
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/shop)
 "iww" = (
-/obj/machinery/vending/cola/black{
-	pixel_y = 20
-	},
+/obj/machinery/vending/cola/black,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
 "iwJ" = (
@@ -64481,9 +64471,7 @@
 /area/vtm/interior/police)
 "sJv" = (
 /obj/effect/turf_decal/bordur,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "sJy" = (
@@ -79405,9 +79393,7 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/millennium_tower/f4)
 "xkM" = (
-/obj/machinery/vending/cola/blue{
-	pixel_y = 20
-	},
+/obj/machinery/vending/cola/blue,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
 "xkN" = (
@@ -82451,6 +82437,10 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"yeP" = (
+/obj/structure/railing,
+/turf/open/openspace,
+/area/vtm/outside/financialdistrict)
 "yeS" = (
 /obj/effect/decal/cleanable/litter,
 /obj/effect/decal/cleanable/litter,
@@ -157047,8 +157037,8 @@ tmu
 oWV
 tmu
 oWV
-oWV
 tmu
+oWV
 oWV
 oWV
 oWV
@@ -157311,7 +157301,7 @@ oWV
 oWV
 oWV
 oWV
-tmu
+oWV
 oWV
 oWV
 oWV
@@ -157825,7 +157815,7 @@ oWV
 gSI
 oWV
 oWV
-gpS
+oWV
 oWV
 dje
 pOb
@@ -171178,7 +171168,7 @@ rhL
 rhL
 edq
 edq
-edq
+yeP
 hMA
 nYX
 nYX
@@ -171692,7 +171682,7 @@ edq
 edq
 edq
 edq
-edq
+yeP
 hMA
 nYX
 nYX
@@ -172206,7 +172196,7 @@ edq
 edq
 edq
 edq
-edq
+yeP
 hMA
 nYX
 nYX

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -3467,6 +3467,10 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"aYu" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "aYA" = (
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/wood/ornate,
@@ -5227,6 +5231,10 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/iron/dark,
 /area/vtm/interior/millennium_tower/f4)
+"byD" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "byL" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/city/toilet,
@@ -10826,7 +10834,6 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
 "deU" = (
-/obj/structure/sign/poster/greenscreen/directional/west,
 /obj/structure/chair/office/darkpack/red{
 	dir = 4
 	},
@@ -15369,6 +15376,7 @@
 /area/vtm/outside/fishermanswharf)
 "ezp" = (
 /obj/item/broadcast_camera,
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "ezt" = (
@@ -22855,8 +22863,8 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "gFt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/vampwall/painted,
+/turf/open/floor/greenscreen,
+/turf/open/floor/greenscreen,
 /area/vtm/interior)
 "gFJ" = (
 /obj/structure/chair/wood/wings{
@@ -27736,7 +27744,6 @@
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
 "ifj" = (
-/obj/structure/sign/poster/greenscreen/directional/west,
 /obj/structure/chair/office/darkpack/red{
 	dir = 4
 	},
@@ -34287,6 +34294,13 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
+"kdA" = (
+/obj/structure/chair/sofa/corp{
+	color = "#CD5C5C";
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "kdD" = (
 /obj/structure/vampdoor/old{
 	lock_id = "triad"
@@ -34699,6 +34713,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/outside/financialdistrict)
+"klf" = (
+/obj/structure/chair/sofa/corp/right{
+	color = "#CD5C5C"
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "klm" = (
 /mob/living/basic/ghost,
 /obj/item/stack/sheet/mineral/wood,
@@ -34909,6 +34929,11 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"knX" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "knZ" = (
 /obj/effect/landmark/npcwall,
 /obj/structure/vampfence/corner/rich{
@@ -37517,6 +37542,10 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"lbT" = (
+/turf/closed/wall/vampwall/painted,
+/turf/closed/wall/vampwall/painted,
+/area/vtm/interior)
 "lbV" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -38466,6 +38495,10 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
 "lqJ" = (
+/obj/machinery/light/directional/east,
+/obj/structure/chair/sofa/corp/corner{
+	color = "#CD5C5C"
+	},
 /turf/open/floor/wood/smooth,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
@@ -40625,6 +40658,10 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"lYI" = (
+/obj/structure/platform/lowwall/painted/window/reinforced,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "lYN" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -41718,6 +41755,7 @@
 /area/vtm/interior/shop)
 "mrm" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "mrB" = (
@@ -46416,6 +46454,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
+/area/vtm/interior)
+"nHK" = (
+/obj/machinery/light/directional/south,
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "nHL" = (
 /obj/structure/vampdoor/glass{
@@ -62306,7 +62352,6 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "sbO" = (
-/obj/structure/sign/poster/greenscreen/directional/west,
 /obj/structure/chair/office/darkpack/red{
 	dir = 4
 	},
@@ -69892,6 +69937,9 @@
 "uuv" = (
 /obj/structure/table/optable,
 /turf/open/floor/city/circled,
+/area/vtm/interior)
+"uuy" = (
+/turf/open/floor/greenscreen,
 /area/vtm/interior)
 "uuz" = (
 /obj/effect/decal/gut_floor,
@@ -188822,10 +188870,10 @@ rFS
 iog
 iog
 hfy
-mrm
-hfy
+knX
+uuy
 gFt
-hfy
+uuy
 mrm
 hfy
 iog
@@ -189078,13 +189126,13 @@ fQP
 rFS
 iog
 iog
-iKd
+lYI
 tYg
 ifj
 deU
 sbO
 tYg
-iKd
+lYI
 iWr
 csP
 cUg
@@ -189335,13 +189383,13 @@ fQP
 rFS
 iog
 iog
-iKd
+lYI
 tYg
 wsO
 nkX
 rYv
 tYg
-iKd
+lYI
 iog
 iog
 cUg
@@ -189592,12 +189640,12 @@ fQP
 rFS
 iog
 iog
-iKd
+lbT
+aYu
 lVM
 lVM
 lVM
-lVM
-lVM
+byD
 hfy
 iog
 iog
@@ -189849,7 +189897,7 @@ fQP
 rFS
 fCt
 iog
-iKd
+lYI
 lVM
 lVM
 taZ
@@ -190106,7 +190154,7 @@ fQP
 tpw
 iog
 iog
-iKd
+lYI
 lVM
 lVM
 lVM
@@ -190363,12 +190411,12 @@ fQP
 rFS
 iog
 iog
-iKd
+lYI
 eeI
 lVM
-lVM
-lVM
-lVM
+klf
+hRI
+hRI
 hfy
 iog
 iog
@@ -190624,8 +190672,8 @@ hfy
 ezp
 lVM
 lqJ
-lVM
-lVM
+kdA
+nHK
 hfy
 iog
 iog

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -7419,6 +7419,10 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
+"chb" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/techshop)
 "chj" = (
 /obj/machinery/shower/directional/west,
 /turf/open/floor/city/toilet,
@@ -10870,6 +10874,10 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/banu/haven)
+"dfe" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/carpet,
+/area/vtm/interior/cog/pantry)
 "dfj" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -13993,6 +14001,10 @@
 /obj/structure/platform/lowwall/junk/alt/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/setite/basement)
+"ecY" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/city/circled,
+/area/vtm/interior/laundromat)
 "edg" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth,
@@ -18274,6 +18286,10 @@
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
+"frP" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/trujah)
 "frR" = (
 /obj/effect/decal/carpet,
 /turf/open/floor/wood/smooth/old,
@@ -21341,6 +21357,10 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"gjq" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/setite)
 "gjt" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -24629,6 +24649,10 @@
 /obj/darkpack_car/retro/rand,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
+"hhB" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/carpet/red,
+/area/vtm/interior/jazzclub)
 "hhD" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
@@ -27483,6 +27507,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
+"ict" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/church)
 "icz" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -28901,6 +28929,10 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/outside/financialdistrict)
+"iAP" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "iAQ" = (
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bucket,
@@ -29738,6 +29770,10 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/financialdistrict)
+"iNq" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/vjanitor)
 "iNx" = (
 /obj/structure/lamppost/sidewalk,
 /turf/open/misc/dirt,
@@ -45771,6 +45807,11 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
+"nzD" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/oldchurch)
 "nzK" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcwall,
@@ -46321,6 +46362,10 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/fishermanswharf)
+"nHw" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/carpet/royalblack,
+/area/vtm/interior/banu)
 "nHB" = (
 /obj/machinery/light/directional/south,
 /obj/structure/chair/wood{
@@ -53741,6 +53786,10 @@
 /obj/effect/decal/kopatich,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop)
+"pKG" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police)
 "pKH" = (
 /obj/structure/hotelbanner,
 /turf/open/floor/plating/sidewalk,
@@ -60042,6 +60091,10 @@
 /obj/structure/stairs/south,
 /turf/open/floor/carpet,
 /area/vtm/interior/giovanni)
+"rwD" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/hotel)
 "rwG" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/washing_machine,
@@ -61796,6 +61849,10 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/library)
+"rXq" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/chantry)
 "rXs" = (
 /obj/item/smartphone/payphone,
 /turf/open/floor/plating/sidewalk/poor,
@@ -63597,6 +63654,10 @@
 /obj/item/stack/medical/suture,
 /turf/open/floor/carpet,
 /area/vtm/interior/cog/caern)
+"sxH" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "sxJ" = (
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/ghetto)
@@ -68107,6 +68168,10 @@
 /obj/structure/roadsign/warningpedestrian,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
+"tTo" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/carpet,
+/area/vtm/interior/bianchiBank)
 "tTG" = (
 /obj/structure/vampdoor/simple,
 /obj/effect/mapping_helpers/door/access/setite,
@@ -72162,6 +72227,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
+"vez" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/anarch)
 "veF" = (
 /mob/living/basic/corvid/crow,
 /turf/open/floor/plating/sidewalk/rich,
@@ -72397,6 +72466,10 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
 /area/vtm/interior/banu/haven)
+"vhU" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/clinic)
 "vhX" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/city/plating_mono,
@@ -73652,6 +73725,7 @@
 /area/vtm/interior/supply)
 "vCC" = (
 /obj/machinery/sprinkler/area_managed,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower)
 "vCE" = (
@@ -75208,6 +75282,11 @@
 /obj/structure/platform/lowwall/rich/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower)
+"vZA" = (
+/obj/effect/decal/cleanable/trash,
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior/supply)
 "vZB" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/prince/directional/east,
@@ -105508,7 +105587,7 @@ fLD
 oLs
 oLs
 dAN
-dAN
+tTo
 jBt
 nYX
 nYX
@@ -151850,7 +151929,7 @@ rsL
 rsL
 iKo
 dAV
-dAV
+gjq
 dKN
 nho
 wpP
@@ -158946,7 +159025,7 @@ bMn
 vpr
 jLV
 vpr
-bzp
+frP
 bzp
 bzp
 kDz
@@ -165716,7 +165795,7 @@ iEe
 jPg
 jPg
 dII
-jPg
+ict
 jPg
 dII
 jPg
@@ -167536,7 +167615,7 @@ vEB
 pCm
 eBw
 bVp
-hXm
+dfe
 oYN
 bVp
 eBw
@@ -167634,7 +167713,7 @@ fwN
 fwN
 fwN
 fwN
-lDo
+nzD
 fYI
 pqW
 pqW
@@ -169204,7 +169283,7 @@ uiJ
 kBp
 kBp
 xLh
-pMC
+vez
 pMC
 pMC
 pMC
@@ -180089,7 +180168,7 @@ wbX
 wbX
 wcJ
 jeC
-rBR
+hhB
 rBR
 rBR
 rBR
@@ -180762,7 +180841,7 @@ jcx
 jcx
 jcx
 jcx
-jcx
+vhU
 dwF
 idz
 idz
@@ -185088,7 +185167,7 @@ mCk
 lzT
 ehd
 icg
-iBs
+iNq
 vEb
 iog
 iog
@@ -189290,7 +189369,7 @@ hoA
 hoA
 hoA
 hoA
-hoA
+rXq
 hoA
 hoA
 hoA
@@ -189732,7 +189811,7 @@ pcm
 pcm
 pcm
 pcm
-pcm
+chb
 hro
 iog
 mXC
@@ -191580,7 +191659,7 @@ qRf
 dar
 fFa
 fFa
-fFa
+sxH
 fFa
 dar
 raO
@@ -199604,7 +199683,7 @@ mVc
 vBn
 qLO
 mVc
-dwi
+rwD
 wdL
 fkd
 fkd
@@ -200139,7 +200218,7 @@ gSG
 rmo
 izL
 orv
-kgu
+ecY
 kgu
 wgA
 ory
@@ -200570,7 +200649,7 @@ vDM
 yhf
 qyr
 yhf
-yhf
+pKG
 hoH
 rYn
 rYn
@@ -203107,7 +203186,7 @@ ulT
 jlv
 hfy
 vdz
-lVM
+iAP
 hRI
 qeM
 jbr
@@ -203292,7 +203371,7 @@ jzV
 fgY
 ugx
 bjm
-puG
+vZA
 bjm
 wkB
 bjm
@@ -206437,7 +206516,7 @@ jXv
 jXv
 jXv
 jXv
-jXv
+nHw
 gzg
 jlv
 szg

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -525,6 +525,13 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
+"aig" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/bouquet/sunflower{
+	desc = "A bright bouquet of sunflowers. It feels like you know who they are for. Attached is a letter: 'from R to M' "
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "aih" = (
 /mob/living/carbon/human/npc/hobo,
 /turf/open/floor/plating/sidewalk/poor,
@@ -3630,6 +3637,10 @@
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/tzimisce_sanctum)
+"bbv" = (
+/obj/structure/vampdoor/glass,
+/turf/open/floor/plating/sidewalk/rich,
+/area/vtm/interior/shop)
 "bbB" = (
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
@@ -3743,6 +3754,11 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/theatre)
+"bcY" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/bouquet,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "bde" = (
 /obj/structure/flora/rock/stalagmite,
 /turf/open/floor/plating/rough/cave,
@@ -4801,14 +4817,6 @@
 /obj/item/clothing/head/vampire/top,
 /turf/open/floor/city/saint,
 /area/vtm/interior/oldchurch)
-"bsp" = (
-/obj/effect/turf_decal/bordur,
-/obj/structure/sign/flag/usa{
-	pixel_y = 32
-	},
-/mob/living/carbon/human/npc/hobo,
-/turf/open/floor/plating/sidewalk/rich,
-/area/vtm/outside/financialdistrict)
 "bsr" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -5080,6 +5088,11 @@
 "bwN" = (
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
+"bwP" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/hedge,
+/turf/open/misc/grass,
+/area/vtm/outside/financialdistrict)
 "bwR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -11025,6 +11038,14 @@
 "dht" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/strip)
+"dhu" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/secateurs{
+	anchored = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "dhw" = (
 /obj/structure/fence/corner,
 /turf/open/floor/plating/asphalt,
@@ -11398,9 +11419,10 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "dnv" = (
-/obj/effect/decal/wallpaper/low,
-/obj/structure/platform/lowwall/market/window/reinforced,
-/turf/open/floor/plating/rough,
+/obj/item/shovel/vamp{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
 /area/vtm/interior/shop)
 "dnx" = (
 /obj/structure/barricade/wooden,
@@ -11947,13 +11969,6 @@
 /obj/structure/platform/lowwall/market/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/trujah)
-"dvM" = (
-/obj/effect/turf_decal/bordur,
-/obj/structure/sign/flag/usa{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/sidewalk/rich,
-/area/vtm/outside/financialdistrict)
 "dvN" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm)
@@ -12435,6 +12450,12 @@
 "dEo" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/forest)
+"dEt" = (
+/obj/item/cultivator{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "dEx" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/landmark/npcwall,
@@ -14968,6 +14989,13 @@
 /obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/plating/rough,
 /area/vtm/outside/forest)
+"esh" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/platform/lowwall/brick/window,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/shop)
 "esp" = (
 /obj/structure/table/countertop/bubway,
 /obj/item/ammo_box/darkpack/c556{
@@ -15415,6 +15443,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
+"eAV" = (
+/obj/effect/decal/wallpaper/paper/darkgreen,
+/turf/closed/wall/vampwall/brick,
+/area/vtm/interior/shop)
 "eAX" = (
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/library)
@@ -15917,6 +15949,10 @@
 /obj/darkpack_car/retro/rand,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
+"eIH" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/shop)
 "eIR" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/rough/cave,
@@ -16529,6 +16565,10 @@
 /obj/structure/platform/lowwall/painted,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/bianchiBank)
+"eRR" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "eRS" = (
 /obj/structure/lattice/pentex,
 /obj/effect/turf_decal/plaque{
@@ -21471,6 +21511,12 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
+"glA" = (
+/obj/machinery/vending/cola/black{
+	pixel_y = 20
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/shop)
 "glF" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/city/circled,
@@ -23033,6 +23079,10 @@
 /obj/item/ammo_box/darkpack/c44/silver,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
+"gIV" = (
+/obj/structure/hedge,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "gJa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -24277,6 +24327,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
+"hck" = (
+/obj/structure/table,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "hcn" = (
 /obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/city/plating_mono,
@@ -26804,6 +26858,10 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"hSo" = (
+/obj/item/bouquet/poppy,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "hSs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -27811,6 +27869,7 @@
 /area/vtm)
 "iis" = (
 /obj/effect/decal/cleanable/litter,
+/obj/structure/hedge,
 /turf/open/misc/grass,
 /area/vtm/outside/financialdistrict)
 "iit" = (
@@ -28055,6 +28114,10 @@
 /obj/effect/landmark/event_spawn/szlachta,
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
+"inr" = (
+/mob/living/carbon/human/npc/garden,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "inw" = (
 /obj/effect/landmark/start/darkpack/sabbat/priest,
 /turf/open/floor/carpet/darkpack/redsilver,
@@ -30330,6 +30393,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"iWC" = (
+/obj/item/soil_sack{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "iWE" = (
 /obj/structure/vampdoor/reinf{
 	dir = 8
@@ -37416,6 +37485,13 @@
 /obj/item/melee/vamp/tire,
 /turf/open/floor/plating/concrete,
 /area/vtm/graveyard/interior)
+"lcN" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/scythe/vamp{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "lcY" = (
 /obj/item/clothing/suit/vampire/slickbackcoat,
 /obj/item/clothing/suit/vampire/fancy_gray,
@@ -39917,6 +39993,12 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
+"lPv" = (
+/obj/item/reagent_containers/cup/watering_can/metal{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "lPA" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood/smooth/old,
@@ -40687,6 +40769,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
+"mcq" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "mcr" = (
 /obj/effect/turf_decal/asphaltline/alt{
 	dir = 8;
@@ -45348,6 +45434,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
+"nvu" = (
+/obj/structure/platform/lowwall/brick/window,
+/obj/effect/decal/wallpaper/paper/darkgreen/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/shop)
 "nvy" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/litter,
@@ -47039,6 +47130,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"nTz" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/reagent_containers/cup/watering_can/metal{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "nTA" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/light/small/directional/south,
@@ -53757,6 +53855,11 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/carpet,
 /area/vtm/interior/cog/caern)
+"pMQ" = (
+/obj/structure/table,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "pMW" = (
 /obj/structure/chair/wood/wings{
 	dir = 8;
@@ -56105,6 +56208,10 @@
 /obj/effect/landmark/start/darkpack/citizen/club_worker,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/strip)
+"qwO" = (
+/obj/structure/coclock,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "qwT" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/old,
@@ -59357,6 +59464,9 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/giovanni/courtyard)
+"rqA" = (
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "rqE" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -59949,6 +60059,12 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
+"rzu" = (
+/obj/machinery/vending/cola/blue{
+	pixel_y = 20
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/shop)
 "rzB" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth,
@@ -60215,6 +60331,10 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
+"rEG" = (
+/obj/structure/hedge,
+/turf/open/misc/grass,
+/area/vtm/outside/financialdistrict)
 "rEX" = (
 /obj/structure/hedge,
 /obj/structure/railing{
@@ -60985,6 +61105,10 @@
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/city,
 /area/vtm/interior/ghetto)
+"rPY" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "rQu" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
@@ -62062,6 +62186,9 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
+"seo" = (
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/shop)
 "ser" = (
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/rich/old,
@@ -66736,6 +66863,10 @@
 /obj/item/instrument/piano_synth/headphones,
 /turf/open/misc/sandy_dirt,
 /area/vtm/interior/bianchiBank)
+"tBK" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "tBS" = (
 /obj/structure/hedge,
 /obj/structure/railing{
@@ -70123,7 +70254,7 @@
 	},
 /obj/effect/mapping_helpers/door/access/npc,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/plating/concrete,
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
 "uEd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -76001,6 +76132,13 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
+"wqT" = (
+/obj/structure/rack/wide/med_shelf,
+/obj/item/soil_sack{
+	anchored = 1
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "wqX" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -77211,6 +77349,13 @@
 /obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
+"wKt" = (
+/obj/structure/table,
+/obj/structure/retail/flower_shop{
+	dir = 8
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "wKy" = (
 /mob/living/carbon/human/npc/guard,
 /turf/open/floor/plating/concrete,
@@ -81622,6 +81767,10 @@
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/anarch)
+"xZl" = (
+/obj/item/bouquet/rose,
+/turf/open/floor/city/plating,
+/area/vtm/interior/shop)
 "xZq" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -175298,11 +175447,11 @@ lVK
 wbX
 nrX
 nhT
-jjW
-fxx
+bwP
+rEG
 iis
-jjW
-fxx
+bwP
+rEG
 nrX
 nhT
 wbX
@@ -175554,13 +175703,13 @@ wbX
 lVK
 wbX
 nrX
-bvc
-bvc
-bvc
-bvc
-bvc
-bvc
-bvc
+hIT
+hIT
+hIT
+hIT
+hIT
+hIT
+hIT
 nhT
 wbX
 lVK
@@ -175811,13 +175960,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-gDD
-iTZ
-iTZ
-iTZ
-iTZ
-bvc
+eAV
+mcq
+rqA
+tBK
+rqA
+eRR
+mAl
 nhT
 wbX
 lVK
@@ -176068,13 +176217,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
-wiu
+eAV
+qwO
+inr
+rqA
+rqA
+rqA
+mAl
 qZE
 wbX
 lVK
@@ -176325,13 +176474,13 @@ wbX
 lVK
 wbX
 nrX
-bvc
-bvc
-bvc
-mJk
-iTZ
-iTZ
-wiu
+eAV
+pMQ
+wKt
+hck
+gIV
+rqA
+mAl
 nhT
 wbX
 lVK
@@ -176582,14 +176731,14 @@ wbX
 lVK
 wbX
 nrX
-mJk
-pfw
-ewI
-dnv
-iTZ
-uSK
-bvc
-dvM
+nvu
+rqA
+seo
+rqA
+rqA
+rPY
+hIT
+nhT
 wbX
 lVK
 wbX
@@ -176839,13 +176988,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-xie
-ewI
-dnv
-iTZ
-iTZ
-wiu
+nvu
+rzu
+seo
+rqA
+rqA
+rqA
+mAl
 nhT
 wbX
 lVK
@@ -177096,13 +177245,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-txn
-ewI
-dnv
-iTZ
-iTZ
-wiu
+nvu
+glA
+seo
+seo
+seo
+rqA
+mAl
 qZE
 wbX
 lVK
@@ -177353,13 +177502,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-tzq
-cmT
-pWt
-iTZ
-iTZ
-gWV
+eAV
+aig
+seo
+lcN
+seo
+rqA
+esh
 nhT
 wbX
 lVK
@@ -177610,13 +177759,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-txn
-ewI
+eAV
+hSo
+seo
 dnv
-iTZ
-iTZ
-wiu
+seo
+rPY
+hIT
 nhT
 wbX
 lVK
@@ -177867,13 +178016,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-xie
-ewI
-dnv
-iTZ
-iTZ
-wiu
+eAV
+bcY
+seo
+nTz
+seo
+rqA
+hIT
 nhT
 wbX
 lVK
@@ -178124,14 +178273,14 @@ wbX
 lVK
 wbX
 nrX
-mJk
-pfw
-ewI
-dnv
-iTZ
-uSK
-bvc
-bsp
+eAV
+xZl
+seo
+lPv
+seo
+rqA
+hIT
+qZE
 wbX
 lVK
 wbX
@@ -178381,13 +178530,13 @@ wbX
 lVK
 wbX
 nrX
-bvc
-mJk
-aKi
-mJk
-iTZ
-iTZ
-wiu
+eAV
+dhu
+seo
+wqT
+seo
+seo
+bbv
 nhT
 wbX
 lVK
@@ -178638,13 +178787,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
-wiu
+eAV
+dEt
+seo
+iWC
+seo
+rqA
+hIT
 nhT
 wbX
 lVK
@@ -178895,13 +179044,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
-had
-iTZ
-iTZ
-iTZ
-iTZ
-bvc
+eAV
+seo
+seo
+seo
+eIH
+rqA
+hIT
 nhT
 wbX
 lVK
@@ -179152,13 +179301,13 @@ wbX
 lVK
 wbX
 nrX
-bvc
-mJk
+hIT
+eAV
 uEa
-bvc
-bvc
-bvc
-bvc
+hIT
+hIT
+hIT
+hIT
 nhT
 wbX
 lVK
@@ -179409,13 +179558,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
+eAV
 kMR
 ewI
 ewI
 ewI
 ewI
-bvc
+hIT
 nhT
 wbX
 lVK
@@ -179666,13 +179815,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
+eAV
 rAv
 ewI
 tYp
 ofo
 oyM
-bvc
+hIT
 nhT
 wbX
 lVK
@@ -179923,13 +180072,13 @@ wbX
 lVK
 wbX
 nrX
-mJk
+eAV
 jYd
 ewI
 pRj
 sMV
 ewI
-bvc
+hIT
 nhT
 wbX
 lVK
@@ -180180,13 +180329,13 @@ wbX
 lVK
 wbX
 nrX
-bvc
-bvc
-bvc
-bvc
-bvc
-bvc
-bvc
+hIT
+hIT
+hIT
+hIT
+hIT
+hIT
+hIT
 nhT
 wbX
 lVK
@@ -244688,11 +244837,11 @@ ntq
 ntq
 ntq
 ntq
-bvc
-bvc
+hIT
+hIT
 exm
-bvc
-bvc
+hIT
+hIT
 pEQ
 cEq
 ntq
@@ -244945,11 +245094,11 @@ ntq
 ntq
 ntq
 ntq
-mJk
+eAV
 iTZ
 iTZ
 iTZ
-bvc
+hIT
 kno
 cEq
 ntq
@@ -245202,11 +245351,11 @@ ntq
 ntq
 ntq
 ntq
-mJk
+eAV
 toK
 iTZ
 iTZ
-bvc
+hIT
 pEQ
 cEq
 ntq
@@ -245459,11 +245608,11 @@ ntq
 ntq
 ntq
 ntq
-mJk
+eAV
 had
 iTZ
 wKD
-bvc
+hIT
 kno
 cEq
 ntq
@@ -245716,11 +245865,11 @@ ntq
 ntq
 ntq
 ntq
-bvc
-bvc
-bvc
-bvc
-bvc
+hIT
+hIT
+hIT
+hIT
+hIT
 wol
 ogR
 ntq

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -1600,6 +1600,10 @@
 /obj/structure/transport/linear/public,
 /turf/open/floor/plating/elevatorshaft,
 /area/vtm/interior)
+"ayb" = (
+/obj/weapon_showcase,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "ayf" = (
 /mob/living/carbon/human/npc/shop{
 	resistant_to_disciplines = 1
@@ -2464,6 +2468,11 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"aKx" = (
+/obj/weapon_showcase,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "aKy" = (
 /obj/structure/chair/plastic{
 	dir = 8;
@@ -3306,6 +3315,9 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
+"aWe" = (
+/turf/open/space/basic,
+/area/vtm/interior/shop)
 "aWj" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -6384,6 +6396,15 @@
 /obj/item/camera/detective,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/police/fed)
+"bRa" = (
+/obj/item/gun/ballistic/automatic/darkpack/huntrifle{
+	pixel_y = 30;
+	layer = 4;
+	anchored = 1;
+	desc = "A semi-automatic hunting rifle, just like what your dad used to shoot. If your dad didn't go out to get milk, anyways. This one is just for display."
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "bRd" = (
 /obj/machinery/light/directional/west,
 /obj/weapon_showcase,
@@ -9432,6 +9453,10 @@
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
+"cJQ" = (
+/obj/structure/rack/wide/store_shelf,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "cJS" = (
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
@@ -11306,6 +11331,13 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
+"dmu" = (
+/obj/structure/retail/camping{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "dmz" = (
 /obj/effect/decal/cleanable/wrapping,
 /obj/structure/barrels/rand,
@@ -12888,6 +12920,16 @@
 /mob/living/basic/szlachta/fister/hostile,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
+"dMg" = (
+/obj/item/fish/darkpack/shark{
+	pixel_y = 31;
+	pixel_x = 16;
+	layer = 4;
+	anchored = 1;
+	desc = "A stuffed and taxidermied shark. Its' eyes stare at you lifelessly. This one doesn't make any noise."
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "dMj" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/rough/cave,
@@ -19342,6 +19384,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"fHT" = (
+/obj/effect/decal/kopatich,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "fIi" = (
 /obj/effect/decal/graffiti,
 /obj/structure/mop_bucket,
@@ -27338,6 +27384,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
+"ibD" = (
+/obj/effect/decal/wallpaper/paper/stripe,
+/obj/structure/fish_mount/bar{
+	name = "gun mount"
+	},
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/shop)
 "ibG" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/dresser,
@@ -27694,11 +27747,6 @@
 /mob/living/carbon/human/npc/business,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
-"iho" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/rack/clothing_hanger,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
 "ihq" = (
 /turf/open/water{
 	color = "#483C32"
@@ -43245,16 +43293,6 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/shop)
-"mQg" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
 "mQp" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -49326,10 +49364,9 @@
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
 "oDz" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
+/obj/structure/coclock,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "oDM" = (
 /obj/structure/mop_bucket/janitorialcart,
 /obj/item/mop,
@@ -49628,12 +49665,8 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/tzimisce_manor)
 "oHG" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/city/toilet,
-/area/vtm/interior)
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "oHH" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/grass,
@@ -51633,6 +51666,14 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
+"plk" = (
+/obj/structure/vampdoor/wood{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/door/access/npc,
+/obj/effect/mapping_helpers/door/lock,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "plm" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -53751,6 +53792,10 @@
 "pNH" = (
 /turf/open/misc/grass,
 /area/vtm/outside/park)
+"pNL" = (
+/obj/structure/platform/lowwall/market/window/reinforced,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "pNN" = (
 /obj/effect/landmark/npcbeacon,
 /obj/effect/landmark/npcability,
@@ -57272,6 +57317,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
+"qOB" = (
+/obj/structure/platform/lowwall/market/window/reinforced,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "qOE" = (
 /obj/structure/coclock,
 /turf/open/floor/city/saint,
@@ -59552,6 +59601,10 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
+"ruc" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "rug" = (
 /obj/effect/turf_decal/bordur{
 	dir = 5
@@ -63413,6 +63466,10 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/techshop)
+"szW" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "sAa" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/outside/forest)
@@ -63833,6 +63890,11 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"sGi" = (
+/obj/structure/fish_mount/bar,
+/obj/effect/decal/wallpaper/paper/stripe,
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/shop)
 "sGC" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/wood/old,
@@ -65023,6 +65085,10 @@
 	},
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
+"tbQ" = (
+/obj/structure/vampdoor/glass,
+/turf/open/floor/plating/sidewalk,
+/area/vtm/interior/shop)
 "tbS" = (
 /obj/structure/table/wood,
 /obj/underplate,
@@ -73150,10 +73216,9 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/forest)
 "vAO" = (
-/obj/machinery/light/small/directional/south,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "vBa" = (
 /obj/structure/chair/plastic,
 /turf/open/floor/wood/smooth,
@@ -74771,6 +74836,13 @@
 /obj/effect/landmark/npcbeacon/directed,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
+"vYI" = (
+/mob/living/carbon/human/npc/campingstore,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "vYU" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -76345,6 +76417,10 @@
 	},
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
+"wyL" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "wyW" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/prince/directional/north,
@@ -82005,9 +82081,8 @@
 /area/vtm/interior/police)
 "yhi" = (
 /obj/machinery/light/small/directional/north,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/shop)
 "yhk" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -180719,12 +180794,12 @@ jMv
 pdi
 bUo
 oiT
-oOD
-oOD
-oOD
-oOD
-oOD
-oOD
+bvc
+bvc
+bvc
+bvc
+bvc
+bvc
 gEh
 tgt
 xkt
@@ -180976,12 +181051,12 @@ jMv
 pdi
 bUo
 oiT
-eVP
-rwG
-iIm
-uQS
-sTS
-uQS
+sQR
+szW
+ayb
+aKx
+ayb
+szW
 gEh
 tgt
 ddc
@@ -181233,11 +181308,11 @@ jMv
 pdi
 bUo
 oiT
-eVP
-vfw
-uQS
-uQS
-eVP
+sGi
+dMg
+ewI
+ewI
+ewI
 oHG
 gEh
 tgt
@@ -181490,12 +181565,12 @@ jMv
 pdi
 bUo
 oiT
-oOD
-oOD
-eVP
-uUT
-oOD
-oOD
+ibD
+bRa
+ewI
+ewI
+ewI
+oHG
 gEh
 tgt
 pgd
@@ -181747,12 +181822,12 @@ jMv
 pdi
 bUo
 oiT
-nLG
+sQR
 yhi
-iHq
-iHq
-jsE
-iHq
+ewI
+ewI
+ewI
+ruc
 gEh
 tgt
 nkL
@@ -182004,12 +182079,12 @@ jMv
 pdi
 bUo
 oiT
-nLG
-iHq
-iHq
-iHq
-iHq
-cCD
+sQR
+cJQ
+ewI
+ewI
+ewI
+cJQ
 gEh
 tgt
 nkL
@@ -182261,12 +182336,12 @@ jMv
 pdi
 bUo
 oiT
-vhu
-iHq
-iHq
-iHq
-iHq
-iHq
+sQR
+oHG
+ewI
+ewI
+ewI
+oHG
 gEh
 tgt
 wdR
@@ -182518,12 +182593,12 @@ jMv
 pdi
 svk
 oiT
-nLG
-iho
-iHq
-iHq
-iHq
-iHq
+sQR
+yhi
+ewI
+ewI
+ewI
+ruc
 gEh
 tgt
 bfz
@@ -182775,12 +182850,12 @@ jMv
 pdi
 bUo
 oiT
-nLG
-iHq
-iHq
-iHq
-iHq
-txX
+tbQ
+oHG
+ewI
+fHT
+ewI
+oHG
 gEh
 tgt
 hUa
@@ -183032,12 +183107,12 @@ jMv
 pdi
 bUo
 oiT
-nLG
-uLD
-uLD
-iHq
-iHq
-ihN
+tbQ
+oHG
+ewI
+ewI
+ewI
+oHG
 gEh
 tgt
 tgt
@@ -183289,12 +183364,12 @@ jMv
 pdi
 bUo
 oiT
-nLG
-tmr
-ihN
-iHq
-iHq
-tVk
+sQR
+yhi
+ewI
+ewI
+ewI
+ruc
 gEh
 qGw
 qGw
@@ -183546,13 +183621,13 @@ jMv
 pdi
 bUo
 oiT
-nLG
-ihN
-ihN
-iHq
-iHq
-mQg
-oOD
+sQR
+cJQ
+ewI
+ewI
+ewI
+cJQ
+bvc
 lIb
 kpk
 kpk
@@ -183803,13 +183878,13 @@ jMv
 pdi
 bUo
 oiT
-nLG
-btF
-btF
-iHq
-iHq
-ihN
-oOD
+sQR
+aWe
+ewI
+ewI
+ewI
+oHG
+bvc
 sBO
 rUK
 kpk
@@ -184060,13 +184135,13 @@ jMv
 pdi
 bUo
 oiT
-nLG
-kwh
-iHq
-iHq
-iHq
-iHq
-oOD
+sQR
+yhi
+ewI
+ewI
+ewI
+ruc
+bvc
 sWl
 kpk
 kpk
@@ -184317,13 +184392,13 @@ jMv
 pdi
 bUo
 oiT
-nLG
-iHq
-iHq
-iHq
-iHq
-cCD
-oOD
+sQR
+qOB
+dmu
+ofo
+pNL
+plk
+bvc
 iIq
 kpk
 kpk
@@ -184574,13 +184649,13 @@ jMv
 pdi
 bUo
 oiT
-nLG
-iHq
-iHq
-iHq
-iHq
-iHq
-oOD
+sQR
+oHG
+vYI
+ewI
+ewI
+oHG
+bvc
 iIq
 kpk
 kpk
@@ -184831,13 +184906,13 @@ jMv
 pdi
 bUo
 oiT
-nLG
+sQR
 oDz
-iHq
-iHq
-iHq
-iHq
-oOD
+ewI
+ewI
+ewI
+oHG
+bvc
 iIq
 kpk
 kpk
@@ -185088,13 +185163,13 @@ jMv
 pdi
 bUo
 oiT
-nLG
-ihN
-ihN
-pyi
-gMy
+sQR
+szW
+oHG
+wyL
+oHG
 vAO
-oOD
+bvc
 hmq
 gnq
 gnq
@@ -185345,13 +185420,13 @@ jMv
 pdi
 bUo
 oiT
-oOD
-oOD
-oOD
-oOD
-oOD
-oOD
-oOD
+bvc
+bvc
+bvc
+bvc
+bvc
+bvc
+bvc
 oiT
 dFO
 ojC

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -324,6 +324,10 @@
 /obj/structure/table,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"aeV" = (
+/obj/item/storage/bag/trash,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "aeX" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -19065,6 +19069,10 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
+"fCk" = (
+/mob/living/carbon/human/npc/shop,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "fCo" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/pallet,
@@ -21616,14 +21624,6 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/city,
 /area/vtm/interior)
-"gnD" = (
-/obj/item/storage/briefcase/secure,
-/obj/item/gun/ballistic/automatic/darkpack/sniper,
-/obj/item/clothing/head/fedora,
-/obj/structure/closet/cabinet,
-/obj/item/ammo_box/darkpack/c50,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
 "gnJ" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
@@ -23384,15 +23384,11 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/obj/structure/vampdoor/old{
-	dir = 8;
-	lock_id = "triad";
-	locked = 1;
-	lockpick_difficulty = 16;
-	name = "Shady Laundromat door"
+/obj/structure/vampdoor/glass{
+	dir = 4
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior)
+/area/vtm/interior/shop)
 "gOG" = (
 /turf/closed/wall/vampwall/metal,
 /area/vtm/interior/wyrm_corrupted)
@@ -25457,11 +25453,6 @@
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
-"htR" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/rack/clothing_hanger,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
 "htX" = (
 /obj/structure/chair/pew/left{
 	dir = 8
@@ -38677,6 +38668,10 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"lvN" = (
+/obj/structure/sink/directional/west,
+/turf/open/floor/city/toilet,
+/area/vtm/interior/shop)
 "lvY" = (
 /obj/structure/vampdoor/old{
 	dir = 1;
@@ -44284,6 +44279,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/clinic)
+"ncz" = (
+/obj/structure/rack/wide/wood_shelf,
+/obj/item/pushbroom,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "ncI" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -45702,6 +45702,11 @@
 /obj/structure/flora/rock/stalagmite,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sabbat_lair)
+"nyv" = (
+/obj/structure/rack/wide/wood_shelf,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "nyC" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -46885,6 +46890,10 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
+"nPn" = (
+/obj/effect/decal/wallpaper/paper/green,
+/turf/closed/wall/vampwall/brick_old,
+/area/vtm/interior/shop)
 "nPu" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -47477,6 +47486,12 @@
 /obj/structure/chair,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
+"nYr" = (
+/obj/structure/platform/lowwall/city,
+/obj/structure/retail/general,
+/obj/structure/table,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "nYv" = (
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/market,
@@ -50889,6 +50904,11 @@
 /obj/effect/landmark/event_spawn/sarcophagus,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"oWc" = (
+/obj/structure/coclock,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "oWd" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/rich,
@@ -54772,6 +54792,10 @@
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
+"qam" = (
+/obj/item/wirecutters,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "qau" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -56197,6 +56221,10 @@
 /obj/structure/ladder/manhole/down,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"qvN" = (
+/obj/structure/platform/lowwall/city/window,
+/turf/closed/wall/vampwall/brick_old,
+/area/vtm/interior/shop)
 "qvU" = (
 /obj/structure/closet/crate/large,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
@@ -57054,6 +57082,11 @@
 /obj/structure/table,
 /turf/open/floor/light,
 /area/vtm/interior/strip)
+"qHW" = (
+/obj/structure/rack/wide/wood_shelf,
+/obj/item/taperecorder/empty,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "qHZ" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -58608,6 +58641,12 @@
 /obj/structure/ladder/manhole/down,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
+"rds" = (
+/obj/structure/rack/wide/wood_shelf{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "rdG" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
@@ -59959,6 +59998,11 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/supply)
+"rvX" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/vampdoor/simple,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "rwa" = (
 /obj/effect/decal/pallet,
 /obj/effect/decal/cleanable/cardboard,
@@ -63413,6 +63457,12 @@
 /mob/living/basic/pet/dog/darkpack/white,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"svp" = (
+/obj/effect/decal/carpet{
+	pixel_y = -6
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "svr" = (
 /obj/structure/bonfire/dense,
 /turf/open/misc/dirt,
@@ -63849,13 +63899,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
-"sCL" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/carpet,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
 "sCT" = (
 /obj/structure/noticeboard,
 /obj/effect/decal/wallpaper/blue,
@@ -74618,6 +74661,13 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"vRM" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/city/toilet,
+/area/vtm/interior/shop)
 "vRQ" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -78748,6 +78798,10 @@
 	},
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
+"xdA" = (
+/obj/item/razor,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "xdE" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/rough/cave,
@@ -81607,6 +81661,11 @@
 	},
 /turf/closed/wall/vampwall/old,
 /area/vtm)
+"xVH" = (
+/obj/structure/platform/lowwall/city,
+/obj/structure/table,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "xVM" = (
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/asphalt,
@@ -199841,14 +199900,14 @@ lym
 lym
 aFt
 jTk
-jcc
-jcc
+fDZ
+fDZ
 gOB
-jcc
-jcc
-jcc
-jcc
-jcc
+fDZ
+qvN
+qvN
+qvN
+fDZ
 aFt
 rtY
 qeN
@@ -200098,14 +200157,14 @@ yec
 lym
 aFt
 jTk
-dhp
-kGa
-iHq
-htR
-iHq
-iHq
-iHq
-jcc
+nPn
+mpn
+ewI
+oDW
+ewI
+ewI
+ewI
+fDZ
 aFt
 rtY
 dhb
@@ -200355,14 +200414,14 @@ kDy
 lym
 aFt
 jTk
-dhp
-iHq
-iHq
-iHq
-iHq
-iHq
-iHq
-jcc
+nPn
+ncz
+svp
+ewI
+ewI
+ewI
+ewI
+fDZ
 jTk
 rtY
 dhb
@@ -200612,14 +200671,14 @@ mCW
 lym
 aFt
 jTk
-dhp
-kwh
-iHq
-uLD
-uLD
-iHq
-iHq
-jcc
+nPn
+aeV
+ewI
+ewI
+xVH
+xVH
+xVH
+fDZ
 jTk
 rtY
 gcg
@@ -200869,14 +200928,14 @@ cNN
 lym
 jTk
 jTk
-dhp
-jsE
-iHq
-ihN
-hms
-iHq
-cCD
-jcc
+nPn
+dYz
+ewI
+ewI
+nYr
+fCk
+oaO
+fDZ
 jTk
 rtY
 dhb
@@ -201126,14 +201185,14 @@ lym
 lym
 jTk
 jTk
-dhp
-kQU
-iHq
-ihN
-ihN
-iHq
-iHq
-jcc
+nPn
+qHW
+ewI
+ewI
+xVH
+ewI
+ewI
+fDZ
 jTk
 rtY
 dhb
@@ -201383,14 +201442,14 @@ eQL
 lym
 jTk
 jTk
-dhp
-ihN
-iHq
-sCL
-btF
-iHq
-kGa
-jcc
+nPn
+xdA
+ewI
+ewI
+ewI
+ewI
+ewI
+fDZ
 jTk
 rtY
 bBe
@@ -201640,14 +201699,14 @@ slJ
 lym
 jTk
 jTk
-dhp
-tmr
-iHq
-iHq
-iHq
-iHq
-gnD
-jcc
+nPn
+dYz
+ewI
+ewI
+ewI
+rds
+mpn
+fDZ
 jTk
 rtY
 dhb
@@ -201897,14 +201956,14 @@ nmY
 lym
 mBV
 jTk
-dhp
-tVk
-iHq
-cCD
-jcc
-jcc
-jcc
-jcc
+nPn
+nyv
+ewI
+oaO
+fDZ
+fDZ
+fDZ
+fDZ
 jTk
 rtY
 dhb
@@ -202154,14 +202213,14 @@ rfe
 lym
 jTk
 jTk
-dhp
-yeb
-iHq
-iHq
-qHJ
-uQS
-iIm
-jcc
+nPn
+qam
+ewI
+ewI
+rvX
+paa
+paa
+fDZ
 xTH
 rtY
 dhb
@@ -202411,14 +202470,14 @@ fwh
 lym
 jTk
 jTk
-dhp
-dSs
-pyi
-gMy
-vhx
-emy
-dpj
-jcc
+nPn
+oWc
+ewI
+ewI
+xga
+vRM
+lvN
+fDZ
 jTk
 rtY
 dhb
@@ -202668,14 +202727,14 @@ lym
 lym
 jTk
 jTk
-jcc
-jcc
-jcc
-jcc
-jcc
-jcc
-jcc
-jcc
+fDZ
+fDZ
+fDZ
+fDZ
+fDZ
+fDZ
+fDZ
+fDZ
 jTk
 rtY
 dhb

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -4651,13 +4651,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
-"bqg" = (
-/obj/machinery/light/directional/north,
-/obj/structure/rack/food{
-	dir = 4
-	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/shop)
 "bqk" = (
 /obj/structure/table,
 /obj/structure/microscope,
@@ -5637,6 +5630,12 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
+"bEn" = (
+/obj/structure/table,
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/condiment/olive_oil,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "bEo" = (
 /obj/transfer_point_vamp{
 	dir = 4;
@@ -6973,6 +6972,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/baali)
+"bZL" = (
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/cup/mixing_bowl,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "bZW" = (
 /obj/effect/decal/cleanable/litter,
 /obj/item/cigbutt,
@@ -8208,6 +8212,10 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/clinic/haven)
+"crs" = (
+/obj/item/reagent_containers/condiment/soysauce,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "crx" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -9065,6 +9073,13 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
+"cEK" = (
+/obj/machinery/light/directional/south,
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/shop)
 "cEO" = (
 /obj/structure/roofstuff/vent_end{
 	dir = 8
@@ -12186,6 +12201,13 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
+"dzk" = (
+/obj/structure/table,
+/obj/structure/retail/smoke_menu{
+	dir = 1
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "dzm" = (
 /obj/structure/railing{
 	dir = 1;
@@ -12286,8 +12308,8 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/bianchiBank)
 "dAP" = (
-/obj/effect/decal/wallpaper/grey/low,
 /obj/structure/platform/lowwall/market/window,
+/obj/effect/decal/wallpaper/blue/low,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop)
 "dAU" = (
@@ -12905,6 +12927,11 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
+"dLu" = (
+/obj/structure/rack/wide/store_shelf,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "dLx" = (
 /obj/structure/table,
 /obj/item/chair/stool/bar,
@@ -13187,6 +13214,10 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"dQI" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "dQN" = (
 /turf/closed/wall/vampwall/metal,
 /area/vtm/interior/endron_facility/restricted)
@@ -16396,9 +16427,8 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "ePz" = (
-/obj/item/rack_parts,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/plating/concrete,
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "ePC" = (
 /obj/effect/turf_decal/bordur{
@@ -17708,6 +17738,11 @@
 	dir = 1
 	},
 /turf/open/floor/plating/concrete,
+/area/vtm/interior/shop)
+"fiP" = (
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/condiment/bbqsauce,
+/turf/open/floor/iron,
 /area/vtm/interior/shop)
 "fiX" = (
 /obj/structure/table/wood,
@@ -19437,8 +19472,7 @@
 /area/vtm/interior/clinic/haven)
 "fIj" = (
 /obj/machinery/light/directional/north,
-/mob/living/carbon/human/npc/pharmacystore,
-/turf/open/floor/plating/concrete,
+/turf/open/floor/iron/dark,
 /area/vtm/interior/shop)
 "fIl" = (
 /obj/structure/table/wood/fancy/red,
@@ -20579,10 +20613,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
-"fZl" = (
-/obj/machinery/vending/snack/orange,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/shop)
 "fZm" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -21753,6 +21783,13 @@
 /obj/structure/platform/lowwall/rich/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/ventrue)
+"gpJ" = (
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "gpO" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/city/plating_mono,
@@ -22241,6 +22278,13 @@
 "gwI" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
+"gwN" = (
+/obj/structure/table,
+/obj/structure/retail/grocery_store{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "gxs" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/decal/cleanable/litter,
@@ -22333,6 +22377,11 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/ventrue)
+"gyZ" = (
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/condiment/cornmeal,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "gzc" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/city/plating_mono,
@@ -22395,7 +22444,8 @@
 /area/vtm/interior/bianchiBank)
 "gzD" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/carpet,
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "gzE" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -22740,6 +22790,11 @@
 /obj/item/storage/box/ingredients/carnivore,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
+"gEf" = (
+/obj/machinery/light/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "gEg" = (
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/brick_old,
@@ -23368,6 +23423,10 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating/granite,
 /area/vtm/interior/bianchiBank)
+"gNK" = (
+/obj/item/reagent_containers/condiment/cherryjelly,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "gNW" = (
 /obj/machinery/light/directional/east,
 /obj/structure/tank_holder/extinguisher,
@@ -24457,6 +24516,10 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/old)
+"heJ" = (
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "heK" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
@@ -26209,6 +26272,10 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/fed)
+"hHo" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "hHu" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/rust,
@@ -26668,6 +26735,12 @@
 /obj/structure/sink/directional/east,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/trujah)
+"hOQ" = (
+/obj/structure/vampdoor/wood,
+/obj/effect/mapping_helpers/door/access/npc,
+/obj/effect/mapping_helpers/door/lock,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/shop)
 "hOV" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcability,
@@ -27102,9 +27175,8 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
 "hWj" = (
-/obj/structure/table,
 /obj/structure/coclock,
-/turf/open/floor/plating/concrete,
+/turf/open/floor/iron/dark,
 /area/vtm/interior/shop)
 "hWu" = (
 /obj/structure/table,
@@ -28847,6 +28919,13 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
+"iAb" = (
+/obj/machinery/vending/snack{
+	pixel_y = 20;
+	density = 0
+	},
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "iAd" = (
 /obj/structure/vampfence/rich{
 	dir = 1
@@ -29999,6 +30078,10 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/supply)
+"iRF" = (
+/obj/item/reagent_containers/condiment/vinegar,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "iRJ" = (
 /obj/structure/vampfence/corner{
 	dir = 8
@@ -31015,6 +31098,10 @@
 /obj/item/clothing/suit/hooded/robes/black,
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/endron_facility)
+"jgN" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "jgO" = (
 /obj/effect/turf_decal/stock{
 	dir = 8
@@ -31707,6 +31794,13 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"jrG" = (
+/obj/structure/table,
+/obj/structure/retail/junkfood_menu{
+	dir = 1
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "jrM" = (
 /obj/structure/vampdoor,
 /obj/effect/mapping_helpers/door/access/malkavian,
@@ -31770,6 +31864,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"jsF" = (
+/obj/structure/closet/secure_closet/freezer/commercial,
+/obj/item/reagent_containers/condiment/soymilk,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "jsG" = (
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/city/plating,
@@ -32850,6 +32949,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/church)
+"jII" = (
+/obj/item/reagent_containers/condiment/flour,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "jIL" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/smooth/old,
@@ -32890,6 +32993,10 @@
 "jJq" = (
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer/nosferatu_town)
+"jJt" = (
+/obj/item/storage/box/matches,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "jJA" = (
 /obj/effect/turf_decal/siding/wood,
 /mob/living/basic/corvid/crow,
@@ -36208,6 +36315,10 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
+"kKG" = (
+/obj/structure/platform/lowwall/market/window,
+/turf/open/space/basic,
+/area/vtm/interior/shop)
 "kKI" = (
 /obj/structure/table,
 /obj/item/melee/vamp/tire{
@@ -41481,6 +41592,11 @@
 	},
 /turf/open/floor/iron/stairs,
 /area/vtm/interior)
+"moM" = (
+/obj/structure/closet/secure_closet/freezer/commercial,
+/obj/item/reagent_containers/condiment/coconut_milk,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "moQ" = (
 /obj/structure/food_cart,
 /turf/open/floor/plating/sidewalkalt,
@@ -43441,6 +43557,9 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"mRu" = (
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "mRv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -43937,10 +44056,6 @@
 /obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
-"mXF" = (
-/obj/machinery/roulette,
-/turf/open/floor/carpet,
-/area/vtm/interior/shop)
 "mXG" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall/vampwall/rich/old,
@@ -46037,6 +46152,11 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"nEh" = (
+/obj/structure/closet/secure_closet/freezer/commercial,
+/obj/item/reagent_containers/condiment/yoghurt,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "nEm" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/darkpack/citizen/janitor,
@@ -48076,6 +48196,12 @@
 	},
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
+"oiH" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/shop)
 "oiK" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -48998,10 +49124,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/techshop)
-"oxc" = (
-/obj/machinery/vending/snack/green,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/shop)
 "oxf" = (
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/sabbat_lair)
@@ -49853,6 +49975,10 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"oIV" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "oJe" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -50080,6 +50206,12 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
+"oMq" = (
+/obj/machinery/vending/snack/orange{
+	pixel_y = 20
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "oMt" = (
 /obj/structure/sink/directional/south,
 /turf/open/floor/city/church,
@@ -50827,8 +50959,10 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop)
 "oWp" = (
-/obj/machinery/food_cart,
-/turf/open/floor/carpet,
+/obj/machinery/vending/snack/teal{
+	pixel_y = 20
+	},
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "oWq" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -52664,6 +52798,11 @@
 /obj/item/newspaper,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf)
+"pya" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "pyd" = (
 /obj/structure/roofstuff/vent_end{
 	dir = 8
@@ -54843,8 +54982,8 @@
 /turf/open/water,
 /area/vtm/outside/financialdistrict)
 "qdi" = (
-/obj/machinery/computer/arcade,
-/turf/open/floor/carpet,
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "qdk" = (
 /obj/structure/table,
@@ -57588,6 +57727,12 @@
 /obj/structure/roadsign/speedlimit25,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights)
+"qQT" = (
+/obj/machinery/vending/cola/starkist{
+	pixel_y = 20
+	},
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "qQX" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/sign/city/strip_club/directional/north,
@@ -57853,9 +57998,8 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/church/haven)
 "qTY" = (
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/plating/concrete,
+/mob/living/carbon/human/npc/shop,
+/turf/open/floor/iron/dark,
 /area/vtm/interior/shop)
 "qTZ" = (
 /obj/item/paper/fluff,
@@ -59771,8 +59915,10 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/police/upstairs)
 "ruK" = (
-/obj/machinery/vending/snack/teal,
-/turf/open/floor/plating/concrete,
+/obj/machinery/vending/cola/pwr_game{
+	pixel_y = 20
+	},
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "ruM" = (
 /obj/effect/turf_decal/siding/wood{
@@ -60059,6 +60205,9 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
+"rzo" = (
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "rzu" = (
 /obj/machinery/vending/cola/blue{
 	pixel_y = 20
@@ -61068,6 +61217,9 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
+"rPn" = (
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "rPp" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -62355,7 +62507,7 @@
 "shy" = (
 /obj/structure/vampdoor/glass,
 /obj/effect/turf_decal/bordur,
-/turf/open/floor/plating/concrete,
+/turf/open/floor/iron,
 /area/vtm/interior/shop)
 "shA" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -63875,12 +64027,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough,
 /area/vtm/outside/forest)
-"sEj" = (
-/obj/structure/rack/food{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/vtm/interior/shop)
 "sEl" = (
 /obj/structure/table/wood,
 /obj/structure/platform/lowwall/painted,
@@ -64423,6 +64569,10 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"sNS" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "sNT" = (
 /obj/effect/decal/pallet,
 /obj/machinery/light/small/directional/south,
@@ -64879,7 +65029,7 @@
 /area/vtm/outside/pacificheights)
 "sWm" = (
 /mob/living/carbon/human/npc/shop,
-/turf/open/floor/plating/concrete,
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "sWo" = (
 /obj/machinery/vending/coffee,
@@ -66331,6 +66481,12 @@
 /obj/vampire_computer,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/police/fed)
+"tsU" = (
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "tsW" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/concrete,
@@ -70053,6 +70209,11 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
+"uAy" = (
+/obj/structure/rack/wide/store_shelf,
+/obj/item/reagent_containers/condiment/peanut_butter,
+/turf/open/floor/iron,
+/area/vtm/interior/shop)
 "uAD" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -70696,6 +70857,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/strip)
+"uJY" = (
+/obj/machinery/light/directional/south,
+/obj/structure/rack/food/rand{
+	dir = 4
+	},
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "uKh" = (
 /obj/structure/closet/crate/dumpster{
 	pixel_x = 3;
@@ -71670,6 +71838,12 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
+"uZR" = (
+/obj/structure/vampdoor/glass{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "uZV" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
@@ -73272,6 +73446,13 @@
 /obj/structure/table,
 /turf/open/floor/city/plating,
 /area/vtm/outside/giovanni/courtyard)
+"vze" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/platform/lowwall/market/window,
+/turf/open/space/basic,
+/area/vtm/interior/shop)
 "vzi" = (
 /obj/structure/curtain/bounty,
 /obj/effect/decal/cleanable/food/egg_smudge,
@@ -75554,8 +75735,10 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
 "whE" = (
-/obj/machinery/vending/sovietsoda,
-/turf/open/floor/plating/concrete,
+/obj/machinery/vending/cola{
+	pixel_y = 20
+	},
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "whJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -76152,6 +76335,10 @@
 "wra" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/cog/caern)
+"wrg" = (
+/obj/structure/vampdoor/glass,
+/turf/open/floor/sepia,
+/area/vtm/interior/shop)
 "wri" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -77900,10 +78087,6 @@
 "wTq" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/sewer)
-"wTs" = (
-/obj/machinery/vending/snack/blue,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/shop)
 "wTx" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/rough/cave,
@@ -78433,8 +78616,8 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
 "xbj" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/plating/concrete,
+/obj/structure/rack/wide/store_shelf,
+/turf/open/floor/sepia,
 /area/vtm/interior/shop)
 "xbo" = (
 /obj/structure/vampdoor/simple{
@@ -79439,6 +79622,10 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/two,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
+"xqC" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/shop)
 "xqD" = (
 /obj/structure/ladder/manhole/down,
 /turf/open/misc/grass,
@@ -80342,6 +80529,10 @@
 	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/ventrue)
+"xEZ" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark,
+/area/vtm/interior/shop)
 "xFe" = (
 /obj/structure/chair{
 	dir = 1
@@ -156423,12 +156614,12 @@ bzp
 bzp
 bzp
 qvp
-nYv
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
+bgX
+sNS
+nEh
+moM
+jsF
+sNS
 bvc
 lFa
 msq
@@ -156680,12 +156871,12 @@ bpj
 iBm
 bzp
 bzp
-nYv
-iTZ
-fjw
-iTZ
-iTZ
-iTZ
+bgX
+qQT
+rzo
+mRu
+rzo
+mRu
 bvc
 xdS
 msq
@@ -156937,12 +157128,12 @@ nGZ
 yas
 stS
 hED
-nYv
-iTZ
-fjw
-iTZ
-iTZ
-iTZ
+bgX
+iAb
+rzo
+mRu
+rzo
+mRu
 shy
 msq
 ulk
@@ -157194,12 +157385,12 @@ nGZ
 stS
 stS
 vvP
-nYv
+bgX
 fIj
-tIg
-iTZ
-iTZ
-iTZ
+rzo
+mRu
+rzo
+mRu
 shy
 msq
 nlc
@@ -157451,12 +157642,12 @@ nGZ
 stt
 stS
 iAk
-nYv
+bgX
 hWj
-fjw
-iTZ
-iTZ
-iTZ
+rzo
+mRu
+rzo
+mRu
 bvc
 bvc
 bvc
@@ -157708,23 +157899,23 @@ nGZ
 nGZ
 nGZ
 nGZ
-nYv
+bgX
 qTY
-iTZ
-iTZ
-iTZ
-iTZ
+gwN
+mRu
+rzo
+mRu
 bgX
 wgU
 mDw
 fgd
 kMR
-ewI
+xqC
 bgX
 ePz
-fjw
-iTZ
-iTZ
+dzk
+rPn
+rPn
 bvc
 oWV
 qDW
@@ -157965,12 +158156,12 @@ kDz
 nGZ
 eIB
 oWV
-nYv
-xmz
-iTZ
-iTZ
-iTZ
-uSK
+bgX
+pya
+dQI
+mRu
+rzo
+hHo
 bgX
 lpX
 mPa
@@ -157979,10 +158170,10 @@ ewI
 ewI
 bgX
 sWm
-tIg
-iTZ
-iTZ
-pst
+jrG
+rPn
+rPn
+vze
 pHN
 vox
 hwp
@@ -158223,11 +158414,11 @@ nGZ
 obM
 oWV
 dAP
-mGs
-iTZ
-iTZ
-mGs
-iTZ
+mRu
+rzo
+mRu
+rzo
+mRu
 bgX
 aIo
 aIo
@@ -158235,11 +158426,11 @@ sTQ
 ewI
 ewI
 ajx
-iTZ
-iTZ
-iTZ
-uSK
-bvc
+rPn
+rPn
+rPn
+rPn
+kKG
 oWV
 vox
 hwp
@@ -158480,11 +158671,11 @@ nGZ
 obM
 oWV
 dAP
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
+qTY
+gwN
+mRu
+rzo
+mRu
 bgX
 ewI
 ofo
@@ -158492,11 +158683,11 @@ ofo
 ewI
 ewI
 bgX
-xmz
-iTZ
-mGs
-iTZ
-wiu
+jgN
+rPn
+rPn
+oIV
+bvc
 oWV
 vox
 hwp
@@ -158736,24 +158927,24 @@ kDz
 nGZ
 obM
 oWV
-nYv
-bqg
-iTZ
-iTZ
-mGs
-uSK
 bgX
-oEe
+pya
+dQI
+mRu
+rzo
+hHo
+hOQ
+ewI
 ewI
 pRj
 ewI
 wEP
 bgX
 xbj
-iTZ
-iTZ
-iTZ
-wiu
+rPn
+rPn
+rPn
+bvc
 oWV
 vox
 hwp
@@ -158994,11 +159185,11 @@ nGZ
 obM
 oWV
 dAP
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
+mRu
+rzo
+mRu
+rzo
+mRu
 bvc
 bvc
 bvc
@@ -159006,11 +159197,11 @@ bvc
 bvc
 bvc
 bgX
-wTs
-iTZ
-mGs
-uSK
-bvc
+rPn
+rPn
+rPn
+rPn
+wrg
 oWV
 vox
 hwp
@@ -159251,11 +159442,11 @@ rPN
 fnj
 oWV
 dAP
-mGs
-iTZ
-iTZ
-mGs
-iTZ
+mRu
+rzo
+mRu
+rzo
+mRu
 bvc
 oWV
 oWV
@@ -159263,11 +159454,11 @@ oWV
 oWV
 oWV
 bgX
-oxc
-iTZ
-iTZ
-iTZ
-wiu
+jgN
+rPn
+rPn
+oIV
+bvc
 oWV
 vox
 hwp
@@ -159507,12 +159698,12 @@ ech
 ech
 qua
 oWV
-nYv
-xmz
-iTZ
-iTZ
-iTZ
-uSK
+bgX
+fIj
+bEn
+mRu
+dLu
+hHo
 bvc
 dnN
 oWV
@@ -159520,11 +159711,11 @@ oWV
 oWV
 oWV
 bgX
-cGa
-iTZ
-mGs
-iTZ
-wiu
+rPn
+rPn
+rPn
+rPn
+bvc
 oWV
 vox
 hwp
@@ -159765,23 +159956,23 @@ hwp
 obM
 oWV
 dAP
-mGs
-iTZ
-iTZ
-mGs
-iTZ
+mRu
+iRF
+mRu
+jJt
+mRu
 bvc
 nXI
 oWV
 oWV
 oWV
 oWV
-bgX
-fZl
-iTZ
-iTZ
-uSK
-bvc
+wrg
+rPn
+rPn
+rPn
+uJY
+kKG
 oWV
 vox
 hwp
@@ -160022,11 +160213,11 @@ hwp
 obM
 oWV
 dAP
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
+mRu
+rzo
+mRu
+rzo
+mRu
 bvc
 rdm
 oWV
@@ -160035,9 +160226,9 @@ oWV
 oWV
 bgX
 ruK
-iTZ
-mGs
-iTZ
+rPn
+rPn
+rPn
 wiu
 oWV
 vox
@@ -160278,12 +160469,12 @@ hwp
 hwp
 obM
 oWV
-nYv
-bqg
-iTZ
-iTZ
-mGs
-uSK
+bgX
+fIj
+gyZ
+mRu
+uAy
+hHo
 bvc
 hGy
 oWV
@@ -160292,10 +160483,10 @@ oWV
 oWV
 bgX
 whE
-iTZ
-iTZ
-iTZ
-wiu
+rPn
+rPn
+gpJ
+bvc
 oWV
 vox
 hwp
@@ -160536,11 +160727,11 @@ hwp
 obM
 oWV
 dAP
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
+mRu
+jII
+mRu
+gNK
+mRu
 bvc
 hGy
 oWV
@@ -160548,11 +160739,11 @@ oWV
 oWV
 oWV
 bgX
-xmz
-iTZ
-mGs
-uSK
-bvc
+gEf
+rPn
+rPn
+oIV
+kKG
 dnN
 vox
 hwp
@@ -160793,11 +160984,11 @@ hwp
 obM
 oWV
 dAP
-mGs
-iTZ
-iTZ
-mGs
-iTZ
+mRu
+rzo
+mRu
+rzo
+mRu
 bvc
 oWV
 oWV
@@ -160805,10 +160996,10 @@ oWV
 oWV
 oWV
 bgX
-iTZ
-iTZ
-iTZ
-iTZ
+oMq
+rPn
+rPn
+tsU
 wiu
 oWV
 vox
@@ -161049,12 +161240,12 @@ jul
 hwp
 obM
 oWV
-nYv
-xmz
-iTZ
-iTZ
-iTZ
-uSK
+bgX
+fIj
+bZL
+mRu
+fiP
+hHo
 bvc
 hGy
 oWV
@@ -161063,10 +161254,10 @@ oWV
 oWV
 bgX
 oWp
-aIo
-sEj
-iTZ
-wiu
+rPn
+rPn
+rPn
+bvc
 oWV
 vox
 hwp
@@ -161307,11 +161498,11 @@ hwp
 obM
 oWV
 dAP
-mGs
-iTZ
-iTZ
-mGs
-iTZ
+mRu
+heJ
+mRu
+crs
+mRu
 bvc
 hGy
 oWV
@@ -161319,10 +161510,10 @@ gSI
 oWV
 oWV
 bgX
-mXF
-aIo
-aIo
-uSK
+rPn
+rPn
+rPn
+cEK
 bvc
 oWV
 vox
@@ -161564,11 +161755,11 @@ hwp
 obM
 oWV
 dAP
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
+mRu
+rzo
+mRu
+rzo
+mRu
 bvc
 oWV
 oWV
@@ -161577,10 +161768,10 @@ oWV
 oWV
 bgX
 gzD
-aIo
-aIo
-iTZ
-pst
+rPn
+rPn
+oIV
+oiH
 oWV
 vox
 hwp
@@ -161820,12 +162011,12 @@ jul
 hwp
 obM
 oWV
-nYv
-iTZ
-iTZ
-iTZ
-iTZ
-iTZ
+bgX
+xEZ
+rzo
+mRu
+rzo
+mRu
 bvc
 kjB
 oWV
@@ -161834,9 +162025,9 @@ oWV
 oWV
 bgX
 qdi
-aIo
-aIo
-iTZ
+rPn
+rPn
+rPn
 bvc
 oWV
 vox
@@ -162080,7 +162271,7 @@ wwM
 bvc
 bvc
 bvc
-cRq
+uZR
 bvc
 bvc
 bvc
@@ -162090,9 +162281,9 @@ oWV
 oWV
 oWV
 bvc
-bvc
-bvc
-bvc
+kKG
+kKG
+kKG
 bvc
 bvc
 oWV

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -21272,6 +21272,10 @@
 /obj/effect/landmark/event_spawn/sarcophagus,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
+"gii" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/carpet,
+/area/vtm/interior/anarch)
 "gij" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -70190,11 +70194,6 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/tzimisce_sanctum)
-"uxF" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/turf/open/floor/carpet,
-/area/vtm/interior/anarch)
 "uxV" = (
 /turf/closed/wall/vampwall/rock{
 	density = 0
@@ -165238,7 +165237,7 @@ mtQ
 iZB
 nhy
 xBo
-qLB
+gii
 qLB
 qLB
 uTJ
@@ -166275,7 +166274,7 @@ oZb
 bGN
 qLB
 qLB
-uxF
+bGN
 fkk
 rXs
 msq

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -5429,9 +5429,12 @@
 /area/vtm/interior)
 "bBC" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/darkpack/sniper,
 /obj/effect/decal/graffiti,
-/obj/item/ammo_box/darkpack/c50,
+/obj/item/gun/ballistic/automatic/darkpack/mac10/super,
+/obj/item/ammo_box/magazine/darkpack45smg,
+/obj/item/ammo_box/magazine/darkpack45smg,
+/obj/item/ammo_box/magazine/darkpack45smg,
+/obj/item/ammo_box/magazine/darkpack45smg,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "bBT" = (

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -67877,10 +67877,6 @@
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
-"tNP" = (
-/obj/structure/platform/lowwall/market/window,
-/turf/open/space/basic,
-/area/vtm/interior/shop)
 "tNQ" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -162355,9 +162351,9 @@ oWV
 oWV
 oWV
 bvc
-tNP
-tNP
-tNP
+wiu
+wiu
+wiu
 bvc
 bvc
 oWV

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -917,9 +917,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "amQ" = (
@@ -8186,9 +8184,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "cqM" = (
@@ -8807,9 +8803,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/f2)
 "cAe" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
@@ -10909,9 +10903,7 @@
 /area/vtm/interior/jazzclub)
 "dfy" = (
 /obj/effect/decal/pallet,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /obj/effect/decal/pallet{
 	pixel_x = 4;
 	pixel_y = 8
@@ -13786,6 +13778,17 @@
 /obj/structure/platform/lowwall/painted,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/bianchiBank)
+"eaD" = (
+/obj/effect/turf_decal/bordur{
+	dir = 4
+	},
+/obj/effect/turf_decal/bordur,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "eaE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -19166,9 +19169,7 @@
 /area/vtm/outside/forest)
 "fDm" = (
 /obj/effect/turf_decal/bordur,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "fDt" = (
@@ -19516,9 +19517,7 @@
 	pixel_x = 6;
 	pixel_y = 9
 	},
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /obj/effect/decal/pallet,
 /obj/structure/lattice,
 /turf/open/floor/wood/old,
@@ -45609,9 +45608,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /obj/effect/turf_decal/bordur/corner,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
@@ -50239,6 +50236,17 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"oLZ" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/bordur,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "oMk" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -74788,9 +74796,7 @@
 /obj/structure/gargoyle{
 	pixel_y = -28
 	},
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
 	},
@@ -76299,9 +76305,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bordur,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
 	},
@@ -311281,7 +311285,7 @@ kno
 kno
 kno
 tUd
-jPE
+oLZ
 ntq
 ntq
 ntq
@@ -312565,7 +312569,7 @@ kno
 kno
 kno
 tUd
-jPE
+eaD
 ntq
 ntq
 ntq

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -82451,13 +82451,6 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"yeP" = (
-/obj/machinery/light/directional/south,
-/obj/structure/rack/food/rand{
-	dir = 4
-	},
-/turf/open/floor/sepia,
-/area/vtm/interior/shop)
 "yeS" = (
 /obj/effect/decal/cleanable/litter,
 /obj/effect/decal/cleanable/litter,
@@ -160131,7 +160124,7 @@ hJS
 fZl
 fZl
 fZl
-yeP
+wae
 wiu
 oWV
 vox
@@ -160902,7 +160895,7 @@ bgX
 nKd
 fZl
 fZl
-iBm
+fZl
 wiu
 dnN
 vox

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -11829,13 +11829,6 @@
 /obj/effect/mapping_helpers/door/access/primogen_malkavian,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic/haven)
-"dtl" = (
-/obj/effect/decal/wallpaper/paper/stripe,
-/obj/structure/fish_mount/bar{
-	name = "gun mount"
-	},
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/shop)
 "dtG" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -44006,11 +43999,6 @@
 /obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
-"mXF" = (
-/obj/structure/fish_mount/bar,
-/obj/effect/decal/wallpaper/paper/stripe,
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/shop)
 "mXG" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall/vampwall/rich/old,
@@ -56272,7 +56260,7 @@
 /area/vtm/interior/chantry)
 "qvN" = (
 /obj/structure/platform/lowwall/city/window,
-/turf/closed/wall/vampwall/brick_old,
+/turf/open/floor/plating/rough,
 /area/vtm/interior/shop)
 "qvU" = (
 /obj/structure/closet/crate/large,
@@ -63405,7 +63393,7 @@
 	dir = 1
 	},
 /obj/structure/platform/lowwall/market/window,
-/turf/open/space/basic,
+/turf/open/floor/plating/rough,
 /area/vtm/interior/shop)
 "stu" = (
 /mob/living/basic/pet/cat/darkpack,
@@ -68068,16 +68056,6 @@
 /obj/structure/table,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
-"tRw" = (
-/obj/item/fish/darkpack/shark{
-	pixel_y = 31;
-	pixel_x = 16;
-	layer = 4;
-	anchored = 1;
-	desc = "A stuffed and taxidermied shark. Its' eyes stare at you lifelessly. This one doesn't make any noise."
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "tRL" = (
 /obj/effect/decal/cleanable/garbage{
 	pixel_y = 9
@@ -73608,15 +73586,6 @@
 /obj/structure/chair/plastic,
 /turf/open/floor/wood/smooth,
 /area/vtm)
-"vBd" = (
-/obj/item/gun/ballistic/automatic/darkpack/huntrifle{
-	pixel_y = 30;
-	layer = 4;
-	anchored = 1;
-	desc = "A semi-automatic hunting rifle, just like what your dad used to shoot. If your dad didn't go out to get milk, anyways. This one is just for display."
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/shop)
 "vBf" = (
 /obj/structure/table,
 /obj/item/reagent_containers/blood,
@@ -158535,7 +158504,7 @@ fZl
 fZl
 fZl
 fZl
-tNP
+wiu
 oWV
 vox
 hwp
@@ -160077,7 +160046,7 @@ fZl
 fZl
 fZl
 yeP
-tNP
+wiu
 oWV
 vox
 hwp
@@ -160848,7 +160817,7 @@ nKd
 fZl
 fZl
 iBm
-tNP
+wiu
 dnN
 vox
 hwp
@@ -181753,8 +181722,8 @@ jMv
 pdi
 bUo
 oiT
-mXF
-tRw
+sQR
+oHG
 ewI
 ewI
 ewI
@@ -182010,8 +181979,8 @@ jMv
 pdi
 bUo
 oiT
-dtl
-vBd
+sQR
+oHG
 ewI
 ewI
 ewI

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -3987,11 +3987,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"bgS" = (
-/obj/item/clothing/head/cone,
-/obj/structure/barricade/wooden/crude,
-/turf/open/misc/dirt,
-/area/vtm/interior)
 "bgV" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/smooth,
@@ -5560,10 +5555,6 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
-"bDg" = (
-/obj/structure/barricade/wooden/crude,
-/turf/open/misc/dirt,
-/area/vtm/interior)
 "bDh" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -10835,8 +10826,12 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
 "deU" = (
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
+/obj/structure/sign/poster/greenscreen/directional/west,
+/obj/structure/chair/office/darkpack/red{
+	dir = 4
+	},
+/turf/open/indestructible/white/textured,
+/area/vtm/interior)
 "deV" = (
 /obj/effect/turf_decal/bordur{
 	dir = 9
@@ -11417,10 +11412,6 @@
 "dnv" = (
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop)
-"dnx" = (
-/obj/structure/barricade/wooden,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "dny" = (
 /obj/structure/chair,
 /turf/open/floor/wood/smooth,
@@ -12421,6 +12412,10 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
+"dDD" = (
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/plating/sidewalk,
+/area/vtm/interior/library)
 "dDN" = (
 /obj/effect/decal/rugs,
 /turf/open/floor/plating/concrete,
@@ -14098,9 +14093,10 @@
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
 "eeI" = (
-/obj/effect/decal/graffiti,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
+/obj/structure/rack/wide/metal_shelf,
+/obj/item/radio/entertainment/microphone/physical,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "eeK" = (
 /turf/open/floor/iron/stairs{
 	dir = 8
@@ -15372,9 +15368,9 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
 "ezp" = (
-/obj/structure/bonfire/fire_barrel,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
+/obj/item/broadcast_camera,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "ezt" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/coclock,
@@ -16657,11 +16653,6 @@
 /obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
-"eSR" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/graffiti,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "eST" = (
 /obj/structure/disposalpipe/trunk,
 /turf/open/water/vamp_sewer,
@@ -22865,8 +22856,8 @@
 /area/vtm/outside/pacificheights/forest)
 "gFt" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
+/turf/closed/wall/vampwall/painted,
+/area/vtm/interior)
 "gFJ" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -23913,10 +23904,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
-"gVt" = (
-/obj/effect/decal/cleanable/trash,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "gVA" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/misc/beach/vamp,
@@ -27748,6 +27735,16 @@
 /obj/structure/flora/tree/vamp,
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
+"ifj" = (
+/obj/structure/sign/poster/greenscreen/directional/west,
+/obj/structure/chair/office/darkpack/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/indestructible/white/textured,
+/area/vtm/interior)
 "ifn" = (
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/canal,
@@ -29629,9 +29626,9 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
 "iKd" = (
-/obj/effect/decal/wallpaper/stone,
-/turf/closed/wall/vampwall/junk/alt,
-/area/vtm/outside/unionsquare)
+/obj/structure/platform/lowwall/painted/window/reinforced,
+/turf/closed/wall/vampwall/painted,
+/area/vtm/interior)
 "iKe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -30445,7 +30442,6 @@
 /area/vtm/interior)
 "iWr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "iWt" = (
@@ -35370,13 +35366,6 @@
 /obj/structure/hedge,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
-"kvZ" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/mob/living/carbon/human/npc/hobo,
-/turf/open/misc/dirt,
-/area/vtm/interior)
 "kwh" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -38476,6 +38465,10 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
+"lqJ" = (
+/turf/open/floor/wood/smooth,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "lro" = (
 /obj/effect/decal/wallpaper/paper/rich,
 /turf/closed/wall/vampwall/painted,
@@ -40619,10 +40612,6 @@
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
-"lYC" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "lYE" = (
 /obj/structure/lamppost/one{
 	dir = 8
@@ -41728,8 +41717,8 @@
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/shop)
 "mrm" = (
-/obj/structure/bonfire/fire_barrel,
-/turf/open/misc/dirt,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "mrB" = (
 /obj/structure/lamppost/sidewalk,
@@ -44880,8 +44869,12 @@
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
 "nkX" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/misc/dirt,
+/obj/structure/table,
+/obj/item/newspaper,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/turf/open/indestructible/white/textured,
 /area/vtm/interior)
 "nkY" = (
 /obj/effect/landmark/npcbeacon/directed,
@@ -48831,11 +48824,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/upstairs)
-"ota" = (
-/obj/item/clothing/head/cone,
-/obj/structure/barricade/wooden/crude,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "oth" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -55097,8 +55085,8 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "qdt" = (
-/obj/effect/decal/wallpaper/stone,
-/turf/closed/wall/vampwall/junk/alt,
+/obj/structure/vampdoor/glass,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "qdu" = (
 /obj/machinery/light/directional/south,
@@ -61922,10 +61910,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/library)
-"rXq" = (
-/obj/effect/landmark/navigate_destination,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "rXs" = (
 /obj/item/smartphone/payphone,
 /turf/open/floor/plating/sidewalk/poor,
@@ -62007,6 +61991,16 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/park)
+"rYv" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 6
+	},
+/turf/open/indestructible/white/textured,
+/area/vtm/interior)
 "rYy" = (
 /obj/structure/table,
 /obj/item/vamp/keys/brujah,
@@ -62311,6 +62305,14 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
+"sbO" = (
+/obj/structure/sign/poster/greenscreen/directional/west,
+/obj/structure/chair/office/darkpack/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/indestructible/white/textured,
+/area/vtm/interior)
 "sbT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -64191,13 +64193,6 @@
 /obj/item/radio/headset/darkpack/police,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior)
-"sFh" = (
-/obj/effect/decal/pallet{
-	pixel_x = -3;
-	pixel_y = -4
-	},
-/turf/open/misc/dirt,
-/area/vtm/interior)
 "sFi" = (
 /obj/structure/rack,
 /obj/item/clothing/head/vampire/helmet/egorium,
@@ -65434,6 +65429,10 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
+"taZ" = (
+/obj/machinery/greenscreen_camera,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "tbc" = (
 /obj/effect/turf_decal/weather/sand{
 	dir = 10
@@ -66292,9 +66291,6 @@
 /obj/structure/chair/sofa/left/brown,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
-"toF" = (
-/turf/closed/wall/vampwall/junk/alt,
-/area/vtm/outside/unionsquare)
 "toK" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/ladder/manhole/down,
@@ -68520,12 +68516,8 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "tYg" = (
-/obj/structure/bed/maint{
-	pixel_x = 14;
-	pixel_y = 8
-	},
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "tYj" = (
 /obj/effect/decal/pallet,
 /obj/effect/decal/cleanable/cardboard,
@@ -71830,11 +71822,6 @@
 /obj/effect/landmark/npcbeacon/directed,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/library)
-"uXM" = (
-/obj/effect/decal/cleanable/blood/oil/slippery,
-/obj/effect/landmark/npcwall,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "uXU" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -72383,12 +72370,6 @@
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
-"vgo" = (
-/obj/effect/decal/cleanable/trash{
-	icon_state = "trash8"
-	},
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "vgp" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -72769,10 +72750,6 @@
 /obj/machinery/shower/directional/north,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
-"vmq" = (
-/obj/effect/decal/cleanable/blood/splatter/oil,
-/turf/open/misc/dirt,
-/area/vtm/outside/unionsquare)
 "vmr" = (
 /mob/living/basic/pet/cat/darkpack,
 /obj/effect/decal/graffiti/large{
@@ -76557,10 +76534,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
 "wsO" = (
-/obj/effect/decal/cleanable/trash{
-	icon_state = "trash5"
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
 	},
-/turf/open/misc/dirt,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/turf/open/indestructible/white/textured,
 /area/vtm/interior)
 "wsX" = (
 /turf/open/floor/plating/rough,
@@ -188583,13 +188564,13 @@ fQP
 rFS
 iog
 iog
-lFi
-toF
-toF
-toF
-lFi
-lFi
-qdt
+hfy
+iKd
+hfy
+hfy
+hfy
+iKd
+hfy
 iog
 iog
 hfy
@@ -188645,7 +188626,7 @@ eAX
 eAX
 eAX
 sYL
-eAX
+dDD
 eAX
 eAX
 eAX
@@ -188840,13 +188821,13 @@ fQP
 rFS
 iog
 iog
-qdt
-eSR
-deU
-gFt
-kvZ
+hfy
 mrm
-qdt
+hfy
+gFt
+hfy
+mrm
+hfy
 iog
 iog
 cUg
@@ -189097,11 +189078,11 @@ fQP
 rFS
 iog
 iog
-qdt
+iKd
+tYg
+ifj
 deU
-deU
-deU
-vwN
+sbO
 tYg
 iKd
 iWr
@@ -189354,13 +189335,13 @@ fQP
 rFS
 iog
 iog
-bDg
-vwN
+iKd
+tYg
 wsO
 nkX
-vwN
-vgo
-dnx
+rYv
+tYg
+iKd
 iog
 iog
 cUg
@@ -189416,7 +189397,7 @@ hoA
 hoA
 hoA
 hoA
-rXq
+hoA
 hoA
 hoA
 hoA
@@ -189611,13 +189592,13 @@ fQP
 rFS
 iog
 iog
-bgS
-vwN
-vwN
-vwN
-vwN
-deU
-ota
+iKd
+lVM
+lVM
+lVM
+lVM
+lVM
+hfy
 iog
 iog
 cUg
@@ -189868,13 +189849,13 @@ fQP
 rFS
 fCt
 iog
-qdt
-vwN
-vwN
-vwN
-vwN
-vwN
-qdt
+iKd
+lVM
+lVM
+taZ
+lVM
+lVM
+hfy
 bcC
 iog
 hfy
@@ -190126,11 +190107,11 @@ tpw
 iog
 iog
 iKd
-tYg
-deU
-vmq
-deU
-vwN
+lVM
+lVM
+lVM
+lVM
+lVM
 qdt
 iog
 iog
@@ -190384,11 +190365,11 @@ iog
 iog
 iKd
 eeI
-gVt
-deU
-deU
-sFh
-qdt
+lVM
+lVM
+lVM
+lVM
+hfy
 iog
 iog
 hfy
@@ -190639,14 +190620,14 @@ fQP
 rFS
 iog
 iog
-iKd
+hfy
 ezp
-deU
-gFt
-lYC
-sFh
-qdt
-xna
+lVM
+lqJ
+lVM
+lVM
+hfy
+iog
 iog
 hfy
 vfw
@@ -190896,13 +190877,13 @@ fQP
 rFS
 iog
 iog
-iKd
-dnx
-uXM
-toF
-toF
-lFi
-qdt
+hfy
+hfy
+hfy
+hfy
+hfy
+hfy
+hfy
 iog
 iog
 hfy

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -377,14 +377,14 @@ GLOBAL_LIST_EMPTY(key_to_status_display)
 /// Evac display which shows shuttle timer or message set by Command.
 /obj/machinery/status_display/evac
 	current_mode = SD_PICTURE
-	current_picture = "default"  // Show the logo when we start round
+	current_picture = "ai_off"  // Show the logo when we start round // CRIMSON EDIT - Original: current_picture = "default"
 	var/frequency = FREQ_STATUS_DISPLAYS
 	var/friendc = FALSE      // track if Friend Computer mode
 	var/last_picture  // For when Friend Computer mode is undone
 	/// What mode we should go back to when the alert timer runs out
 	var/revert_mode = SD_PICTURE
 	/// What picture we should show when reverting back
-	var/revert_picture = "default"
+	var/revert_picture = "ai_off" // CRIMSON EDIT - Original: var/revert_picture = "default"
 	/// Timer for switching back to normal after showing alerts
 	var/alert_display_timer
 	/// How important our current display is (bigger number = more important)
@@ -465,7 +465,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 		return manual_display_state.Copy()
 
 	// Nothing special happening, just show the logo
-	return list("mode" = SD_PICTURE, "priority" = DISPLAY_PRIORITY_LOGO, "picture" = "default")
+	return list("mode" = SD_PICTURE, "priority" = DISPLAY_PRIORITY_LOGO, "picture" = "ai_off") // CRIMSON EDIT - Original:return list("mode" = SD_PICTURE, "priority" = DISPLAY_PRIORITY_LOGO, "picture" = "default")
 
 /// Tries to change what the display is showing, but respects priority levels
 /// Returns TRUE if we actually changed it, FALSE if something more important was already showing
@@ -484,7 +484,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 
 	// Store manually set displays (not temporary alerts, automated shuttle, or logo defaults)
 	// Logo selections shouldn't be treated as manual overrides since logo is the default anyway
-	var/is_logo_default = (new_mode == SD_PICTURE && (picture_state == "default" || picture_state == null))
+	var/is_logo_default = (new_mode == SD_PICTURE && (picture_state == "ai_off" || picture_state == null)) // CRIMSON EDIT - Original: var/is_logo_default = (new_mode == SD_PICTURE && (picture_state == "default" || picture_state == null))
 	if(priority >= DISPLAY_PRIORITY_MESSAGE && priority != DISPLAY_PRIORITY_ALERT_TEMP && priority != DISPLAY_PRIORITY_SHUTTLE && !is_logo_default)
 		manual_display_state = list(
 			"mode" = new_mode,
@@ -532,7 +532,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 			var/emergency_type = signal.data["emergency_type"]
 
 			// Check if this is just setting the logo back to default
-			if(picture_state == "default")
+			if(picture_state == "ai_off") // CRIMSON EDIT - Original: if(picture_state == "default")
 				// Clear any manual display state and reset to logo priority
 				manual_display_state = null
 				set_display_with_priority(SD_PICTURE, DISPLAY_PRIORITY_LOGO, picture_state = picture_state, force_override = TRUE)

--- a/modular_darkpack/modules/retail/code/stores/flower_shop.dm
+++ b/modular_darkpack/modules/retail/code/stores/flower_shop.dm
@@ -1,6 +1,6 @@
 /obj/structure/retail/flower_shop
 	name = "Community Garden"
-	desc = "The only twenty-four hour gardening store in San Francisco."
+	desc = "The only 24hr flower shop in SanFran."
 	products_list = list(
 		new /datum/data/vending_product("Gardening Gloves", /obj/item/clothing/gloves/botanic_leather, 45),
 		new /datum/data/vending_product("respirator", /obj/item/clothing/mask/gas/vampire),

--- a/modular_darkpack/modules/retail/code/stores/flower_shop.dm
+++ b/modular_darkpack/modules/retail/code/stores/flower_shop.dm
@@ -1,6 +1,6 @@
 /obj/structure/retail/flower_shop
 	name = "Community Garden"
-	desc = "The only 24hr flower shop in SanFran."
+	desc = "The only twenty-four hour gardening store in San Francisco."
 	products_list = list(
 		new /datum/data/vending_product("Gardening Gloves", /obj/item/clothing/gloves/botanic_leather, 45),
 		new /datum/data/vending_product("respirator", /obj/item/clothing/mask/gas/vampire),


### PR DESCRIPTION

## About The Pull Request
This is a medium-scale mapping PR that edits multiple locations to improve San Fangcisco. 
What it does:
The central gunstore has been removed and replaced with a gardening shop. You can buy seeds and farming supplies here.
The two identical junkfood stores next to the cabaret club have been given an overhaul, and the top store is now a grocery store, where you can buy cooking ingredients from.
A random house next to the underpass leading you into the forest has been turned into a hunting goods store. You can get hunting rifles, shotguns, stakes, binoculars, that kind of thing.
A random house in Chinatown south of the laundromat has been turned into a general store where you can purchase cleaning supplies and tools.
Navigation markers have been added to (most of the) important locations. Locations without navigation markers either were not compatible with the system or I wanted to keep them secret. 
TV screens have been distributed  so that the new Newscaster role may function- they should be able to remotely display a feed of the Newscaster's camera. 
(And if Chaz pulls through the Newscaster job and station will also be integrated with this PR)

Oh, I almost forgot, the Anarch Baron has a .45 caliber Mac10 now. Enjoy.


## Why It's Good For The Game
This PR began with realizing how broken the economy was. You couldn't get rods to fish, and you couldn't get fertilizer to grow pot. Big problems! So, I wanted to address them. Initially this PR was wider in scope and I wanted to add a whole recycling and farm selling system but I'll save that for later.  Mainly what this PR does is make the economy actually function by making two of the main money-making methods be feasible again. It also makes the map more interesting and distributes more fun items for people to play with. The Navigation markers should help new players get around properly and the Newscasters will be great for RP and immersion.
## Changelog
:cl:
add: Sporting Goods Store! Come get all of your hunting and fishing essentials. The binoculars are just for birds, creep. Just next to the underpass going into the state park.
add: Gardening Store! Come and get everything your plants could ever need. TOTALLY not for weed, no, sir. Just north of the Millennium Tower.
add: Grocery Store! Ever wondered where your dad left to get milk? This is the place! (Oh, and the cornerstore just south of it got a remodel, too.) Find it next to the Cabaret Club!
add: General store! Come and get all of your cleaning and miscellaneous needs! The mops are rated for human blood. Right next to the Chinatown laundromat.
add: Navigation markers have been placed for, well, ease of navigation! Just use the button in your hud and you'll be lead to most locations. The ones that aren't supposed to be secretive, anyways. 
add: It's TV-time, and RED News has you covered! Find their live broadcasts on screens across the city- or maybe work as a reporter yourself? This reporting was brought to you by [REDACTED]
del: Removed the old central gun store, two random houses that no one cared about, made the antique store slightly smaller.
/:cl:
