### PR TITLE
Welders no longer deconstruct city walls

### DIFF
--- a/modular_darkpack/modules/walls/code/walls.dm
+++ b/modular_darkpack/modules/walls/code/walls.dm
@@ -72,6 +72,13 @@
 /turf/closed/wall/vampwall/attack_hand(mob/user)
 	return
 
+// CRIMSON EDIT ADD START - Welders no longer deconstruct city walls
+/turf/closed/wall/vampwall/try_decon(obj/item/I, mob/user)
+	if(I.tool_behaviour == TOOL_WELDER)
+		to_chat(user, span_warning("The wall is too solid to cut through."))
+	return FALSE
+// CRIMSON EDIT ADD END - Welders no longer deconstruct city walls
+
 /turf/closed/wall/vampwall/mouse_drop_receive(atom/dropped, mob/user, params)
 	. = ..()
 	if(!isliving(user))


### PR DESCRIPTION
## About The Pull Request

"It's just a wall, man." 

"No. It was _premade_. PRE-MADE." 

"What does that eve---"

Are you tired of having your walls cut through by unregulated high-capacity industrial strength welders? 

Scared to wake up and your toolshed's sliced clean through?

We hear you! 

Sleep peacefully knowing that your family is safe and sound thanks to California's Prop 233 "Stop Illegal Assault Welders Now!".

Prop 233 requires manufacturers to install safeguard power limiters on welders so that they can no longer be used to destroy our premade city walls. 

Either gain entry through the window and door, or get yourself a can of "<img width="34" height="30" alt="image" src="https://github.com/user-attachments/assets/7579e7cf-c84f-47bb-8958-0344d0db4ed1" /> <img width="230" height="40" alt="image" src="https://github.com/user-attachments/assets/a6920c02-3e41-4a1a-a81f-db1116da9dd5" />."

_Disclaimer: You can still deconstruct player-made walls. Only Endron has a chem dispenser to make thermite. Supply does not sell thermite. Stores do not sell thermite. Good luck.)_

## Why It's Good For The Game

Players could be banned for welding through prebuilt city walls, so this PR saves lives until a better option comes along. 

## Changelog

:cl:
balance: Welders can no longer cut through prebuilt walls. You can still cut through player-made walls as normal. 
/:cl:
