### PR TITLE
Ook's Chicken Nuggets

### DIFF
--- a/modular_darkpack/modules/merits_flaws/code/negative_quirks/legless.dm
+++ b/modular_darkpack/modules/merits_flaws/code/negative_quirks/legless.dm
@@ -1,0 +1,43 @@
+// VTM pg. 482 (Lame, taken to its extreme)
+/datum/quirk/darkpack/legless
+	name = "Legless"
+	desc = "Both of your legs are gone. You get around in a wheelchair, and nothing is ever going to change that."
+	icon = FA_ICON_WHEELCHAIR
+	value = -10
+	gain_text = span_warning("You can't feel your legs!")
+	lose_text = span_notice("Huh? Your legs are back...")
+	failure_message = span_notice("You can feel your legs again.")
+	quirk_flags = QUIRK_CHANGES_APPEARANCE
+
+/datum/quirk/darkpack/legless/add(client/client_source)
+	. = ..()
+	var/mob/living/carbon/human/human_holder = astype(quirk_holder)
+	if(!human_holder)
+		return
+	human_holder.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/darkpack/legless/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_holder = astype(quirk_holder)
+	if(!human_holder)
+		return
+
+	qdel(human_holder.get_item_by_slot(ITEM_SLOT_FEET))
+	qdel(human_holder.get_bodypart(BODY_ZONE_L_LEG))
+	qdel(human_holder.get_bodypart(BODY_ZONE_R_LEG))
+
+	if(human_holder.buckled)
+		human_holder.buckled.unbuckle_mob(human_holder)
+
+	var/turf/holder_turf = get_turf(human_holder)
+	var/obj/vehicle/ridden/wheelchair/wheels = new(holder_turf)
+	wheels.buckle_mob(human_holder)
+
+	// The paralysis can make them drop what they spawned holding
+	for(var/obj/item/dropped_item in holder_turf)
+		if(dropped_item.fingerprintslast == human_holder.ckey)
+			human_holder.put_in_hands(dropped_item)
+
+/datum/quirk/darkpack/legless/remove()
+	. = ..()
+	var/mob/living/carbon/human/human_holder = astype(quirk_holder)
+	human_holder?.cure_trauma_type(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7595,6 +7595,7 @@
 #include "modular_darkpack\modules\merits_flaws\code\negative_quirks\hemophiliac.dm"
 #include "modular_darkpack\modules\merits_flaws\code\negative_quirks\horrific_appearance_quirk.dm"
 #include "modular_darkpack\modules\merits_flaws\code\negative_quirks\lame.dm"
+#include "modular_darkpack\modules\merits_flaws\code\negative_quirks\legless.dm"
 #include "modular_darkpack\modules\merits_flaws\code\negative_quirks\light_sensitive.dm"
 #include "modular_darkpack\modules\merits_flaws\code\negative_quirks\mage_blood.dm"
 #include "modular_darkpack\modules\merits_flaws\code\negative_quirks\monstrous_quirk.dm"


### PR DESCRIPTION
## About The Pull Request

Ook asked for this one. It's a new -10 flaw called Legless.

Built off the existing One Arm flaw. You spawn with both legs deleted (shoes get cleaned up too, otherwise they'd just be floating there), you get the paraplegic brain trauma at absolute resilience so nothing will ever fix it, and you start the round already buckled into a wheelchair.

The wheelchair isn't a bonus, it's the only reason the character can move at all. Same deal as the existing paraplegic quirk.

No left/right option since there's nothing to choose, and no splat restrictions. Anyone who can take One Arm can take this.

## Why It's Good For The Game

We've got One Arm at -3 and Lame at -3 already, but nothing at the heavy end for people who want a genuinely broken character. -10 is a lot of freebie points and this earns them. You can't walk, you can't stand, you're in a chair permanently, and stairs and chases and fights all become someone else's problem to sort out for you.

## Changelog

:cl:
add: Added the Legless flaw (-10). You spawn with no legs, permanently paralyzed from the waist down, and start the round in a wheelchair.
/:cl: