### PR TITLE
Samedi Get Necromancy Now

### DIFF
--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/samedi.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/samedi.dm
@@ -7,7 +7,8 @@
 	clan_disciplines = list(
 		/datum/discipline/obfuscate,
 		/datum/discipline/fortitude,
-		/datum/discipline/thanatosis
+		/datum/discipline/thanatosis,
+		/datum/discipline/necromancy
 	)
 	alt_sprite = "rotten4"
 	clan_traits = list(

--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/samedi.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/samedi.dm
@@ -8,7 +8,7 @@
 		/datum/discipline/obfuscate,
 		/datum/discipline/fortitude,
 		/datum/discipline/thanatosis,
-		/datum/discipline/necromancy
+		/datum/discipline/necromancy // CRIMSON EDIT ADD - Samedi Get Necromancy Now
 	)
 	alt_sprite = "rotten4"
 	clan_traits = list(


### PR DESCRIPTION

## About The Pull Request
Adds the necromancy discipline to Samedi. Just flat out adds it it doesn't replace any disciplines. 

## Why It's Good For The Game
They're commonly associated with necromancers in-lore and are theorized to have some kind of connection to the Giovanni. It's kind of weird that they don't get Necromancy. Maybe replacing one of their disciplines with Necromancy's the better move, but another multiplayer Dark Pack project I saw just straight up gave Samedi necromancy on top of everything just because of the vibes. 

Consider it an extra incentive to allocate all your dots towards necromancy or physical disciplines once they shrink all the discipline dot allotments some. 

## Changelog
:cl:
add: Samedi get necromancy as a clan discipline.
/:cl:
