### PR TITLE
[Port] Ghost visibility in the statpanel

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -320,6 +320,11 @@
 		ADD_NEWLINE_IF_NECESSARY(.)
 		. += "<b>Quirks:</b> [get_quirk_string(FALSE, CAT_QUIRK_ALL)]"
 
+	// CRIMSON EDIT ADD START
+	if((isobserver(user) || isrevenant(user)) && user.invisibility <= see_invisible)
+		. += span_revennotice("[t_He] can see you!")
+	// CRIMSON EDIT ADD END
+
 	SEND_SIGNAL(src, COMSIG_ATOM_EXAMINE, user, .)
 	if(length(.))
 		.[1] = "<span class='info'>" + .[1]

--- a/modular_vcg/modules/ghost_visibility_notice/code/observer.dm
+++ b/modular_vcg/modules/ghost_visibility_notice/code/observer.dm
@@ -1,0 +1,13 @@
+// I know, you were expecting more, right?
+// Nah just kidding, search "can see you!" in code/modules/mob/living/carbon/examine.dm
+
+// Okay, you came back thinking there was more, right? no thats it.
+
+/mob/dead/observer/get_status_tab_items()
+	. = ..()
+	if(!GLOB.observer_default_invisibility)
+		. += "Ghosts visible to the living!"
+	else if (!invisibility)
+		. += "You are visible to the living!"
+	else if (invisibility <= SEE_INVISIBLE_LIVING)
+		. += "You are visibile to most living mobs!"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8148,6 +8148,7 @@
 #include "modular_vcg\master_files\code\modules\logging\log_holder.dm"
 #include "modular_vcg\master_files\code\modules\mentor\mentorsay.dm"
 #include "modular_vcg\master_files\code\modules\mocking\client.dm"
+#include "modular_vcg\modules\ghost_visibility_notice\code\observer.dm"
 #include "modular_vcg\modules\jobs\code\camarilla\prince.dm"
 #include "modular_vcg\modules\jobs\code\garou\councillor.dm"
 #include "modular_vcg\modules\jobs\code\garou\guardian.dm"


### PR DESCRIPTION

## About The Pull Request

- Port of https://github.com/Monkestation/Monkestation2.0/pull/8897

>Adds the ability to see your visibility status as a ghost to other players via statpanel and examines.

## Why It's Good For The Game

>Kinda wish i knew if i was visible to the living or not when i observe.
## Changelog
:cl:
add: Statpanel now shows if players can see you as a ghost.
add: As a ghost, examining a mob will show you if you're visible to them or not
/:cl:
