### PR TITLE
[TM ONLY] You can only share clan innate disciplines

### DIFF
--- a/modular_darkpack/modules/vampire_the_masquerade/code/kindred/give_vitae.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/kindred/give_vitae.dm
@@ -74,6 +74,12 @@
 			continue
 		if(disc.type in seen_types)
 			continue
+		// CRIMSON GRID EDIT START - You can only share clan innate disciplines
+		var/mob/living/teacher = owner
+		var/datum/subsplat/vampire_clan/teacher_clan = teacher.get_clan()
+		if(!(disc.type in teacher_clan.clan_disciplines))
+			continue
+		// CRIMSON GRID EDIT END
 		seen_types += disc.type // prevent duplicates
 		discipline_entries += "[disc.name]"
 		disc_type["[disc.name]"] = disc.type


### PR DESCRIPTION
## About The Pull Request

makes it so you can only share disciplines if your clan has them innate
that means if trujah (for example) shares temporis, the person that got temporis will not be able to pass it to anyone else

trying to disc share temporis as tremere (it doesnt show up)
<img width="791" height="220" alt="image" src="https://github.com/user-attachments/assets/131ae490-b29a-4b4c-90c2-740b9255f393" />

## Why It's Good For The Game

STOP. SHARING. THAUMATURGY. I'M TIRED OF SEEING IT. THE TOWER HAS THAUMATURGY. I LOOK AT ENDRON THEY HAVE THAUMATURGY. I WAS IN ANARCHY ROSE, RIGHT? AND EVERYONE THERE JUST KNOWS THAUMATURGY STUFF. I WALK INTO TOWER AND I DO MY RITUAL AND EVERYONE GOES "WOW THAUMATURGY? I KNOW IT TOO". I FUCKING LOOK AT THE SABBAT AND THEY HAVE THAUMATURGY. I WALK INTO WOODS AND I SEE SEPT AND THEY KNOW THAUMATURGY. FUCK MY TREMERE LIFE.

## Changelog

:cl:
balance: You can only share starter disciplines of your clan
/:cl:
