### PR TITLE
Beheading (Only for dead bodies)

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -84,7 +84,7 @@
 	var/datum/worn_feature_offset/worn_face_offset
 
 	/// Can this head be dismembered normally?
-	VAR_PROTECTED/can_dismember = FALSE
+	VAR_PROTECTED/can_dismember = TRUE // CRIMSON EDIT CHANGE - Original : VAR_PROTECTED/can_dismember = FALSE
 
 /obj/item/bodypart/head/Initialize(mapload)
 	. = ..()
@@ -159,7 +159,7 @@
 	if (!can_dismember)
 		return FALSE
 
-	if(!HAS_TRAIT(owner, TRAIT_CURSED) && owner.stat < HARD_CRIT)
+	if(!HAS_TRAIT(owner, TRAIT_CURSED) && owner.stat != DEAD) // CRIMSON EDIT CHANGE - Original : if(!HAS_TRAIT(owner, TRAIT_CURSED) && owner.stat < HARD_CRIT)
 		return FALSE
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request
adds beheading back
## Why It's Good For The Game
I think it really fits the setting/environment and you can ONLY behead dead bodies, which if someone is dead they are already at your mercy, so I don't think this changes anything other than adding a fun way to handle dead bodies. This also allows people to use heads on spikes for putting-off decorations etc.
## Changelog
:cl:
add: beheading of dead bodies
/:cl:
