### PR TITLE
Further reduces recoil

### DIFF
--- a/modular_vcg/modules/weapons/code/guns.dm
+++ b/modular_vcg/modules/weapons/code/guns.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/ballistic/automatic/darkpack
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/automatic/pistol/darkpack
 	recoil = 2
@@ -13,68 +13,68 @@
 
 // Pistols
 /obj/item/gun/ballistic/automatic/pistol/darkpack/deagle
-	recoil = 3
+	recoil = 2
 
 /obj/item/gun/ballistic/automatic/pistol/darkpack/deagle/c50
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/automatic/pistol/darkpack/glock21
-	recoil = 3
+	recoil = 2
 
 // SMGs
 /obj/item/gun/ballistic/automatic/darkpack/uzi
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/automatic/darkpack/mp5
 	recoil = 2
 
 /obj/item/gun/ballistic/automatic/darkpack/mac10
-	recoil = 5
+	recoil = 4
 
 /obj/item/gun/ballistic/automatic/darkpack/mac10/super
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/automatic/darkpack/mp7
 	recoil = 1
 
 // Rifles
 /obj/item/gun/ballistic/automatic/darkpack/ar15
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/automatic/darkpack/huntrifle
-	recoil = 2
+	recoil = 1
 
 /obj/item/gun/ballistic/automatic/darkpack/ak74
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/automatic/darkpack/ak74/sawn
-	recoil = 6
+	recoil = 4
 
 /obj/item/gun/ballistic/automatic/darkpack/aug
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/automatic/darkpack/thompson
-	recoil = 4
+	recoil = 3
 
 /obj/item/gun/ballistic/rifle/darkpack/lever
-	recoil = 2
+	recoil = 1
 
 // Sniper
 /obj/item/gun/ballistic/automatic/darkpack/sniper
-	recoil = 8
+	recoil = 6
 
 /obj/item/gun/ballistic/automatic/darkpack/autosniper
-	recoil = 5
+	recoil = 4
 
 // Shotguns
 /obj/item/gun/ballistic/shotgun/vampire
-	recoil = 5
-
-/obj/item/gun/ballistic/shotgun/vampire/sawnoff
-	recoil = 8
-
-/obj/item/gun/ballistic/shotgun/vampire/doublebarrel
 	recoil = 4
 
+/obj/item/gun/ballistic/shotgun/vampire/sawnoff
+	recoil = 6
+
+/obj/item/gun/ballistic/shotgun/vampire/doublebarrel
+	recoil = 3
+
 /obj/item/gun/ballistic/automatic/darkpack/autoshotgun
-	recoil = 5
+	recoil = 4


### PR DESCRIPTION
## About The Pull Request

was asked to further reduce recoil 

followed a simple procedure - if recoil was 5 or greater, reduce by 2
if recoil was 3 or greater, reduce by 1
if recoil was 2 or lower, don't reduce

## Why It's Good For The Game

was asked to do this

## Changelog

:cl:

balance: further reduces recoil

/:cl:
