### PR TITLE
Adds Duffelbags to Black Market

### DIFF
--- a/modular_darkpack/modules/retail/code/stores/black_market.dm
+++ b/modular_darkpack/modules/retail/code/stores/black_market.dm
@@ -14,6 +14,7 @@
 		new /datum/data/vending_product("switchblade", /obj/item/switchblade/vamp, 85),
 		new /datum/data/vending_product("knuckledusters", /obj/item/clothing/gloves/vampire/brassknuckles, 100),
 		new /datum/data/vending_product("stake", /obj/item/vampire_stake, 100),
+		new /datum/data/vending_product("duffelbag", /obj/item/storage/backpack/duffelbag,	100), // CRIMSON EDIT ADD - Adds Duffelbags to Black Market
 		new /datum/data/vending_product("Surgery dufflebag", /obj/item/storage/backpack/duffelbag/sec/surgery, 100),
 		new /datum/data/vending_product("Handcuffs", /obj/item/restraints/handcuffs, 50),
 		new /datum/data/vending_product("Black bag", /obj/item/clothing/head/vampire/blackbag, 50),


### PR DESCRIPTION
## About The Pull Request

Players are buying surgical duffel bags at the black market and dumping their contents on the floor. 
Now the black market sells empty duffel bags. Same end result, but with less clutter. 

## Why It's Good For The Game

Less clutter.

<img width="850" height="382" alt="image" src="https://github.com/user-attachments/assets/d0352c58-7b1d-49b3-9425-25552cf11218" />


## Changelog
:cl:
add: Added black duffel bags to the black market.
/:cl:
