### PR TITLE
No more missing cargo

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -164,15 +164,15 @@
 
 	manifest_paper.add_raw_text(manifest_text)
 
-	// CRIMSON EDIT REMOVAL START - No More Missing Cargo
-	//if(manifest_paper.errors & MANIFEST_ERROR_ITEM)
-	//	if(HAS_TRAIT(container, TRAIT_NO_MISSING_ITEM_ERROR))
-	//		manifest_paper.errors &= ~MANIFEST_ERROR_ITEM
-	//	else
-	//		var/lost = max(round(container.contents.len / 10), 1)
-	//		while(--lost >= 0)
-	//			qdel(pick(container.contents))
-	// CRIMSON EDIT REMOVAL END - No More Missing Cargo
+	/* CRIMSON EDIT REMOVAL START - No More Missing Cargo
+	if(manifest_paper.errors & MANIFEST_ERROR_ITEM)
+		if(HAS_TRAIT(container, TRAIT_NO_MISSING_ITEM_ERROR))
+			manifest_paper.errors &= ~MANIFEST_ERROR_ITEM
+		else
+			var/lost = max(round(container.contents.len / 10), 1)
+			while(--lost >= 0)
+				qdel(pick(container.contents))
+	*/ // CRIMSON EDIT REMOVAL END - No More Missing Cargo
 
 	manifest_paper.update_appearance()
 	manifest_paper.forceMove(container)

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -164,13 +164,15 @@
 
 	manifest_paper.add_raw_text(manifest_text)
 
-	if(manifest_paper.errors & MANIFEST_ERROR_ITEM)
-		if(HAS_TRAIT(container, TRAIT_NO_MISSING_ITEM_ERROR))
-			manifest_paper.errors &= ~MANIFEST_ERROR_ITEM
-		else
-			var/lost = max(round(container.contents.len / 10), 1)
-			while(--lost >= 0)
-				qdel(pick(container.contents))
+	// CRIMSON EDIT REMOVAL START - No More Missing Cargo
+	//if(manifest_paper.errors & MANIFEST_ERROR_ITEM)
+	//	if(HAS_TRAIT(container, TRAIT_NO_MISSING_ITEM_ERROR))
+	//		manifest_paper.errors &= ~MANIFEST_ERROR_ITEM
+	//	else
+	//		var/lost = max(round(container.contents.len / 10), 1)
+	//		while(--lost >= 0)
+	//			qdel(pick(container.contents))
+	// CRIMSON EDIT REMOVAL END - No More Missing Cargo
 
 	manifest_paper.update_appearance()
 	manifest_paper.forceMove(container)


### PR DESCRIPTION

## About The Pull Request

Removed the chance for Supply orders to be lost (i.e. crate is delivered but it's empty or missing a number of items). 

## Why It's Good For The Game

It's not communicated to the player and it causes unnecessary player frustration, confusion, and loss with really no gameplay upside. Players have been successfully ahelping to get their ordered items back. In-game issues have been caused because of the unverifiability of this mechanic and of the randomness of its occurrence. Discord thread: https://discord.com/channels/1495925316273832099/1544278088269955113

## Changelog
:cl:
del: Removed the small chance of ordered supply crates arriving empty cargo or missing a portion of items
/:cl:
