### PR TITLE
Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -177,9 +177,11 @@
 	vitae_cost = 2
 
 	violates_masquerade = TRUE
-	var/saved_brute_mod = 1// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-	var/saved_burn_mod = 1// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-	var/saved_aggravated_mod = 1// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+// CRIMSON EDIT ADD START - Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+	var/saved_brute_mod = 1
+	var/saved_burn_mod = 1
+	var/saved_aggravated_mod = 1
+// CRIMSON EDIT ADD END - Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
 	toggled = TRUE
 	duration_length = 999 SCENES
 

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -206,7 +206,6 @@
 /datum/discipline_power/obtenebration/black_metamorphosis/activate()
 	. = ..()
 	activating = FALSE
-
 	var/roll = SSroll.storyteller_roll_datum(owner, difficulty = 7, applic_stats = list(STAT_MANIPULATION, STAT_COURAGE))
 	switch(roll)
 		if(ROLL_SUCCESS)

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -177,9 +177,9 @@
 	vitae_cost = 2
 
 	violates_masquerade = TRUE
-	var/saved_brute_mod = 1
-	var/saved_burn_mod = 1
-	var/saved_aggravated_mod = 1
+	var/saved_brute_mod = 1// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+	var/saved_burn_mod = 1// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+	var/saved_aggravated_mod = 1// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
 	toggled = TRUE
 	duration_length = 999 SCENES
 
@@ -210,12 +210,12 @@
 	switch(roll)
 		if(ROLL_SUCCESS)
 			successful = TRUE
-			saved_brute_mod = owner.physiology.brute_mod
-			owner.physiology.brute_mod = 0.70//Specifically at 30% dr due to it having no upkeep cost
-			saved_burn_mod = owner.physiology.burn_mod
-			owner.physiology.burn_mod = 2
-			saved_aggravated_mod= owner.physiology.aggravated_mod
-			owner.physiology.aggravated_mod = 0.80
+			saved_brute_mod = owner.physiology.brute_mod  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+			owner.physiology.brute_mod = 0.70// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+			saved_burn_mod = owner.physiology.burn_mod  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+			owner.physiology.burn_mod = 2  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+			saved_aggravated_mod= owner.physiology.aggravated_mod  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+			owner.physiology.aggravated_mod = 0.80  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
 
 			animate(owner, color = "#000000", time = 1 SECONDS, loop = 1)
 			to_chat(owner, span_green("You successfully fuse with the shadows!"))
@@ -234,9 +234,9 @@
 	
 	to_chat(owner, span_notice("The shadows fall away from your body."))
 	playsound(owner.loc, 'sound/effects/magic/voidblink.ogg', 50, FALSE)
-	owner.physiology.brute_mod = saved_brute_mod
-	owner.physiology.burn_mod = saved_burn_mod
-	owner.physiology.aggravated_mod = saved_aggravated_mod
+	owner.physiology.brute_mod = saved_brute_mod // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+	owner.physiology.burn_mod = saved_burn_mod // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+	owner.physiology.aggravated_mod = saved_aggravated_mod // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
 	animate(owner, color = initial(owner.color), time = 1 SECONDS, loop = 1)
 
 /datum/discipline_power/obtenebration/tenebrous_form

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -177,7 +177,9 @@
 	vitae_cost = 2
 
 	violates_masquerade = TRUE
-
+	var/saved_brute_mod = 1
+	var/saved_burn_mod = 1
+	var/saved_aggravated_mod = 1
 	toggled = TRUE
 	duration_length = 999 SCENES
 
@@ -204,14 +206,12 @@
 /datum/discipline_power/obtenebration/black_metamorphosis/activate()
 	. = ..()
 	activating = FALSE
-	var/saved_brute_mod = 1
-	var/saved_burn_mod = 1
-	var/saved_aggravated_mod = 1
+
 	var/roll = SSroll.storyteller_roll_datum(owner, difficulty = 7, applic_stats = list(STAT_MANIPULATION, STAT_COURAGE))
 	switch(roll)
 		if(ROLL_SUCCESS)
 			successful = TRUE
-			saved_brute_mod = owner.physiology.brute_mod//your armor 
+			saved_brute_mod = owner.physiology.brute_mod
 			owner.physiology.brute_mod = 0.70//Specifically at 30% dr due to it having no upkeep cost
 			saved_burn_mod = owner.physiology.burn_mod
 			owner.physiology.burn_mod = 2
@@ -232,9 +232,12 @@
 	. = ..()
 	if(!successful)
 		return
+	
 	to_chat(owner, span_notice("The shadows fall away from your body."))
 	playsound(owner.loc, 'sound/effects/magic/voidblink.ogg', 50, FALSE)
-	owner.physiology.damage_resistance -= 60
+	owner.physiology.brute_mod = saved_brute_mod
+	owner.physiology.burn_mod = saved_burn_mod
+	owner.physiology.aggravated_mod = saved_aggravated_mod
 	animate(owner, color = initial(owner.color), time = 1 SECONDS, loop = 1)
 
 /datum/discipline_power/obtenebration/tenebrous_form

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -235,7 +235,6 @@
 	. = ..()
 	if(!successful)
 		return
-	
 	to_chat(owner, span_notice("The shadows fall away from your body."))
 	playsound(owner.loc, 'sound/effects/magic/voidblink.ogg', 50, FALSE)
 // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -212,12 +212,14 @@
 	switch(roll)
 		if(ROLL_SUCCESS)
 			successful = TRUE
-			saved_brute_mod = owner.physiology.brute_mod  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-			owner.physiology.brute_mod = 0.70// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-			saved_burn_mod = owner.physiology.burn_mod  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-			owner.physiology.burn_mod = 2  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-			saved_aggravated_mod= owner.physiology.aggravated_mod  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-			owner.physiology.aggravated_mod = 0.80  // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+			saved_brute_mod = owner.physiology.brute_mod  
+			owner.physiology.brute_mod = 0.70
+			saved_burn_mod = owner.physiology.burn_mod 
+			owner.physiology.burn_mod = 2  
+			saved_aggravated_mod= owner.physiology.aggravated_mod
+			owner.physiology.aggravated_mod = 0.80
+// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
 
 			animate(owner, color = "#000000", time = 1 SECONDS, loop = 1)
 			to_chat(owner, span_green("You successfully fuse with the shadows!"))
@@ -236,9 +238,11 @@
 	
 	to_chat(owner, span_notice("The shadows fall away from your body."))
 	playsound(owner.loc, 'sound/effects/magic/voidblink.ogg', 50, FALSE)
-	owner.physiology.brute_mod = saved_brute_mod // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-	owner.physiology.burn_mod = saved_burn_mod // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
-	owner.physiology.aggravated_mod = saved_aggravated_mod // CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
+	owner.physiology.brute_mod = saved_brute_mod
+	owner.physiology.burn_mod = saved_burn_mod 
+	owner.physiology.aggravated_mod = saved_aggravated_mod
+// CRIMSON EDIT ADD Reduces Strength of Obtenebration 4 to stop it being stronger than fortitude
 	animate(owner, color = initial(owner.color), time = 1 SECONDS, loop = 1)
 
 /datum/discipline_power/obtenebration/tenebrous_form

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -212,11 +212,11 @@
 		if(ROLL_SUCCESS)
 			successful = TRUE
 			saved_brute_mod = owner.physiology.brute_mod//your armor 
-			owner.physiology.brute_mod = 0.75
+			owner.physiology.brute_mod = 0.70//Specifically at 30% dr due to it having no upkeep cost
 			saved_burn_mod = owner.physiology.burn_mod
 			owner.physiology.burn_mod = 2
 			saved_aggravated_mod= owner.physiology.aggravated_mod
-			owner.physiology.aggravated_mod = 0.9
+			owner.physiology.aggravated_mod = 0.80
 
 			animate(owner, color = "#000000", time = 1 SECONDS, loop = 1)
 			to_chat(owner, span_green("You successfully fuse with the shadows!"))

--- a/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
+++ b/modular_darkpack/modules/powers/code/discipline/obtenebration/obtenebration.dm
@@ -204,11 +204,20 @@
 /datum/discipline_power/obtenebration/black_metamorphosis/activate()
 	. = ..()
 	activating = FALSE
+	var/saved_brute_mod = 1
+	var/saved_burn_mod = 1
+	var/saved_aggravated_mod = 1
 	var/roll = SSroll.storyteller_roll_datum(owner, difficulty = 7, applic_stats = list(STAT_MANIPULATION, STAT_COURAGE))
 	switch(roll)
 		if(ROLL_SUCCESS)
 			successful = TRUE
-			owner.physiology.damage_resistance += 60
+			saved_brute_mod = owner.physiology.brute_mod//your armor 
+			owner.physiology.brute_mod = 0.75
+			saved_burn_mod = owner.physiology.burn_mod
+			owner.physiology.burn_mod = 2
+			saved_aggravated_mod= owner.physiology.aggravated_mod
+			owner.physiology.aggravated_mod = 0.9
+
 			animate(owner, color = "#000000", time = 1 SECONDS, loop = 1)
 			to_chat(owner, span_green("You successfully fuse with the shadows!"))
 		if(ROLL_FAILURE)


### PR DESCRIPTION

## About The Pull Request

This Pr specifically changes the Obtenebration 4 ability of shadow armor to specifically only give 30% damage resistance instead of the 60 flat damage resistance it was giving prior and gives it a weakness to fire like the ability above it has. Sorry if this pr is kinda slap dashed I have not done this in a while.

## Why It's Good For The Game

Lasombras currently are able to utilize this ability to get a permanent fortitude 4 ability which also has a stronger burn resistance than even level 5 fortitude. This ability also does not drain blood points at all while used. You would think fighting a man made of shadow with a lot of fire would be a good idea but as of now fire is worthless against them entirely. This is unlike however the level 5 ability in their tree which explicitly has a 2x weakness to fire. To bring things closer to how it should work and reign in armor stacking a bit I believe the values should be reduced and a counter to this ability actually implemented.

## Changelog

Gives Lasombras level 4 ability a weakness to fire and burn damage and reduces its overall strength


:cl:

balance: reduced lasombras level 4 abilities strength)

/:cl:
