### PR TITLE
Shape of the Beast / Protean 4 buffs 

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/protean/beast_form.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/beast_form.dm
@@ -7,34 +7,25 @@
 		/mob/living/basic/pet/dog/wolf/protean,
 	)
 
-// CRIMSON EDIT ADDITION - Protean 4 buffs
 // FIGHT FORMS
 /mob/living/basic/pet/dog/wolf/protean
-	maxHealth = 400
-	health = 400
-	melee_damage_lower = 40
-	melee_damage_upper = 40
-	melee_attack_cooldown = 8
+	maxHealth = 300
+	health = 300
+	melee_damage_lower = 20
+	melee_damage_upper = 20
 	random_wolf_color = FALSE
-	speed = -0.4
 
 /mob/living/basic/pet/dog/darkpack/protean
 	maxHealth = 300
 	health = 300
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	melee_attack_cooldown = 8
-	speed = -0.6
-	random_dog_color = FALSE
 
 /mob/living/basic/bear/vampire/protean
-	maxHealth = 500
-	health = 500
-	melee_damage_lower = 60
-	melee_damage_upper = 60
-	melee_attack_cooldown = 10
-	speed = -0.2
-	slowed_by_drag = FALSE
+	maxHealth = 300
+	health = 300
+	melee_damage_lower = 20
+	melee_damage_upper = 20
 
 // FLIGHT FORMS
 /mob/living/basic/bat/protean
@@ -45,16 +36,6 @@
 /mob/living/basic/corvid/protean
 	maxHealth = 300
 	health = 300
-	mob_size = MOB_SIZE_SMALL
-
-/mob/living/basic/pet/cat/darkpack/protean // Meow :3
-	maxHealth = 300
-	health = 300
-	mob_size = MOB_SIZE_SMALL
-	speed = -0.8
-	melee_attack_cooldown = 8
-	random_cat_color = FALSE
-
 
 /datum/action/cooldown/spell/shapeshift/gangrel/beast_form/Grant(mob/grant_to)
 	. = ..()
@@ -65,9 +46,7 @@
 				/mob/living/basic/bear/vampire/protean,
 				/mob/living/basic/pet/dog/darkpack/protean,
 				/mob/living/basic/corvid/protean,
-				/mob/living/basic/pet/cat/darkpack/protean,
 			)
-// CRIMSON EDIT END - Protean 4 buffs
 
 /mob/living/basic/gangrel
 	name = "horrid form"

--- a/modular_darkpack/modules/powers/code/discipline/protean/beast_form.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/beast_form.dm
@@ -7,25 +7,34 @@
 		/mob/living/basic/pet/dog/wolf/protean,
 	)
 
+// CRIMSON EDIT ADDITION - Protean 4 buffs
 // FIGHT FORMS
 /mob/living/basic/pet/dog/wolf/protean
-	maxHealth = 300
-	health = 300
-	melee_damage_lower = 20
-	melee_damage_upper = 20
+	maxHealth = 400
+	health = 400
+	melee_damage_lower = 40
+	melee_damage_upper = 40
+	melee_attack_cooldown = 8
 	random_wolf_color = FALSE
+	speed = -0.4
 
 /mob/living/basic/pet/dog/darkpack/protean
 	maxHealth = 300
 	health = 300
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	melee_attack_cooldown = 8
+	speed = -0.6
+	random_dog_color = FALSE
 
 /mob/living/basic/bear/vampire/protean
-	maxHealth = 300
-	health = 300
-	melee_damage_lower = 20
-	melee_damage_upper = 20
+	maxHealth = 500
+	health = 500
+	melee_damage_lower = 60
+	melee_damage_upper = 60
+	melee_attack_cooldown = 10
+	speed = -0.2
+	slowed_by_drag = FALSE
 
 // FLIGHT FORMS
 /mob/living/basic/bat/protean
@@ -36,6 +45,16 @@
 /mob/living/basic/corvid/protean
 	maxHealth = 300
 	health = 300
+	mob_size = MOB_SIZE_SMALL
+
+/mob/living/basic/pet/cat/darkpack/protean // Meow :3
+	maxHealth = 300
+	health = 300
+	mob_size = MOB_SIZE_SMALL
+	speed = -0.8
+	melee_attack_cooldown = 8
+	random_cat_color = FALSE
+
 
 /datum/action/cooldown/spell/shapeshift/gangrel/beast_form/Grant(mob/grant_to)
 	. = ..()
@@ -46,7 +65,9 @@
 				/mob/living/basic/bear/vampire/protean,
 				/mob/living/basic/pet/dog/darkpack/protean,
 				/mob/living/basic/corvid/protean,
+				/mob/living/basic/pet/cat/darkpack/protean,
 			)
+// CRIMSON EDIT END - Protean 4 buffs
 
 /mob/living/basic/gangrel
 	name = "horrid form"

--- a/modular_vcg/modules/powers/code/discipline/protean/beast_form.dm
+++ b/modular_vcg/modules/powers/code/discipline/protean/beast_form.dm
@@ -45,3 +45,7 @@
 				/mob/living/basic/corvid/protean,
 				/mob/living/basic/pet/cat/darkpack/protean
 			)
+		if(grant_to_human.is_clan(/datum/subsplat/vampire_clan/setite/tlacique)) // Host requested
+			possible_shapes += list(
+				/mob/living/basic/pet/cat/darkpack/protean
+			)

--- a/modular_vcg/modules/powers/code/discipline/protean/beast_form.dm
+++ b/modular_vcg/modules/powers/code/discipline/protean/beast_form.dm
@@ -1,0 +1,47 @@
+// Protean 4 buffs
+/mob/living/basic/pet/dog/wolf/protean
+	maxHealth = 400
+	health = 400
+	melee_damage_lower = 40
+	melee_damage_upper = 40
+	melee_attack_cooldown = 8
+	random_wolf_color = FALSE
+	speed = -0.4
+
+/mob/living/basic/pet/dog/darkpack/protean
+	melee_attack_cooldown = 8
+	speed = -0.6
+	random_dog_color = FALSE
+
+/mob/living/basic/bear/vampire/protean
+	maxHealth = 500
+	health = 500
+	melee_damage_lower = 60
+	melee_damage_upper = 60
+	melee_attack_cooldown = 10
+	speed = -0.2
+	slowed_by_drag = FALSE
+
+// FLIGHT FORMS
+/mob/living/basic/corvid/protean
+	mob_size = MOB_SIZE_SMALL
+
+/mob/living/basic/pet/cat/darkpack/protean // Meow :3
+	maxHealth = 300
+	health = 300
+	mob_size = MOB_SIZE_SMALL
+	speed = -0.8
+	melee_attack_cooldown = 8
+	random_cat_color = FALSE
+
+/datum/action/cooldown/spell/shapeshift/gangrel/beast_form/Grant(mob/grant_to)
+	. = ..()
+	if(ishuman(grant_to))
+		var/mob/living/carbon/human/grant_to_human = grant_to
+		if(grant_to_human.is_clan(/datum/subsplat/vampire_clan/gangrel))
+			possible_shapes += list(
+				/mob/living/basic/bear/vampire/protean,
+				/mob/living/basic/pet/dog/darkpack/protean,
+				/mob/living/basic/corvid/protean,
+				/mob/living/basic/pet/cat/darkpack/protean
+			)

--- a/modular_vcg/modules/powers/code/discipline/protean/beast_form.dm
+++ b/modular_vcg/modules/powers/code/discipline/protean/beast_form.dm
@@ -8,10 +8,20 @@
 	random_wolf_color = FALSE
 	speed = -0.4
 
+/mob/living/basic/pet/dog/wolf/protean/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/swing_attack)
+
+
 /mob/living/basic/pet/dog/darkpack/protean
 	melee_attack_cooldown = 8
 	speed = -0.6
 	random_dog_color = FALSE
+
+/mob/living/basic/pet/dog/darkpack/protean/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/swing_attack)
+
 
 /mob/living/basic/bear/vampire/protean
 	maxHealth = 500
@@ -22,17 +32,39 @@
 	speed = -0.2
 	slowed_by_drag = FALSE
 
+/mob/living/basic/bear/vampire/protean/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/swing_attack)
+
 // FLIGHT FORMS
 /mob/living/basic/corvid/protean
 	mob_size = MOB_SIZE_SMALL
+	speed = -0.6
 
-/mob/living/basic/pet/cat/darkpack/protean // Meow :3
+/mob/living/basic/cat/protean // Meow :3 - This needs to be it's own mob completely as the cat subtype is horrendously bugged as a player.
+	name = "cat"
+	desc = "Kitty!!"
 	maxHealth = 300
 	health = 300
-	mob_size = MOB_SIZE_SMALL
 	speed = -0.8
-	melee_attack_cooldown = 8
-	random_cat_color = FALSE
+	melee_damage_lower = 10
+	melee_damage_upper = 10
+	melee_attack_cooldown = 4
+	mob_size = MOB_SIZE_SMALL
+	icon_state = "cat3"
+	base_icon_state = "cat"
+	icon = 'modular_darkpack/master_files/icons/mobs/simple/pets.dmi'
+	attack_verb_continuous = "claws"
+	attack_verb_simple = "claw"
+	attack_sound = 'sound/items/weapons/slash.ogg'
+	attack_vis_effect = ATTACK_EFFECT_CLAW
+
+/mob/living/basic/cat/protean/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/pet_bonus, "purr", /datum/mood_event/pet_animal)
+	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_CLAW)
+	AddElement(/datum/element/can_be_held)
+	AddElement(/datum/element/swing_attack)
 
 /datum/action/cooldown/spell/shapeshift/gangrel/beast_form/Grant(mob/grant_to)
 	. = ..()
@@ -43,9 +75,9 @@
 				/mob/living/basic/bear/vampire/protean,
 				/mob/living/basic/pet/dog/darkpack/protean,
 				/mob/living/basic/corvid/protean,
-				/mob/living/basic/pet/cat/darkpack/protean
+				/mob/living/basic/cat/protean
 			)
 		if(grant_to_human.is_clan(/datum/subsplat/vampire_clan/setite/tlacique)) // Host requested
 			possible_shapes += list(
-				/mob/living/basic/pet/cat/darkpack/protean
+				/mob/living/basic/cat/protean
 			)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8417,6 +8417,7 @@
 #include "modular_vcg\modules\powers\code\discipline\celerity\celerity_movespeed_modifier.dm"
 #include "modular_vcg\modules\powers\code\discipline\fortitude\fortitude.dm"
 #include "modular_vcg\modules\powers\code\discipline\potence\potence.dm"
+#include "modular_vcg\modules\powers\code\discipline\protean\beast_form.dm"
 #include "modular_vcg\modules\powers\code\discipline\vicissitude\arm_augments.dm"
 #include "modular_vcg\modules\powers\code\discipline\vicissitude\bonecrafting.dm"
 #include "modular_vcg\modules\powers\code\discipline\vicissitude\crafting_recipe.dm"


### PR DESCRIPTION

## About The Pull Request
This pr buffs all "fight" protean animal forms. Click cooldowns lowered across the board and varying amounts of speed and damage have been given to bear, wolf and dog form. Bear form can drag mobs without any slowdown. Adds a cat form with the niche of being a "flight" form that has no flight. Meow?
## Why It's Good For The Game
Right now there is no reason to use anything but bat form. Potency does not work with simplemob damage and currently their damage is incredibly low- currently any supernatural splat could shrug off a bear attack with bloodheal or fera regen. These forms should be scary, and the buffs attempt to give each one a niche of their own. Bears are tanky, Dogs are mobile, Wolves are in the middle of these two.

As for the cat form, mechanical variety in "flight" forms as well could be nice; a form for running away that doesn't rely on z level flight.
## Changelog
:cl:
add: Adds cat form to Shape of the Beast (Protean 4) for Gangrels and Tlacique!
balance: Protean "fight" animal forms move and attack faster and do more damage and wolves and bears have more health.
balance: Protean bear forms went to the gym and can drag with no slowdown.
/:cl:
