### PR TITLE
Werewolf regeneneration tanking 

### DIFF
--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -80,13 +80,13 @@
 /obj/item/organ/tongue/fera/get_possible_languages()
 	return ..() + /datum/language/garou_tongue
 
-//CRIMSON GRID EDIT START - Gives fera war forms powerful passive regen that is constent, does not heal aggravated damage 
+//CRIMSON GRID EDIT START - Gives fera war forms powerful passive regen that is constent, does not heal aggravated damage
 
 /datum/species/human/shifter/war/on_species_gain(mob/living/carbon/human/species_fera_war, datum/species/old_species, pref_load, regenerate_icons)
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1 SECONDS, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 5, oxy_per_second =5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
+		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 5, oxy_per_second =5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
 		regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -113,7 +113,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 5, heals_wounds = TRUE, brute_per_second = 15, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  null)
+		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 3, heals_wounds = TRUE, brute_per_second = 15, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_FULL_TONER_BLACK)
 		regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -113,7 +113,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 3 SECONDS, heals_wounds = TRUE, brute_per_second = 15, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_FULL_TONER_BLACK)
+		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 2 SECONDS, heals_wounds = TRUE, brute_per_second = 15, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_FULL_TONER_BLACK)
 		regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -113,7 +113,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 3, heals_wounds = TRUE, brute_per_second = 15, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_FULL_TONER_BLACK)
+		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 3 SECONDS, heals_wounds = TRUE, brute_per_second = 15, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_FULL_TONER_BLACK)
 		regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -80,13 +80,13 @@
 /obj/item/organ/tongue/fera/get_possible_languages()
 	return ..() + /datum/language/garou_tongue
 
-//CRIMSON GRID EDIT START - Gives fera war forms powerful passive regen that kicks in after 5 seconds without embeds or damage, does not heal agg or stamina
+//CRIMSON GRID EDIT START - Gives fera war forms powerful passive regen that is constent, does not heal aggravated damage 
 
 /datum/species/human/shifter/war/on_species_gain(mob/living/carbon/human/species_fera_war, datum/species/old_species, pref_load, regenerate_icons)
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 5 SECONDS, heals_wounds = TRUE, brute_per_second = 20, burn_per_second = 10, tox_per_second = 5, oxy_per_second =5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
+		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1 SECONDS, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 5, oxy_per_second =5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
 		regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -100,7 +100,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_dire.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_dire.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 25, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_RED_LIGHT)
+		species_fera_dire.AddComponent(/datum/component/regenerator, regeneration_delay = 1 SECONDS, heals_wounds = TRUE, brute_per_second = 25, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_RED_LIGHT)
 		regenerator = species_fera_dire.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -113,7 +113,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 5, heals_wounds = TRUE, brute_per_second = 10, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  null)
+		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 5, heals_wounds = TRUE, brute_per_second = 15, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  null)
 		regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -80,6 +80,7 @@
 /obj/item/organ/tongue/fera/get_possible_languages()
 	return ..() + /datum/language/garou_tongue
 
+//CRIMSON GRID ADDITION START
 
 /datum/species/human/shifter/war/on_species_gain(mob/living/carbon/human/species_fera_war, datum/species/old_species, pref_load, regenerate_icons)
 	. = ..()
@@ -120,3 +121,5 @@
 /datum/species/human/shifter/bestial/on_species_loss(mob/living/carbon/human/human, datum/species/new_species, pref_load)
 	. = ..()
 	qdel(human.GetComponent(/datum/component/regenerator))
+
+//CRIMSION GRID ADDITION END

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -86,7 +86,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 5, oxy_per_second =5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
+		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1 SECONDS, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 5, oxy_per_second =5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
 		regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -79,3 +79,44 @@
 // Garou tongues can speak all default + garou tongue
 /obj/item/organ/tongue/fera/get_possible_languages()
 	return ..() + /datum/language/garou_tongue
+
+
+/datum/species/human/shifter/war/on_species_gain(mob/living/carbon/human/species_fera_war, datum/species/old_species, pref_load, regenerate_icons)
+	. = ..()
+	var/datum/component/regenerator/regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
+	if(!regenerator)
+		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 10, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED_LIGHT)
+		regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
+	regenerator?.start_regenerating()
+
+
+/datum/species/human/shifter/war/on_species_loss(mob/living/carbon/human/human, datum/species/new_species, pref_load)
+	. = ..()
+	human.set_health(min(human.health, human.maxHealth))
+	qdel(human.GetComponent(/datum/component/regenerator))
+
+/datum/species/human/shifter/dire/on_species_gain(mob/living/carbon/human/species_fera_dire, datum/species/old_species, pref_load, regenerate_icons)
+	. = ..()
+	var/datum/component/regenerator/regenerator = species_fera_dire.GetComponent(/datum/component/regenerator)
+	if(!regenerator)
+		species_fera_dire.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 25, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  COLOR_RED_LIGHT)
+		regenerator = species_fera_dire.GetComponent(/datum/component/regenerator)
+	regenerator?.start_regenerating()
+
+
+/datum/species/human/shifter/dire/on_species_loss(mob/living/carbon/human/human, datum/species/new_species, pref_load)
+	. = ..()
+	qdel(human.GetComponent(/datum/component/regenerator))
+
+/datum/species/human/shifter/bestial/on_species_gain(mob/living/carbon/human/species_fera_bestial, datum/species/old_species, pref_load, regenerate_icons)
+	. = ..()
+	var/datum/component/regenerator/regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
+	if(!regenerator)
+		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 10, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  null)
+		regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
+	regenerator?.start_regenerating()
+
+
+/datum/species/human/shifter/bestial/on_species_loss(mob/living/carbon/human/human, datum/species/new_species, pref_load)
+	. = ..()
+	qdel(human.GetComponent(/datum/component/regenerator))

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -86,7 +86,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 10, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED_LIGHT)
+		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 10, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
 		regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 
@@ -113,7 +113,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 1, heals_wounds = TRUE, brute_per_second = 10, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  null)
+		species_fera_bestial.AddComponent(/datum/component/regenerator, regeneration_delay = 5, heals_wounds = TRUE, brute_per_second = 10, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour =  null)
 		regenerator = species_fera_bestial.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/species/fera_organs.dm
@@ -86,7 +86,7 @@
 	. = ..()
 	var/datum/component/regenerator/regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	if(!regenerator)
-		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1 SECONDS, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 10, tox_per_second = 5, oxy_per_second =5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
+		species_fera_war.AddComponent(/datum/component/regenerator, regeneration_delay = 1 SECONDS, heals_wounds = TRUE, brute_per_second = 35, burn_per_second = 5, tox_per_second = 5, oxy_per_second = 5, ignore_damage_types = list(STAMINA , AGGRAVATED), outline_colour = COLOR_RED)
 		regenerator = species_fera_war.GetComponent(/datum/component/regenerator)
 	regenerator?.start_regenerating()
 

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_splat.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_splat.dm
@@ -153,7 +153,7 @@
 	if(COOLDOWN_FINISHED(src, passive_healing_cd))
 		if(can_passively_heal)
 			// 2 to represent lethal. Fera passive regen closes burn, but not aggravated damage.
-			owner.heal_storyteller_health(2, heal_aggravated = TRUE, heal_scars = TRUE, heal_blood = TRUE, heal_burn = TRUE)
+			owner.heal_storyteller_health(2, heal_aggravated = FALSE, heal_scars = TRUE, heal_blood = TRUE, heal_burn = TRUE)
 			// Keep organ healing ticking so internal damage recovers even between major regrowth pulses.
 			owner.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.5 * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC)
 			owner.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC)

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_splat.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/splats/fera_splat.dm
@@ -153,7 +153,7 @@
 	if(COOLDOWN_FINISHED(src, passive_healing_cd))
 		if(can_passively_heal)
 			// 2 to represent lethal. Fera passive regen closes burn, but not aggravated damage.
-			owner.heal_storyteller_health(2, heal_aggravated = FALSE, heal_scars = TRUE, heal_blood = TRUE, heal_burn = TRUE)
+			owner.heal_storyteller_health(2, heal_aggravated = TRUE, heal_scars = TRUE, heal_blood = TRUE, heal_burn = TRUE)
 			// Keep organ healing ticking so internal damage recovers even between major regrowth pulses.
 			owner.adjust_organ_loss(ORGAN_SLOT_BRAIN, -0.5 * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC)
 			owner.adjust_organ_loss(ORGAN_SLOT_HEART, -0.5 * seconds_per_tick, required_organ_flag = ORGAN_ORGANIC)


### PR DESCRIPTION

## About The Pull Request

This is pull request is about pushing werewolf combat healing far enough that they will regenerate inside of combat with the regeneration , they will heal through brute extremely rapidly, heal through embeds, heal through everything but completely losing all their blood or taking large amounts of aggravated damage. I have also enabled all fera species outside of their breed form to slowly heal aggravated damage so that they are not forever damaged by it. Unless a werewolf runs out of blood or is not attacked by aggravated weapon damage, they are not going to die easily.


## Why It's Good For The Game

Right now werewolves are squishy and do not reflect a regeneration tanking play style, this pushes up their regeneration to absolute extremes to brute damage, every form is affected by this in a different way, crinos will heal massive amounts of brute, dire wolf form will heal a little less and glabro will heal the least and only activate after 2 seconds have passed so that they cannot use it in a fight constantly. This change comes from the regenerator proc to begin ticking constantly changes its effects dramatically, enabling rapid regeneration that is not aggravated damage inflicted by silver, instead of out of combat healing, it becomes in combat healing, letting werewolves regenerate through damage the moment it is applied, showing a glowing red aura around them to others that the damage that was just inflicted is being healed.
## Changelog

Adds the carp regenerator proc to crinos,hispo and glabro forms, making them all regenerate constantly but at different rates from each other.
Enabled the original healing code of the story teller to allow for aggravated healing. This will only heal 20 hp every 5 seconds, far less potent but actually gives werewolf and corax players some aggravated healing for the time being. A bonus side effect is that corax war form will also receive the enhanced regeneration proc to their warforms due to sharing the same naming path.


:cl:
add: Added werewolf tanking regeneration through all their different forms,except lupus and homid
add:Added corax tanking regeneration to their war form only
balance: Changed the werewolf healing itself, they will rapidly heal everything that is not aggravated damage.
/:cl:
/:cl:
