### PR TITLE
Nosferatu Can Once Again See In The Dark

### DIFF
--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/nosferatu.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/nosferatu.dm
@@ -15,7 +15,7 @@
 	clan_traits = list(
 		TRAIT_MASQUERADE_VIOLATING_FACE,
 		TRAIT_VENTCRAWLER_ALWAYS,
-		TRAIT_TRUE_NIGHT_VISION
+		TRAIT_TRUE_NIGHT_VISION //CRIMSON GRID ADDITION - NOSFERATU GET NIGHT VISION
 
 	)
 	male_clothes = /obj/item/clothing/under/vampire/nosferatu
@@ -24,3 +24,12 @@
 	default_accessory = /datum/bodypart_overlay/simple/clan_mark/nosferatu_ears
 	subsplat_keys = /obj/item/vamp/keys/nosferatu
 
+//CRIMSON GRID ADDITION - NOSFERATU GET NIGHT VISION
+/datum/subsplat/vampire_clan/nosferatu/on_gain(mob/living/carbon/human/gaining_mob, datum/splat/gaining_splat, joining_round)
+	. =  ..()
+	gaining_mob.update_sight()
+
+/datum/subsplat/vampire_clan/nosferatu/on_lose(mob/living/carbon/human/losing_mob)
+	. = ..()
+	if(!QDELETED(losing_mob))
+		losing_mob.update_sight()

--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/nosferatu.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/nosferatu.dm
@@ -14,7 +14,9 @@
 	)
 	clan_traits = list(
 		TRAIT_MASQUERADE_VIOLATING_FACE,
-		TRAIT_VENTCRAWLER_ALWAYS
+		TRAIT_VENTCRAWLER_ALWAYS,
+		TRAIT_TRUE_NIGHT_VISION
+
 	)
 	male_clothes = /obj/item/clothing/under/vampire/nosferatu
 	female_clothes = /obj/item/clothing/under/vampire/nosferatu/female


### PR DESCRIPTION

## About The Pull Request
Nosferatu get their special night vision eyes back. 

## Why It's Good For The Game
Nosferatu spawn in the sewers, which are very dark and are a clan that are known for skulking around dark recesses and storm drains. Without this they're just as blind as everyone else in the sewers, which are meant to be their domain. Even a gangrel's better at scampering around the dark! This fixes that. 


## Changelog
:cl:
add: Nosferatu can see in the dark.
/:cl:
