### PR TITLE
No More Super Meth Bombs.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -288,7 +288,7 @@
 	for(var/turf/target in RANGE_TURFS(1,T))
 		new /obj/effect/hotspot(target)
 	holder.chem_temp = 1000 // hot as shit
-	..()
+	// ..() Sure you can heat it, it won't explode now though.
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/methboom2
 	required_reagents = list(/datum/reagent/diethylamine = 1, /datum/reagent/iodine = 1, /datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1) //diethylamine is often left over from mixing the ephedrine.

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -288,7 +288,7 @@
 	for(var/turf/target in RANGE_TURFS(1,T))
 		new /obj/effect/hotspot(target)
 	holder.chem_temp = 1000 // hot as shit
-	// ..() Sure you can heat it, it won't explode now though.
+	// ..() Sure you can heat it, it won't explode now though. // CRIMSON EDIT CHANGE - No More Super Meth Bombs
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/methboom2
 	required_reagents = list(/datum/reagent/diethylamine = 1, /datum/reagent/iodine = 1, /datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1) //diethylamine is often left over from mixing the ephedrine.


### PR DESCRIPTION

## About The Pull Request
No more super meth bomb explosions that create space tiles. This does not fix the space tile issue for other bombs.

This comes on the heels of a very brutal round of greifing.

Testing Evidence: Still creates a fire/hotspot.

https://discord.com/channels/1495925316273832099/1495931575240495104/1533087239876120700

## Why It's Good For The Game
No more super meth bomb explosions.
## Changelog
:cl:
fix: fixed meth bombs to not explode and simply overheat and flame up.
/:cl:
