### PR TITLE
vicissitude nerf 

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
+++ b/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
@@ -127,10 +127,23 @@
 	. = ..()
 
 	var/roll = SSroll.storyteller_roll_datum(owner, target, /datum/storyteller_roll/bonecrafting)
-
-	if(target.stat >= HARD_CRIT)
-		if(target.stat != DEAD)
+//CRIMSON GRID ADDITION START
+	if(target.stat == DEAD)
+		if(target.stat == DEAD)
 			target.death()
+		if(!do_after(
+			owner,
+			10 SECONDS,
+			target = target,
+			timed_action_flags = DO_AFTER_CHECK_NEXT_MOVE | IGNORE_INCAPACITATED
+		))
+			to_chat(owner, span_warning("You stopped before vivasecting the [target]'s corpse."))
+			return FALSE
+		if(QDELETED(target))
+			return FALSE
+		if(target.stat != DEAD)
+			return FALSE
+//CRIMSON GRID ADDITION END
 		var/obj/item/bodypart/arm/right/r_arm = target.get_bodypart(BODY_ZONE_R_ARM)
 		var/obj/item/bodypart/arm/left/l_arm = target.get_bodypart(BODY_ZONE_L_ARM)
 		var/obj/item/bodypart/leg/right/r_leg = target.get_bodypart(BODY_ZONE_R_LEG)

--- a/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
+++ b/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
@@ -129,8 +129,6 @@
 	var/roll = SSroll.storyteller_roll_datum(owner, target, /datum/storyteller_roll/bonecrafting)
 //CRIMSON GRID ADDITION START
 	if(target.stat == DEAD)
-		if(target.stat == DEAD)
-			target.death()
 		if(!do_after(
 			owner,
 			10 SECONDS,

--- a/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
+++ b/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
@@ -141,7 +141,7 @@
 			return FALSE
 		if(target.stat != DEAD)
 			return FALSE
-//CRIMSON GRID ADDITION END
+//CRIMSON GRID ADDITION END - Vicissitude Nerf
 		var/obj/item/bodypart/arm/right/r_arm = target.get_bodypart(BODY_ZONE_R_ARM)
 		var/obj/item/bodypart/arm/left/l_arm = target.get_bodypart(BODY_ZONE_L_ARM)
 		var/obj/item/bodypart/leg/right/r_leg = target.get_bodypart(BODY_ZONE_R_LEG)

--- a/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
+++ b/modular_darkpack/modules/powers/code/discipline/vicissitude/vicissitude.dm
@@ -127,7 +127,7 @@
 	. = ..()
 
 	var/roll = SSroll.storyteller_roll_datum(owner, target, /datum/storyteller_roll/bonecrafting)
-//CRIMSON GRID ADDITION START
+//CRIMSON GRID ADDITION START - Vicissitude Nerf
 	if(target.stat == DEAD)
 		if(!do_after(
 			owner,


### PR DESCRIPTION

## About The Pull Request
This pr is to address the powerful instant deletion ability of bone crafting from the discipline of Vicissitude, it is a powerful skill that had nothing but a cost of blood to instantly round remove players in soft crit without any control factor or downsides, thus being able to be used in the middle of combat when downing someone to instantly round remove them.


## Why It's Good For The Game

Bone crafting is a extremely useful tool, but currently it has gained quite abit of power in a fight due to it being able to delete someone instantly when they are just in merely soft crit, this PR is to address this by making it so bone crafting not only fully requires a person to be dead, even torpor is not enough, the person has to be in a state of full death to allow bone crafting to take place. I have also added in a do after action that takes ten seconds for it to complete before the corpse is deleted to allow it to not be spammed rapidly on dead corpses and to give counter play to the bone craft user.


## Changelog

Modified bone crafting to not be an instant critical health downstate win, the person has to be in a full death state.
Added a do_after to bone crafting, requiring a set amount of time of action to stop combat exploiting when deleting a target.


:cl:
balance: rebalanced bone crafting, no longer an instant win button on soft critical targets
balance: Bone crafting requires a do after of 10 seconds before it casts, it can be interrupted before that by pulling the body away or pushing or pulling the bone crafter.

/:cl:
