### PR TITLE
Suit Storage changes

### DIFF
--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -73771,12 +73771,12 @@
 /area/vtm/interior/baali)
 "vvJ" = (
 /obj/structure/closet,
-/obj/item/clothing/suit/vampire/pentex_labcoat,
-/obj/item/clothing/suit/vampire/pentex_labcoat,
-/obj/item/clothing/suit/vampire/pentex_labcoat,
-/obj/item/clothing/suit/vampire/pentex_labcoat_alt,
-/obj/item/clothing/suit/vampire/pentex_labcoat_alt,
-/obj/item/clothing/suit/vampire/pentex_labcoat_alt,
+/obj/item/clothing/suit/vampire/labcoat/pentex,
+/obj/item/clothing/suit/vampire/labcoat/pentex,
+/obj/item/clothing/suit/vampire/labcoat/pentex,
+/obj/item/clothing/suit/vampire/labcoat/pentex/alt,
+/obj/item/clothing/suit/vampire/labcoat/pentex/alt,
+/obj/item/clothing/suit/vampire/labcoat/pentex/alt,
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/circled,
 /area/vtm/interior/wyrm_corrupted)

--- a/html/changelogs/AutoChangeLog-pr-1100.yml
+++ b/html/changelogs/AutoChangeLog-pr-1100.yml
@@ -1,5 +1,0 @@
-author: "FalloutFalcon"
-delete-after: True
-changes:
-  - code_imp: "new var on datum level for storing info on what source book it comes from"
-  - config: "Adds config for limiting merit based on official status"

--- a/html/changelogs/AutoChangeLog-pr-1286.yml
+++ b/html/changelogs/AutoChangeLog-pr-1286.yml
@@ -1,4 +1,0 @@
-author: "Faengi"
-delete-after: True
-changes:
-  - rscadd: "Added the Uncontrollable flaw for Brujah"

--- a/html/changelogs/archive/2026-08.yml
+++ b/html/changelogs/archive/2026-08.yml
@@ -1,0 +1,7 @@
+2026-08-01:
+  Faengi:
+  - rscadd: Added the Uncontrollable flaw for Brujah
+  FalloutFalcon:
+  - code_imp: new var on datum level for storing info on what source book it comes
+      from
+  - config: Adds config for limiting merit based on official status

--- a/modular_darkpack/modules/clothes/code/suit.dm
+++ b/modular_darkpack/modules/clothes/code/suit.dm
@@ -296,9 +296,17 @@
 
 /obj/item/clothing/suit/vampire/jacket/fbi
 	name = "Federal Bureau of Investigation jacket"
-	desc = "\"FBI OPEN UP!!\""
+	desc = "A polyester jacket with 'FBI' emblazoned in yellow on the back. It's lightly armoured on the inner side, providing meager protection against small calibers and knives."
 	icon_state = "fbi"
 	armor_type = /datum/armor/vampire_jacket
+	allowed = list(
+		/obj/item/card/id,
+		/obj/item/flashlight,
+		/obj/item/melee/baton,
+		/obj/item/gun/energy/taser/darkpack,
+		/obj/item/melee/baton/security/handtaser,
+		/obj/item/restraints/handcuffs
+	) //Same as bulletproof vest's.
 
 /obj/item/clothing/suit/vampire/jacket/punk
 	icon_state = "punk"
@@ -400,6 +408,8 @@
 		/obj/item/card/id,
 		/obj/item/flashlight,
 		/obj/item/melee/baton,
+		/obj/item/gun/energy/taser/darkpack,
+		/obj/item/melee/baton/security/handtaser,
 		/obj/item/restraints/handcuffs
 	)
 
@@ -433,18 +443,18 @@
 /obj/item/clothing/suit/vampire/vest/police
 	name = "police duty vest"
 	icon_state = "pdvest"
-	desc = "Lightweight, bulletproof vest with SFPD markings, tailored for active duty."
+	desc = "Lightweight, bulletproof vest with police markings, tailored for active duty."
 
 /obj/item/clothing/suit/vampire/vest/police/sergeant
 	name = "police sergeant vest"
 	icon_state = "sgtvest"
-	desc = "Lightweight, bulletproof vest with SFPD markings, tailored for active duty. This one has sergeant insignia on it."
+	desc = "Lightweight, bulletproof vest with police markings, tailored for active duty. This one has sergeant insignia on it."
 
 // They got an Army vest post-PD update. I am just giving them the same, instead coded into their equipment instead of mapped.
 /obj/item/clothing/suit/vampire/vest/police/captain
 	name = "police captain duty vest"
 	icon_state = "capvest"
-	desc = "Composite bulletproof vest with SFPD markings, tailored for improved protection. This one has captain insignia on it."
+	desc = "Composite bulletproof vest with police markings, tailored for improved protection. This one has captain insignia on it."
 	armor_type = /datum/armor/highly_protective_vest
 
 /datum/armor/highly_protective_vest
@@ -478,6 +488,14 @@
 	w_class = WEIGHT_CLASS_BULKY
 	armor_type = /datum/armor/eod_suit
 	masquerade_violating = TRUE
+	allowed = list(
+		/obj/item/card/id,
+		/obj/item/flashlight,
+		/obj/item/melee/baton,
+		/obj/item/gun/energy/taser/darkpack,
+		/obj/item/melee/baton/security/handtaser,
+		/obj/item/restraints/handcuffs
+	) //Same as bulletproof vest's.
 
 /datum/armor/eod_suit
 	melee = 90
@@ -507,7 +525,21 @@
 	desc = "For medicine and research purposes."
 	icon_state = "labcoat"
 	armor_type = /datum/armor/labcoat
-
+	allowed = list(
+		/obj/item/card/id,
+		/obj/item/defibrillator/compact,
+		/obj/item/flashlight/pen,
+		/obj/item/healthanalyzer,
+		/obj/item/reagent_containers/applicator,
+		/obj/item/reagent_containers/cup/beaker,
+		/obj/item/reagent_containers/cup/bottle,
+		/obj/item/reagent_containers/cup/tube,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/stack/medical,
+		/obj/item/storage/pill_bottle
+	)
 /datum/armor/labcoat
 	acid = 90
 	wound = 10
@@ -564,13 +596,13 @@
 	icon_state = "DutchJacket"
 
 //Pentex Overwear
-/obj/item/clothing/suit/vampire/pentex_labcoat
+/obj/item/clothing/suit/vampire/labcoat/pentex
 	name = "\improper " + MAIN_EVIL_COMPANY + " labcoat"
 	desc = "A crisp white labcoat. This one has the " + MAIN_EVIL_COMPANY + " International logo stiched onto the breast!"
 	icon_state = "pentex_closedlabcoat"
 	armor_type = /datum/armor/labcoat
 
-/obj/item/clothing/suit/vampire/pentex_labcoat_alt
+/obj/item/clothing/suit/vampire/labcoat/pentex/alt
 	name = "\improper " + MAIN_EVIL_COMPANY + " labcoat"
 	desc = "A crisp white labcoat. This one has a green trim and the " + MAIN_EVIL_COMPANY + " International logo stiched onto the breast!"
 	icon_state = "pentex_labcoat_alt"

--- a/modular_darkpack/modules/clothes/code/suit.dm
+++ b/modular_darkpack/modules/clothes/code/suit.dm
@@ -439,6 +439,14 @@
 	name = "police raincoat"
 	icon_state = "policecoat"
 	desc = "A sturdy and reflective raincoat tailored for wet weather patrols."
+	allowed = list(
+		/obj/item/card/id,
+		/obj/item/flashlight,
+		/obj/item/melee/baton,
+		/obj/item/gun/energy/taser/darkpack,
+		/obj/item/melee/baton/security/handtaser,
+		/obj/item/restraints/handcuffs
+	)
 
 /obj/item/clothing/suit/vampire/vest/police
 	name = "police duty vest"

--- a/modular_darkpack/modules/jobs/code/pentex/branch_lead.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/branch_lead.dm
@@ -51,7 +51,7 @@
 	id = /obj/item/card/pentex/branch_lead
 	uniform =  /obj/item/clothing/under/vampire/pentex_executive_suit
 	shoes = /obj/item/clothing/shoes/vampire/businessblack
-	suit = /obj/item/clothing/suit/vampire/pentex_labcoat_alt
+	suit = /obj/item/clothing/suit/vampire/labcoat/pentex/alt
 	l_pocket = /obj/item/smartphone // /branch_lead - TODO: phone subtype
 	r_pocket = /obj/item/vamp/keys/pentex
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/pistol/darkpack/deagle=1, /obj/item/phone_book=1, /obj/item/card/credit/prince=1)

--- a/tools/UpdatePaths/Scripts/DarkPack/425_pentex_endron_clothes.txt
+++ b/tools/UpdatePaths/Scripts/DarkPack/425_pentex_endron_clothes.txt
@@ -9,8 +9,8 @@
 /obj/item/clothing/under/pentex/pentex_suit : /obj/item/clothing/under/vampire/pentex_suit
 /obj/item/clothing/under/pentex/pentex_suit : /obj/item/clothing/under/vampire/pentex_suitskirt
 /obj/item/clothing/under/suit/white_on_white : /obj/item/clothing/under/suit/white
-/obj/item/clothing/suit/pentex/pentex_labcoat : /obj/item/clothing/suit/vampire/pentex_labcoat
-/obj/item/clothing/suit/pentex/pentex_labcoat_alt : /obj/item/clothing/suit/vampire/pentex_labcoat_alt
+/obj/item/clothing/suit/pentex/pentex_labcoat : /obj/item/clothing/suit/vampire/labcoat/pentex
+/obj/item/clothing/suit/pentex/pentex_labcoat_alt : /obj/item/clothing/suit/vampire/labcoat/pentex/alt
 /obj/item/reagent_containers/food/drinks/silver_goblet : /obj/item/reagent_containers/cup/silver_goblet
 /obj/item/reagent_containers/food/drinks/silver_goblet/vaulderie_goblet : /obj/item/reagent_containers/cup/silver_goblet/vaulderie_goblet
 /obj/structure/vampdoor/oldwood : /obj/structure/vampdoor/old


### PR DESCRIPTION

## About The Pull Request
- Labcoats' suit storage slot can store a variety of medicine-related items.
- Bulletproof vests' suit storage slot can store a police taser and a hand taser in addition to the usual items.
- FBI jacket, police raincoat and EOD armour have same suit storage slot permissions that bulletproof vests do.
- Pentex labcoats are properly subclassed under the standard labcoat instead of being classes separate from the standard labcoat and even each other (why???). This means they also can store the same items that the standard labcoat can.
- FBI jacket has a new description instead of placeholder meme text.
## Why It's Good For The Game
Suit storage is extremely underused. This makes it more useful.
Pentex labcoats being classes separate from the standard labcoat and each other is bad technical design.
Also you don't have to swap your FBI jacket for FBI vest just to carry a baton in the suit storage slot.
## Changelog
:cl:
add: Labcoats' suit storage slot can store a variety of medicine-related items.
add: Bulletproof vests' suit storage slot can store a police taser and a hand taser in addition to the usual items.
add: FBI jacket, police raincoat and EOD armour have same suit storage slot permissions that bulletproof vests do.
fix: Pentex labcoats are properly subclassed under the standard labcoat instead of being classes separate from the standard 
/:cl:
