### PR TITLE
Remove CQC from PD captain

### DIFF
--- a/modular_darkpack/modules/jobs/code/police/captain.dm
+++ b/modular_darkpack/modules/jobs/code/police/captain.dm
@@ -37,9 +37,3 @@
 		/obj/item/melee/baton/vamp = 1,
 		/obj/item/storage/medkit/darkpack/ifak = 1
 	)
-
-/datum/outfit/job/vampire/police_captain/post_equip(mob/living/carbon/human/H)
-	. = ..()
-	var/datum/martial_art/martial_art = new /datum/martial_art/cqc
-	H.ignores_warrant = TRUE
-	martial_art.teach(H)


### PR DESCRIPTION

CQC removal from PD captain. 
## About The Pull Request
## Why It's Good For The Game
No idea why they get it in the first place, its commonly used by PD captains to frag out instead of being a actual captain. Verin also wanted it removed a while ago. 
## Changelog
:cl:
remove: CQC from pd captain 
/:cl:
