### PR TITLE
Improves bloodheal against aggravated damage

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
+++ b/modular_darkpack/modules/powers/code/discipline/bloodheal/bloodheal.dm
@@ -1,5 +1,5 @@
 #define HEAL_BASHING_LETHAL_DAMAGE 30
-#define HEAL_AGGRAVATED_DAMAGE 6
+#define HEAL_AGGRAVATED_DAMAGE 15 // CRIMSON EDIT CHANGE - Original : 6
 
 /datum/discipline/bloodheal
 	name = "Bloodheal"


### PR DESCRIPTION

## About The Pull Request

Increase the bloodheal aggravated damage heal number slightly.

## Why It's Good For The Game

Whenever you fight a werewolf as vampire you will be left with tons of aggravated damage and most likely need to suck 4 npcs to death to be able to fix it with bloodheal, it is too much time consuming and inconvenient. Even worse is whenever a vampire dies and gets out of torpor with minimal amount of blood and they can never get out of crit unless someone finds them by luck and feeds them 3 npcs worth of blood by wrist. This PR just tweaks it a bit in the hopes of it can make this aggravated damage issue a bit less annoying to deal with.

## Changelog
:cl:
Changed the value of agg dmg healing on bloodheal
/:cl:
