### PR TITLE
Dispatch can now unlock the door leading into the Police Station

### DIFF
--- a/_maps/map_files/Vampire/oakland/bomby_oakland.dmm
+++ b/_maps/map_files/Vampire/oakland/bomby_oakland.dmm
@@ -1047,8 +1047,8 @@
 /obj/structure/vampdoor/reinf,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
-/obj/effect/mapping_helpers/door/access/police,
 /obj/effect/mapping_helpers/door/autoname,
+/obj/effect/mapping_helpers/door/access/dispatch,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/police/upstairs)
 "anq" = (
@@ -99019,8 +99019,8 @@
 	},
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
-/obj/effect/mapping_helpers/door/access/police,
 /obj/effect/mapping_helpers/door/autoname,
+/obj/effect/mapping_helpers/door/access/dispatch,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
 "xWo" = (

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -82036,9 +82036,9 @@
 	lockpick_difficulty = 16;
 	dir = 4
 	},
-/obj/effect/mapping_helpers/door/access/police,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/mapping_helpers/door/access/dispatch,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
 "wrz" = (

--- a/modular_darkpack/modules/doors/code/keys/keys.dm
+++ b/modular_darkpack/modules/doors/code/keys/keys.dm
@@ -364,12 +364,14 @@ GLOBAL_LIST_INIT(city_door_lock_ids, list())
 /obj/item/vamp/keys/police
 	name = "police keys"
 	accesslocks = list(
+		LOCKACCESS_DISPATCH,
 		LOCKACCESS_POLICE
 	)
 
 /obj/item/vamp/keys/police/federal
 	name = "federal agent keys"
 	accesslocks = list(
+		LOCKACCESS_DISPATCH,
 		LOCKACCESS_POLICE,
 		LOCKACCESS_FEDERAL
 	)
@@ -383,6 +385,7 @@ GLOBAL_LIST_INIT(city_door_lock_ids, list())
 /obj/item/vamp/keys/police/secure
 	name = "sergeant police keys"
 	accesslocks = list(
+		LOCKACCESS_DISPATCH,
 		LOCKACCESS_POLICE,
 		LOCKACCESS_POLICE_SECURE
 	)


### PR DESCRIPTION

## About The Pull Request
The doors leading into the police station from the Dispatch Office have had their locks changed, and now can be unlocked using Dispatch Keys.

In addition, Police Keys, Police Sergeant Keys and Federal Agent Keys can now open doors locked with the Dispatch Lock, so they're also able to get into the Office easily.

## Why It's Good For The Game
Dispatch spawned locked in their room. They can't get into the PD without assistance, meaning they can't even link their radios which is essential to their job. While a police officer will eventually unlock the door to let you in, the fact Dispatch cant even get into the PD leads to a lot of aggravation. This is some nice QOL for them to actually do their job properly.

## Changelog
:cl:
qol: Dispatch can now unlock the doors that leads into the Police Station
/:cl:
