### PR TITLE
Braddock Mags Buyable

### DIFF
--- a/modular_darkpack/modules/retail/code/stores/black_market.dm
+++ b/modular_darkpack/modules/retail/code/stores/black_market.dm
@@ -19,6 +19,7 @@
 		new /datum/data/vending_product("Black bag", /obj/item/clothing/head/vampire/blackbag, 50),
 		new /datum/data/vending_product("snub-nose revolver", /obj/item/gun/ballistic/revolver/darkpack/snub, 100),
 		new /datum/data/vending_product("Braddock .45 submachine gun", /obj/item/gun/ballistic/automatic/darkpack/mac10, 1200),
+		new /datum/data/vending_product("Braddock .45 magazine", /obj/item/ammo_box/magazine/darkpack45smg, 300), // CRIMSON EDIT ADD - Braddock Mags Buyable
 		new /datum/data/vending_product("cannabis package", /obj/item/food/grown/cannabis, 700),
 		new /datum/data/vending_product("morphine syringe", /obj/item/reagent_containers/syringe/contraband/morphine, 800),
 		new /datum/data/vending_product("meth package", /obj/item/reagent_containers/cup/glass/baggie/meth, 800),


### PR DESCRIPTION

## About The Pull Request

By popular request, the Black Market now sells Braddock .45 mags. 

_Braddock. Settle your grudges today.™_

## Why It's Good For The Game

Players have repeatedly noted that the Braddock does not have a magazine for sale. Now it does. 

## Changelog
:cl:
add: You can now buy Braddock .45 mags from the Black Market for $300. 
/:cl:
