### PR TITLE
Reworks the implimentation of stun jumps

### DIFF
--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -170,4 +170,4 @@
 #undef JUMP_WINDUP
 #undef BASE_JUMP_DISTANCE
 #undef MAX_JUMP_DISTANCE
-#undef JUMP_BOOM_COOLDOWN //CRIMSON GRID ADDITION - cooldown undefine for jump boom
+#undef JUMP_BOOM_COOLDOWN //CRIMSON GRID ADDITION - Reworks the implimentation of stun jumps

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -123,12 +123,13 @@
 	if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8 && COOLDOWN_FINISHED(src, jump_boom_cooldown))
 		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN) //CRIMSON GRID ADDITION - adds an internal cooldown to fix jump misfires
 		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper), (get_dist(jumper.loc, adjusted_target) * 0.5))
+	//CRIMSON GRID EDIT END
 		jumper.visible_message(span_danger("[jumper] takes a mighty leap that shatters \the [adjusted_target] where they land!"))
 		jumper.adjust_stamina_loss(20)
 	else
 		jumper.adjust_stamina_loss(10)
 		jumper.visible_message(span_danger("[jumper] jumps towards [adjusted_target]."))
-	//CRIMSON GRID EDIT END
+
 
 	var/turf/start_T = get_turf(jumper.loc) //Get the start and target tile for the descriptors
 	var/turf/end_T = get_turf(adjusted_target)

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -3,11 +3,11 @@
 #define JUMP_SLOWDOWN_MULT 1.6 // 1.5 means a jumping character and a walking character will keep pace. Increase to slow jumpers further.
 #define BASE_JUMP_DISTANCE 1
 #define MAX_JUMP_DISTANCE 6
-#define JUMP_BOOM_COOLDOWN 2 SECONDS //CRIMSON GRID ADDITION - cooldown define for time
+#define JUMP_BOOM_COOLDOWN 2 SECONDS //CRIMSON GRID ADDITION - Reworks the implimentation of stun jumps
 
 /datum/component/jumper
 	COOLDOWN_DECLARE(jump_cooldown)
-	COOLDOWN_DECLARE(jump_boom_cooldown) //CRMISON GRID ADDITION - cooldown delcare fore smashing the floor
+	COOLDOWN_DECLARE(jump_boom_cooldown) //CRMISON GRID ADDITION - Reworks the implimentation of stun jumps
 	var/prepared_to_jump = FALSE
 
 /datum/component/jumper/Initialize()

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -119,7 +119,7 @@
 		adjusted_target = locate(jumper.loc.x + round(dx * scale), jumper.loc.y + round(dy * scale), jumper.loc.z)
 
 	playsound(jumper.loc, 'modular_darkpack/modules/jumping/sounds/jump_neutral.ogg', 50, TRUE)
-	if(jumper.combat_mode && get_dist(jumper.loc, target) <= 3 && strength >= 8)
+	if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8 && COOLDOWN_FINISHED(src, jump_boom_cooldown)) //CRIMSON GRID EDIT - Reworks the Implimentation of stun jumps - Original: if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8
 		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper),(distance * 0.5))
 		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN) //CRMISON GRID ADDITION - Reworks the implimentation of stun jumps
 		jumper.visible_message(span_danger("[jumper] takes a mighty leap that shatters \the [adjusted_target] where they land!"))

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -156,7 +156,7 @@
 		if(shaken_person == jumper)
 			continue
 		shaken_person.Stun(20)
-		shaken_person.do_stagger_animation(60) //CRIMSON GRID ADDITION - nice little larp trigger, does nothing gameplay wise, just makes them stagger shake for 6 seconds
+		shaken_person.do_stagger_animation(60) //CRIMSON GRID ADDITION - Reworks the implimentation of stun jumps
 		var/distance = get_dist(shaken_person, jumper)
 		shake_camera(shaken_person, max(6-distance), max(4-distance, 1))
 	jumper.Stun(10)

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -119,7 +119,7 @@
 		adjusted_target = locate(jumper.loc.x + round(dx * scale), jumper.loc.y + round(dy * scale), jumper.loc.z)
 
 	playsound(jumper.loc, 'modular_darkpack/modules/jumping/sounds/jump_neutral.ogg', 50, TRUE)
-	if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8 && COOLDOWN_FINISHED(src, jump_boom_cooldown)) //CRIMSON GRID EDIT - Reworks the Implimentation of stun jumps - Original: if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8
+	if(jumper.combat_mode && get_dist(jumper.loc, target) <= 3 && strength >= 8 && COOLDOWN_FINISHED(src, jump_boom_cooldown)) //CRIMSON GRID EDIT - Reworks the Implimentation of stun jumps - Original: if(jumper.combat_mode && get_dist(jumper.loc, target) <= 3 && strength >= 8)
 		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper),(distance * 0.5))
 		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN) //CRMISON GRID ADDITION - Reworks the implimentation of stun jumps
 		jumper.visible_message(span_danger("[jumper] takes a mighty leap that shatters \the [adjusted_target] where they land!"))

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -121,7 +121,7 @@
 	playsound(jumper.loc, 'modular_darkpack/modules/jumping/sounds/jump_neutral.ogg', 50, TRUE)
 	//CRIMSON GRID EDIT START - fixes jump stun flaking out at max distance and actually triggering proper
 	if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8 && COOLDOWN_FINISHED(src, jump_boom_cooldown))
-		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN) //CRIMSON GRID ADDITION - adds an internal cooldown to fix jump misfires
+		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN)
 		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper), (get_dist(jumper.loc, adjusted_target) * 0.5))
 	//CRIMSON GRID EDIT END
 		jumper.visible_message(span_danger("[jumper] takes a mighty leap that shatters \the [adjusted_target] where they land!"))

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -152,7 +152,7 @@
 /datum/component/jumper/proc/jump_boom(mob/living/jumper)
 	playsound(get_turf(jumper), 'modular_darkpack/modules/jumping/sounds/jump_slam.ogg', 40, FALSE)
 	new /obj/effect/temp_visual/dir_setting/crack_effect(get_turf(jumper))
-	for(var/mob/living/shaken_person in range(2, jumper)) //CRIMSON GRID EDIT - nerfs range from 5 tiles from origin of jumper(lmao?) to 2 tile range instead
+	for(var/mob/living/shaken_person in range(2, jumper)) //CRIMSON GRID EDIT - Reworks the Implimentation of stun jumps - Original: 	for(var/mob/living/shaken_person in range(5, jumper))
 		if(shaken_person == jumper)
 			continue
 		shaken_person.Stun(20)

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -3,9 +3,11 @@
 #define JUMP_SLOWDOWN_MULT 1.6 // 1.5 means a jumping character and a walking character will keep pace. Increase to slow jumpers further.
 #define BASE_JUMP_DISTANCE 1
 #define MAX_JUMP_DISTANCE 6
+#define JUMP_BOOM_COOLDOWN 2 SECONDS //CRIMSON GRID ADDITION - cooldown define for time
 
 /datum/component/jumper
 	COOLDOWN_DECLARE(jump_cooldown)
+	COOLDOWN_DECLARE(jump_boom_cooldown) //CRMISON GRID ADDITION - cooldown delcare fore smashing the floor
 	var/prepared_to_jump = FALSE
 
 /datum/component/jumper/Initialize()
@@ -117,14 +119,16 @@
 		adjusted_target = locate(jumper.loc.x + round(dx * scale), jumper.loc.y + round(dy * scale), jumper.loc.z)
 
 	playsound(jumper.loc, 'modular_darkpack/modules/jumping/sounds/jump_neutral.ogg', 50, TRUE)
-
-	if(jumper.combat_mode && get_dist(jumper.loc, target) <= 3 && strength >= 8)
-		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper),(distance * 0.5))
+	//CRIMSON GRID EDIT START - fixes jump stun flaking out at max distance and actually triggering proper
+	if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8 && COOLDOWN_FINISHED(src, jump_boom_cooldown))
+		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN) //CRIMSON GRID ADDITION - adds an internal cooldown to fix jump misfires
+		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper), (get_dist(jumper.loc, adjusted_target) * 0.5))
 		jumper.visible_message(span_danger("[jumper] takes a mighty leap that shatters \the [adjusted_target] where they land!"))
 		jumper.adjust_stamina_loss(20)
 	else
 		jumper.adjust_stamina_loss(10)
 		jumper.visible_message(span_danger("[jumper] jumps towards [adjusted_target]."))
+	//CRIMS GRID EDIT END
 
 	var/turf/start_T = get_turf(jumper.loc) //Get the start and target tile for the descriptors
 	var/turf/end_T = get_turf(adjusted_target)
@@ -148,10 +152,11 @@
 /datum/component/jumper/proc/jump_boom(mob/living/jumper)
 	playsound(get_turf(jumper), 'modular_darkpack/modules/jumping/sounds/jump_slam.ogg', 40, FALSE)
 	new /obj/effect/temp_visual/dir_setting/crack_effect(get_turf(jumper))
-	for(var/mob/living/shaken_person in range(5, jumper))
+	for(var/mob/living/shaken_person in range(2, jumper)) //CRIMSON GRID EDIT - nerfs range from 5 tiles from origin of jumper(lmao?) to 2 tile range instead
 		if(shaken_person == jumper)
 			continue
 		shaken_person.Stun(20)
+		shaken_person.do_stagger_animation(60) //CRIMSON GRID ADDITION - nice little larp trigger, does nothing gameplay wise, just makes them stagger shake for 6 seconds
 		var/distance = get_dist(shaken_person, jumper)
 		shake_camera(shaken_person, max(6-distance), max(4-distance, 1))
 	jumper.Stun(10)
@@ -165,3 +170,4 @@
 #undef JUMP_WINDUP
 #undef BASE_JUMP_DISTANCE
 #undef MAX_JUMP_DISTANCE
+#undef JUMP_BOOM_COOLDOWN //CRIMSON GRID ADDITION - cooldown undefine for jump boom

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -119,11 +119,9 @@
 		adjusted_target = locate(jumper.loc.x + round(dx * scale), jumper.loc.y + round(dy * scale), jumper.loc.z)
 
 	playsound(jumper.loc, 'modular_darkpack/modules/jumping/sounds/jump_neutral.ogg', 50, TRUE)
-	//CRIMSON GRID EDIT START - fixes jump stun flaking out at max distance and actually triggering proper
-	if(jumper.combat_mode && distance <= adjusted_jump_range && strength >= 8 && COOLDOWN_FINISHED(src, jump_boom_cooldown))
-		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN)
-		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper), (get_dist(jumper.loc, adjusted_target) * 0.5))
-	//CRIMSON GRID EDIT END
+	if(jumper.combat_mode && get_dist(jumper.loc, target) <= 3 && strength >= 8)
+		addtimer(CALLBACK(src, PROC_REF(jump_boom), jumper),(distance * 0.5))
+		COOLDOWN_START(src, jump_boom_cooldown, JUMP_BOOM_COOLDOWN) //CRMISON GRID ADDITION - Reworks the implimentation of stun jumps
 		jumper.visible_message(span_danger("[jumper] takes a mighty leap that shatters \the [adjusted_target] where they land!"))
 		jumper.adjust_stamina_loss(20)
 	else

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -130,7 +130,6 @@
 		jumper.adjust_stamina_loss(10)
 		jumper.visible_message(span_danger("[jumper] jumps towards [adjusted_target]."))
 
-
 	var/turf/start_T = get_turf(jumper.loc) //Get the start and target tile for the descriptors
 	var/turf/end_T = get_turf(adjusted_target)
 	if(start_T && end_T)

--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -128,7 +128,7 @@
 	else
 		jumper.adjust_stamina_loss(10)
 		jumper.visible_message(span_danger("[jumper] jumps towards [adjusted_target]."))
-	//CRIMS GRID EDIT END
+	//CRIMSON GRID EDIT END
 
 	var/turf/start_T = get_turf(jumper.loc) //Get the start and target tile for the descriptors
 	var/turf/end_T = get_turf(adjusted_target)


### PR DESCRIPTION

## About The Pull Request
This pr is designed to address something that alot of players and I myself have used and been the victim of, the infamous jump stun of death from players that have more than 8 strength, this pull request is designed to rectify its range, add controllable cooldown triggers and make it actually calculate the increased jump range additions given to the middle click jumping by athletics and strength.
## Why It's Good For The Game
This is a major functionality rework and redesign of the stun jump stomping mechanic, it will still be spamable but the distance of the actual stun has been reduced from a giant 5 tile range from the user to 2 instead. This makes the jump cracking actually look like it lines up the floor crack tiles, gives a visual tell of a stagger animation to those who just got affected and fixes the situation where it was not working past a certain jump range and actually activating constantly with an internalized two second cooldown that can be altered easily in the future for balance. 
## Changelog
Added a stagger animation wobble to the mighty 8+ strength stomp jumping, no gameplay effect just a visual cue you got stunned.
Removed old code that was preventing maximum range from being reached with the jump increases and reworked it to calculate it.
Nerfed the range alot, like it was at 5 tiles from origin which is massive, now its only 2 tile extra range for a little leeway but has alot more forgiving trigger procs.
Added an internalized cooldown of 2 seconds to account for misfiring triggers and for easy future proof rebalancing.

:cl:
add: Added a stagger animation for seconds to the super 8 strength jump on hit, will make the mob wobble a little. 
del: Removed the old code of max jumping range for the stomp jumping, it will now recalculate it properly to account for the increased range due to strength and athletics. 
qol: Made the jumping stomp have an internalized two second force timer to fix misfiring proccing, will probably work with lag aswell to keep it from not ticking.
balance: Lowered the range of the maximum tile stun from 5 tiles to 2 to tiles instead.

server: Might need testing to see if the cooldown actually ticks properly to time dilation
/:cl:
<img width="1060" height="569" alt="Screenshot 2026-08-27 031330" src="https://github.com/user-attachments/assets/33d96d73-457b-4192-beb0-6688867522e8" />
<img width="1198" height="652" alt="Screenshot 2026-08-27 031358" src="https://github.com/user-attachments/assets/bed9c58d-2ff7-4ae2-856b-2002d7311aa9" />

