### PR TITLE
Sniper The Zooming

### DIFF
--- a/modular_vcg/modules/weapons/code/guns.dm
+++ b/modular_vcg/modules/weapons/code/guns.dm
@@ -53,6 +53,10 @@
 /obj/item/gun/ballistic/automatic/darkpack/aug
 	recoil = 3
 
+/obj/item/gun/ballistic/automatic/darkpack/aug/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/scope, range_modifier = 1.2)
+
 /obj/item/gun/ballistic/automatic/darkpack/thompson
 	recoil = 3
 
@@ -63,8 +67,16 @@
 /obj/item/gun/ballistic/automatic/darkpack/sniper
 	recoil = 6
 
+/obj/item/gun/ballistic/automatic/darkpack/sniper/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/scope, range_modifier = 4)
+
 /obj/item/gun/ballistic/automatic/darkpack/autosniper
 	recoil = 4
+
+/obj/item/gun/ballistic/automatic/darkpack/autosniper/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/scope, range_modifier = 4)
 
 // Shotguns
 /obj/item/gun/ballistic/shotgun/vampire


### PR DESCRIPTION

## About The Pull Request

A lazy copy-paste of scopes for .50 sniper rifle, 7x51 autosniper rifle and for aug (cus it has a scope, right???)

Both rifles get scope mod x4, while the aug only x1.2

**To zoom just press RMB**

### **SNIPER RIFLE ZOOM**
<img width="1273" height="1001" alt="image" src="https://github.com/user-attachments/assets/e4ecd26f-f7d3-47f9-b503-eebca888cea6" />
<img width="1271" height="996" alt="image" src="https://github.com/user-attachments/assets/3ef8719d-83c4-48fd-b90b-d3d61021e191" />

### **AUG ZOOM**

<img width="1268" height="990" alt="image" src="https://github.com/user-attachments/assets/8fef9a38-5f93-4de5-87ae-1b73dbdc03ee" />
<img width="1266" height="993" alt="image" src="https://github.com/user-attachments/assets/bb068cac-d93c-414f-9aa1-5f9ed08a4175" />

## Why It's Good For The Game

Almost everyone knows what a sniper rifle is and why there's a scope on it
It may not work so well with bullet lag on high pop, but maybe, some day, it won't be a problem and marskman larpers may enjoy it
<img width="303" height="112" alt="testing_evidence" src="https://github.com/user-attachments/assets/290a44e0-9c8f-4337-9e8a-1b5e5d76040a" />

## Changelog
:cl:
add: ability to scope for sniper rifles and aug
/:cl:
