### PR TITLE
Discipline Active Indicator

### DIFF
--- a/code/__DEFINES/alerts.dm
+++ b/code/__DEFINES/alerts.dm
@@ -75,3 +75,5 @@
 #define ALERT_BITRUNNER_GLITCH "bitrunning_glitch"
 
 #define ALERT_SILICON_RECORDING "silicon_recording"
+
+#define DISCIPLINE_ACTIVE_ALERT(power) "discipline_power_[power.type]" // CRIMSON EDIT ADD - Discipline Active Indicator

--- a/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
@@ -70,6 +70,11 @@
 	src.owner = discipline.owner
 
 /datum/discipline_power/Destroy(force)
+	// CRIMSON EDIT ADD START - Discipline Active Indicator
+	if (toggled && active)
+		owner?.clear_alert(DISCIPLINE_ACTIVE_ALERT(src))
+	// CRIMSON EDIT ADD END - Discipline Active Indicator
+
 	for(var/timer_id in duration_timers)
 		deltimer(timer_id)
 	duration_timers = null
@@ -452,7 +457,7 @@
 
 	// CRIMSON EDIT ADD START - Discipline Active Indicator
 	if (toggled)
-		var/atom/movable/screen/alert/discipline_active/indicator = owner.throw_alert("discipline_power_[type]", /atom/movable/screen/alert/discipline_active)
+		var/atom/movable/screen/alert/discipline_active/indicator = owner.throw_alert(DISCIPLINE_ACTIVE_ALERT(src), /atom/movable/screen/alert/discipline_active)
 		if (istype(indicator))
 			indicator.set_power(src)
 	// CRIMSON EDIT ADD END - Discipline Active Indicator
@@ -671,7 +676,7 @@
 
 	// CRIMSON EDIT ADD START - Discipline Active Indicator
 	if (toggled)
-		owner.clear_alert("discipline_power_[type]")
+		owner.clear_alert(DISCIPLINE_ACTIVE_ALERT(src))
 	// CRIMSON EDIT ADD END - Discipline Active Indicator
 
 	owner.update_action_buttons()

--- a/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
@@ -450,6 +450,13 @@
 	do_caster_notification(target)
 	do_logging(target)
 
+	// CRIMSON EDIT ADD START - Discipline Active Indicator
+	if (toggled)
+		var/atom/movable/screen/alert/discipline_active/indicator = owner.throw_alert("discipline_power_[type]", /atom/movable/screen/alert/discipline_active)
+		if (istype(indicator))
+			indicator.set_power(src)
+	// CRIMSON EDIT ADD END - Discipline Active Indicator
+
 	owner.update_action_buttons()
 
 	return TRUE
@@ -661,6 +668,11 @@
 
 	if (deactivate_sound)
 		owner.playsound_local(owner, deactivate_sound, 50, FALSE)
+
+	// CRIMSON EDIT ADD START - Discipline Active Indicator
+	if (toggled)
+		owner.clear_alert("discipline_power_[type]")
+	// CRIMSON EDIT ADD END - Discipline Active Indicator
 
 	owner.update_action_buttons()
 

--- a/modular_darkpack/modules/powers/code/discipline_actions.dm
+++ b/modular_darkpack/modules/powers/code/discipline_actions.dm
@@ -237,17 +237,24 @@
 	. = ..()
 
 // CRIMSON EDIT ADD START - Discipline Active Indicator
+/datum/action/discipline/is_action_active(atom/movable/screen/movable/action_button/current_button)
+	for(var/datum/discipline_power/power as anything in discipline?.known_powers)
+		if(power.active)
+			return TRUE
+	return FALSE
+
 /datum/action/discipline/build_button_icon(atom/movable/screen/movable/action_button/button, update_flags = ALL, force = FALSE)
 	. = ..()
 
 	if(!button)
 		return
 
-	for(var/datum/discipline_power/power as anything in discipline?.known_powers)
-		if(!power.active)
-			continue
-		button.add_filter("discipline_active", 2, outline_filter(color = COLOR_GOLD, size = 1))
+	var/wants_glow = is_action_active(button)
+	if(wants_glow == !isnull(button.get_filter("discipline_active")))
 		return
 
-	button.remove_filter("discipline_active")
+	if(wants_glow)
+		button.add_filter("discipline_active", 2, outline_filter(color = COLOR_GOLD, size = 1))
+	else
+		button.remove_filter("discipline_active")
 // CRIMSON EDIT ADD END - Discipline Active Indicator

--- a/modular_darkpack/modules/powers/code/discipline_actions.dm
+++ b/modular_darkpack/modules/powers/code/discipline_actions.dm
@@ -235,3 +235,19 @@
 			return
 		//TODO: middle click to swap loadout
 	. = ..()
+
+// CRIMSON EDIT ADD START - Discipline Active Indicator
+/datum/action/discipline/build_button_icon(atom/movable/screen/movable/action_button/button, update_flags = ALL, force = FALSE)
+	. = ..()
+
+	if(!button)
+		return
+
+	for(var/datum/discipline_power/power as anything in discipline?.known_powers)
+		if(!power.active)
+			continue
+		button.add_filter("discipline_active", 2, outline_filter(color = COLOR_GOLD, size = 1))
+		return
+
+	button.remove_filter("discipline_active")
+// CRIMSON EDIT ADD END - Discipline Active Indicator

--- a/modular_vcg/modules/powers/code/discipline_active_alert.dm
+++ b/modular_vcg/modules/powers/code/discipline_active_alert.dm
@@ -1,0 +1,10 @@
+/atom/movable/screen/alert/discipline_active
+
+/atom/movable/screen/alert/discipline_active/proc/set_power(datum/discipline_power/power)
+	if(!power?.discipline)
+		return
+
+	name = "[power.name] Active"
+	desc = "Drawing on your blood to stay active."
+	icon = power.discipline.icon
+	icon_state = power.discipline.icon_state

--- a/modular_vcg/modules/powers/code/discipline_active_alert.dm
+++ b/modular_vcg/modules/powers/code/discipline_active_alert.dm
@@ -1,10 +1,24 @@
 /atom/movable/screen/alert/discipline_active
+	clickable_glow = TRUE
+	var/datum/weakref/power_ref
 
 /atom/movable/screen/alert/discipline_active/proc/set_power(datum/discipline_power/power)
 	if(!power?.discipline)
 		return
 
+	power_ref = WEAKREF(power)
 	name = "[power.name] Active"
-	desc = "Drawing on your blood to stay active."
+	desc = "Drawing on your blood to stay active. Click to switch it off."
 	icon = power.discipline.icon
 	icon_state = power.discipline.icon_state
+
+/atom/movable/screen/alert/discipline_active/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return
+
+	var/datum/discipline_power/power = power_ref?.resolve()
+	if(!power)
+		return
+
+	power.try_deactivate(direct = TRUE, alert = TRUE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8406,6 +8406,7 @@
 #include "modular_vcg\modules\powers\code\discipline\vicissitude\bonecrafting.dm"
 #include "modular_vcg\modules\powers\code\discipline\vicissitude\crafting_recipe.dm"
 #include "modular_vcg\modules\powers\code\discipline\vicissitude\melee.dm"
+#include "modular_vcg\modules\powers\code\discipline_active_alert.dm"
 #include "modular_vcg\modules\relays\code\relays.dm"
 #include "modular_vcg\modules\toggle_looc\code\looc_toggle.dm"
 #include "modular_vcg\modules\vampire_the_masquerade\code\vampire_clan\clans\old_clan_tzimisce.dm"


### PR DESCRIPTION
## About The Pull Request
- Adds HUD icons for less obvious toggled discipline powers that drain your blood while active (ex. Potence, Fortitude, Celerity, etc.).
- You can click this new icon to deactivate the power.
- While active, both this new icon and the ability button are outlined in yellow.

<img width="150" height="148" alt="image" src="https://github.com/user-attachments/assets/79c89e96-1acd-44ba-a10e-15be6a132af5" />
<img width="146" height="142" alt="image" src="https://github.com/user-attachments/assets/ccaba8ba-323b-46a6-8d86-3562b3d81447" />

<img width="2540" height="1346" alt="image" src="https://github.com/user-attachments/assets/c12606b2-ef1f-4c63-820d-d4c5ba7b40bb" />

## Why It's Good For The Game

QoL. Visual indicator. 

Scenario:
You activated Potence for the fight.  
But it turned into a long verbal argument over the warrant.
You forgot Potence was active.
Now you're out of blood and someone just threw the first punch.

Even worse if you realize it's still on after the chase is over. 

## Changelog
:cl:
qol: Discipline active powers now add an icon to your HUD while active. The power's button in the Discipline action bar also turns gold when active. Clicking either that button or the new HUD icon deactivates that power.
/:cl:
