### PR TITLE
Ends Tire Iron's Reign of Terror

### DIFF
--- a/modular_vcg/modules/weapons/code/melee.dm
+++ b/modular_vcg/modules/weapons/code/melee.dm
@@ -4,6 +4,9 @@
 /obj/item/claymore/machete
 	force = 1.5 LETHAL_TTRPG_DAMAGE
 
+/obj/item/melee/vamp/tire
+	force = 1 LETHAL_TTRPG_DAMAGE
+
 /obj/item/fireaxe/vamp
 	force_wielded = 2 LETHAL_TTRPG_DAMAGE
 


### PR DESCRIPTION

## About The Pull Request
Halves the tire iron's damage from 2 lethal damage to 1 lethal damage (40->20)
## Why It's Good For The Game
Contray to popular belief, the tire iron is supposed to be used to fix cars, not be a 50$ 40 force super murder tool and atm cracker that deals somehow more damage than a bat which costs 400$.
## Changelog
:cl:
balance: The tire iron's damage has been halved from 40 to 20
/:cl:
