### PR TITLE
Vampire dots adjustment fine tuning

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline_pref_middleware.dm
+++ b/modular_darkpack/modules/powers/code/discipline_pref_middleware.dm
@@ -156,20 +156,20 @@ GLOBAL_LIST_INIT(rare_discipline_types, list(
 /datum/preference_middleware/disciplines/proc/get_discipline_point_budget(immortal_age)
 	if(immortal_age <= 10)
 		return list(
-			"points" = 5,
+			"points" = 6,
 			"tier" = "Fledgling",
 			"details" ="As a Fledgling, you are still learning how to control your new powers, and face your new problems. You are much the same person as you were prior to the embrace, for good or for bad. The phrase \"Life's sucks and then you die\" leaves out how much it sucks to be dead, but you're starting to learn that first-hand. You might be recently declared dead or reported missing, and are struggling to piece together a new unlife without the support network you had when you were alive. There are a lot of rules and customs you're unfamiliar with, and older kindred look down on you. You may be alone, hiding out after a string of murders post-embrace that put you on the radar of law enforcement and the Camarilla, or under the watchful eye of your Sire learning to control yourself under their wing. Either way, you're going to need help to navigate all of this.")
 	if(immortal_age <= 100)
 		return list(
-			"points" = 7,
+			"points" = 8,
 			"tier" = "Neonate",
 			"details" = "As a Neonate, you're starting to get the hang of things with your unlife. You have learned to control your urges enough to be mostly left to your own devices, but older kindred can still smell your inexperience from a mile away. Friends and family you once knew are beginning to grow old and pass away due to natural causes, leaving you with the lasting emotional scars from their absence. Any who you remain in contact with but haven't told about your embrace are likely suspicious about your lack of aging and absence during the day. As a result, you've learned to remain mostly composed, and to keep things close to the vest, especially when it comes to interacting with Kine. With your Kine touchstones dwindling or gone, you'll begin to find solace in others... Or else your humanity might start to fade with them.")
 	if(immortal_age <= 200)
 		return list(
-			"points" = 9,
+			"points" = 10,
 			"tier" = "Ancilla",
 			"details" = "As an Ancilla, you are a dignified member of kindred society. Ancient by Anarch standards, middle-aged by Camarillan. The ties you once held to your originally life have faded with the deaths of your loved ones over a century prior. You have come to find a new family along the way; either by siring childer of your own or making and keeping friendships that have lasted you through the ages. You are a composed, mature vampire that others often turn to when decisions need additional input, or important things need doing.")
-	return list("points" = 14,
+	return list("points" = 15,
 			"tier" = "Elder",
 			"details" = "As an Elder of your clan, you are a walking history book. You have learned to keep quiet about your true age and origins, and have likely made a coterie of enemies, some alive some dead. Walking through time as the winding centipede, crawling into centuries unfamiliar as you learn and adapt to each new shifting culture. You may have emerged from torpor after a battle you may or may not remember years prior, thrust into a world you don't recognize. You likely possess a reputation for good or for bad, for something you may or may not have done hundreds of years ago. Some may take solace in your company as a familiar face, some may want to turn you to ash for a petty grievance from lifetimes prior. If your true age is discovered, the Camarilla will likely try to employ you as an enforcer due to your strength... or an aspiring lick might come along to diablerize you and take your power for themselves. To have survived this long, you're cautious, old, and cunning. Your routines are important, and you stay out of the petty squables of younger Kindred if you can help it.")
 

--- a/modular_darkpack/modules/powers/code/discipline_pref_middleware.dm
+++ b/modular_darkpack/modules/powers/code/discipline_pref_middleware.dm
@@ -156,20 +156,20 @@ GLOBAL_LIST_INIT(rare_discipline_types, list(
 /datum/preference_middleware/disciplines/proc/get_discipline_point_budget(immortal_age)
 	if(immortal_age <= 10)
 		return list(
-			"points" = 6,
+			"points" = 6, // CRIMSON EDIT CHANGE - Original : "points" = 5,
 			"tier" = "Fledgling",
 			"details" ="As a Fledgling, you are still learning how to control your new powers, and face your new problems. You are much the same person as you were prior to the embrace, for good or for bad. The phrase \"Life's sucks and then you die\" leaves out how much it sucks to be dead, but you're starting to learn that first-hand. You might be recently declared dead or reported missing, and are struggling to piece together a new unlife without the support network you had when you were alive. There are a lot of rules and customs you're unfamiliar with, and older kindred look down on you. You may be alone, hiding out after a string of murders post-embrace that put you on the radar of law enforcement and the Camarilla, or under the watchful eye of your Sire learning to control yourself under their wing. Either way, you're going to need help to navigate all of this.")
 	if(immortal_age <= 100)
 		return list(
-			"points" = 8,
+			"points" = 8, // CRIMSON EDIT CHANGE - Original : "points" = 7,
 			"tier" = "Neonate",
 			"details" = "As a Neonate, you're starting to get the hang of things with your unlife. You have learned to control your urges enough to be mostly left to your own devices, but older kindred can still smell your inexperience from a mile away. Friends and family you once knew are beginning to grow old and pass away due to natural causes, leaving you with the lasting emotional scars from their absence. Any who you remain in contact with but haven't told about your embrace are likely suspicious about your lack of aging and absence during the day. As a result, you've learned to remain mostly composed, and to keep things close to the vest, especially when it comes to interacting with Kine. With your Kine touchstones dwindling or gone, you'll begin to find solace in others... Or else your humanity might start to fade with them.")
 	if(immortal_age <= 200)
 		return list(
-			"points" = 10,
+			"points" = 10, // CRIMSON EDIT CHANGE - Original : "points" = 9,
 			"tier" = "Ancilla",
 			"details" = "As an Ancilla, you are a dignified member of kindred society. Ancient by Anarch standards, middle-aged by Camarillan. The ties you once held to your originally life have faded with the deaths of your loved ones over a century prior. You have come to find a new family along the way; either by siring childer of your own or making and keeping friendships that have lasted you through the ages. You are a composed, mature vampire that others often turn to when decisions need additional input, or important things need doing.")
-	return list("points" = 15,
+	return list("points" = 15, // CRIMSON EDIT CHANGE - Original : "points" = 14,
 			"tier" = "Elder",
 			"details" = "As an Elder of your clan, you are a walking history book. You have learned to keep quiet about your true age and origins, and have likely made a coterie of enemies, some alive some dead. Walking through time as the winding centipede, crawling into centuries unfamiliar as you learn and adapt to each new shifting culture. You may have emerged from torpor after a battle you may or may not remember years prior, thrust into a world you don't recognize. You likely possess a reputation for good or for bad, for something you may or may not have done hundreds of years ago. Some may take solace in your company as a familiar face, some may want to turn you to ash for a petty grievance from lifetimes prior. If your true age is discovered, the Camarilla will likely try to employ you as an enforcer due to your strength... or an aspiring lick might come along to diablerize you and take your power for themselves. To have survived this long, you're cautious, old, and cunning. Your routines are important, and you stay out of the petty squables of younger Kindred if you can help it.")
 


### PR DESCRIPTION

## Tuning to previous "Vampire mald nerf"
 Adds 1 more dot to previously nerfed vampire dots.
## About The Pull Request
Adjusts the discipline points by adding 1 more to each age group.
## Why It's Good For The Game
 Adjusts the discipline points one more time afteer
The previous **big** nerf was made because "Vampires were extremely overtuned and powercrept" (apparently). After the infamous garou buffs and other changes made to the game like removing passives from some skills, I do believe 1 dot buff would not be "OVERPOWERED" or "BROKEN", matter of fact needed. 
## Changelog
:cl:
add: 1 more dot to each age groups budget
/:cl:
