### PR TITLE
[Port] Lobby late join easy character slot selection

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -526,7 +526,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 		preference_middleware.on_new_character(usr)
 
-	character_preview_view?.update_body()
+	character_preview_view?.update_body() // CRIMSON EDIT - Original: character_preview_view.update_body()
 
 /datum/preferences/proc/remove_current_slot()
 	PRIVATE_PROC(TRUE)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -526,7 +526,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
 		preference_middleware.on_new_character(usr)
 
-	character_preview_view.update_body()
+	character_preview_view?.update_body()
 
 /datum/preferences/proc/remove_current_slot()
 	PRIVATE_PROC(TRUE)

--- a/modular_vcg/modules/lobby_join_stuff/README.md
+++ b/modular_vcg/modules/lobby_join_stuff/README.md
@@ -1,0 +1,44 @@
+<!-- This should be copy-pasted into the root of your module folder as readme.md -->
+
+https://github.com/Monkestation/crimson-grid/pull/<!--PR Number-->
+
+## Change Character Slot in Lobby menu <!--Title of your addition.-->
+
+Module ID: CHANGE_CHARACTER_SLOT<!-- Uppercase, UNDERSCORE_CONNECTED name of your module, that you use to mark files. This is so people can case-sensitive search for your edits, if any. -->
+
+### Description:
+
+<!-- Here, try to describe what your PR does, what features it provides and any other directly useful information. -->
+
+### TG Proc/File Changes:
+
+- N/A
+<!-- If you edited any core procs, you should list them here. You should specify the files and procs you changed.
+E.g:
+- `code/modules/mob/living.dm`: `proc/overriden_proc`, `var/overriden_var`
+  -->
+
+### Modular Overrides:
+
+- N/A
+<!-- If you added a new modular override (file or code-wise) for your module, you should list it here. Code files should specify what procs they changed, in case of multiple modules using the same file.
+E.g:
+- `modular_nova/master_files/sound/my_cool_sound.ogg`
+- `modular_nova/master_files/code/my_modular_override.dm`: `proc/overriden_proc`, `var/overriden_var`
+  -->
+- `code/_onclick/hud/new_player.dm`: `/atom/movable/screen/lobby/button/ready/Click`
+- `code/modules/mob/dead/new_player/latejoin_menu.dm`: `/datum/latejoin_menu/ui_data`, `/datum/latejoin_menu/ui_act`
+- `code/modules/mob/dead/dead.dm`: `/mob/dead/get_status_tab_items`
+
+### Defines:
+
+N/A
+
+### Included files that are not contained in this module:
+
+- N/A
+<!-- Likewise, be it a non-modular file or a modular one that's not contained within the folder belonging to this specific module, it should be mentioned here. Good examples are icons or sounds that are used between multiple modules, or other such edge-cases. -->
+
+### Credits:
+
+Flleeppyy

--- a/modular_vcg/modules/lobby_join_stuff/README.md
+++ b/modular_vcg/modules/lobby_join_stuff/README.md
@@ -1,31 +1,20 @@
-<!-- This should be copy-pasted into the root of your module folder as readme.md -->
+https://github.com/Monkestation/crimson-grid/pull/57
 
-https://github.com/Monkestation/crimson-grid/pull/<!--PR Number-->
+## Change Character Slot in Lobby menu
 
-## Change Character Slot in Lobby menu <!--Title of your addition.-->
-
-Module ID: CHANGE_CHARACTER_SLOT<!-- Uppercase, UNDERSCORE_CONNECTED name of your module, that you use to mark files. This is so people can case-sensitive search for your edits, if any. -->
+Module ID: CHANGE_CHARACTER_SLOT
 
 ### Description:
 
-<!-- Here, try to describe what your PR does, what features it provides and any other directly useful information. -->
+It adds a "Change Character" button to late join, letting you choose from a list of saved characters instead of opening the preferences menu clunkily. It also shows your current selected character when you ready up, and also in the stat panel.
 
 ### TG Proc/File Changes:
 
-- N/A
-<!-- If you edited any core procs, you should list them here. You should specify the files and procs you changed.
-E.g:
-- `code/modules/mob/living.dm`: `proc/overriden_proc`, `var/overriden_var`
-  -->
+- `tgui/packages/tgui/interfaces/JobSelection.tsx`
 
 ### Modular Overrides:
 
 - N/A
-<!-- If you added a new modular override (file or code-wise) for your module, you should list it here. Code files should specify what procs they changed, in case of multiple modules using the same file.
-E.g:
-- `modular_nova/master_files/sound/my_cool_sound.ogg`
-- `modular_nova/master_files/code/my_modular_override.dm`: `proc/overriden_proc`, `var/overriden_var`
-  -->
 - `code/_onclick/hud/new_player.dm`: `/atom/movable/screen/lobby/button/ready/Click`
 - `code/modules/mob/dead/new_player/latejoin_menu.dm`: `/datum/latejoin_menu/ui_data`, `/datum/latejoin_menu/ui_act`
 - `code/modules/mob/dead/dead.dm`: `/mob/dead/get_status_tab_items`
@@ -37,7 +26,6 @@ N/A
 ### Included files that are not contained in this module:
 
 - N/A
-<!-- Likewise, be it a non-modular file or a modular one that's not contained within the folder belonging to this specific module, it should be mentioned here. Good examples are icons or sounds that are used between multiple modules, or other such edge-cases. -->
 
 ### Credits:
 

--- a/modular_vcg/modules/lobby_join_stuff/code/change_character_slot.dm
+++ b/modular_vcg/modules/lobby_join_stuff/code/change_character_slot.dm
@@ -1,0 +1,67 @@
+
+/atom/movable/screen/lobby/button/ready/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return
+	var/mob/dead/new_player/new_player = hud.mymob
+	var/client/new_client = new_player?.client
+	if(new_client && new_player.ready == PLAYER_READY_TO_PLAY)
+		var/highest_job = new_client.prefs.GetHighestJobPreference()
+		var/ready_message = "Readying up as '[new_client.prefs.read_preference(/datum/preference/name/real_name)]'"
+		if(length(highest_job))
+			ready_message += ", Highest occupation setting: [highest_job]"
+		to_chat(new_client, span_notice(ready_message))
+
+
+/datum/preferences/proc/GetHighestJobPreference()
+	for(var/job in job_preferences)
+		if(job_preferences[job] == JP_HIGH)
+			return job
+
+GAME_VERB_DESC(/client, change_character_slot, "Change Character Slot", "Changes the active character slot. This is no different than clicking the preferred character slot in the Character Setup menu.", "OOC")
+	var/list/characters = prefs.create_character_profiles()
+	var/list/options = list()
+	var/current_slot
+
+	for(var/i = 1 to length(characters))
+		var/name = characters[i]
+		if (isnull(name))
+			continue
+
+		if(prefs.default_slot == i)
+			current_slot = name
+
+		options[name] = i
+
+	if(!length(options))
+		to_chat(src, span_warning("You have no characters."))
+		return
+
+	var/choice = tgui_input_list(src, "Select a character slot", "Change Character Slot", options, current_slot)
+
+	if(!choice)
+		return
+
+	var/slot = options[choice]
+	prefs.save_character()
+	prefs.switch_to_slot(slot)
+	to_chat(src, span_notice("Selected character '[choice]'"))
+
+/datum/latejoin_menu/ui_data(mob/user)
+	. = ..()
+	.["selected_character"] = user.client?.prefs?.read_preference(/datum/preference/name/real_name)
+
+/datum/latejoin_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return TRUE
+	switch(action)
+		if("change_slot")
+			ui.user.client.change_character_slot()
+			return TRUE
+
+/mob/dead/get_status_tab_items()
+	. = ..()
+	if(client?.prefs)
+		. += "Selected Character: [client.prefs.read_preference(/datum/preference/name/real_name)]"
+		. += ""

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8154,6 +8154,7 @@
 #include "modular_vcg\modules\jobs\code\garou\truthcatcher.dm"
 #include "modular_vcg\modules\jobs\code\garou\warder.dm"
 #include "modular_vcg\modules\jobs\code\garou\wyrmfoe.dm"
+#include "modular_vcg\modules\lobby_join_stuff\code\change_character_slot.dm"
 #include "modular_vcg\modules\ooc_pronouns\code\ooc.dm"
 #include "modular_vcg\modules\plexora\code\_plexora.dm"
 #include "modular_vcg\modules\plexora\code\config.dm"

--- a/tgui/packages/tgui/interfaces/JobSelection.tsx
+++ b/tgui/packages/tgui/interfaces/JobSelection.tsx
@@ -38,6 +38,7 @@ type Data = {
   disable_jobs_for_non_observers: BooleanLike;
   priority: BooleanLike;
   round_duration: string;
+  selected_character?: string; // CRIMSON EDIT ADDITION - CHANGE_CHARACTER_SLOT
 };
 
 type JobEntryProps = {
@@ -189,12 +190,21 @@ export function JobSelection(props) {
       <Window.Content>
         <Section
           buttons={
-            <Button
-              onClick={() => act('select_job', { job: 'Random' })}
-              tooltip="Roll target random job. You can re-roll or cancel your random job if you don't like it."
-            >
-              Random Job!
-            </Button>
+            // CRIMSON EDIT ADDITION - CHANGE_CHARACTER_SLOT - added "change_slot". ORIGINAL: select_job button without the parent fragment
+            <>
+              <Button
+                onClick={() => act('change_slot')}
+                tooltip="Quickly change your current character without opening the Character Setup menu."
+              >
+                Change Character
+              </Button>
+              <Button
+                onClick={() => act('select_job', { job: 'Random' })}
+                tooltip="Roll target random job. You can re-roll or cancel your random job if you don't like it."
+              >
+                Random Job!
+              </Button>
+            </>
           }
           fill
           scrollable
@@ -202,7 +212,14 @@ export function JobSelection(props) {
             <>
               {shuttle_status && <NoticeBox info>{shuttle_status}</NoticeBox>}
               <Box as="span" color="label">
-                It is currently {round_duration} into the night. {/* DARKPACK EDIT CHANGE - ORIGINAL: It is currently {round_duration} into the shift. */}
+                {!!data.selected_character && (
+                  <span style={{ color: 'grey' }}>
+                    Joining as '{data.selected_character}' —{' '}
+                  </span>
+                )}
+                It is currently {round_duration} into the night.
+                {/* DARKPACK EDIT CHANGE - ORIGINAL: It is currently {round_duration} into the shift. */}
+                {/* CRIMSON EDIT CHANGE - CHANGE_CHARACTER_SLOT - Added "Joining as", I am not going to form an ORIGINAL, please git blame */}
               </Box>
             </>
           }


### PR DESCRIPTION

## About The Pull Request
- Modularized Port of https://github.com/Monkestation/Monkestation2.0/pull/10689

>This PR adds a handful of QoLs to the lobby.
> - Pre-round shop, Latejoin menu, and the stat panel now shows the character you're readying up as
> - You can change your current character slot via the verb "Change Character Slot", and through the Pre-round shop and latejoin menu

<img width="1036" height="696" alt="image" src="https://github.com/user-attachments/assets/587f5e09-185f-4ed2-ae19-50c185939a74" />

the $ is gone dont worry

<img width="414" height="94" alt="image" src="https://github.com/user-attachments/assets/5d0dda8e-5ae1-40e4-b882-46dfeb4f9c52" />

## Why It's Good For The Game
>Reaaally tired of opening character setup to check what character I'm readying up as.
## Changelog
:cl:
qol: You can now change your character from the latejoin menus, as well as the "Change Character Slot" verb.
/:cl:
