### PR TITLE
De TG sprites San Fran (And Misc mapping changes)

### DIFF
--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -131,7 +131,7 @@
 /area/vtm/interior/wyrm_corrupted)
 "abB" = (
 /obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/lamp/green,
+/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "abD" = (
@@ -142,7 +142,7 @@
 "abG" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "abQ" = (
 /obj/structure/railing{
@@ -151,7 +151,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
 "abS" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/machinery/light/directional/north,
 /mob/living/carbon/human/npc/shop,
 /obj/effect/mapping_helpers/mob_buckler,
@@ -205,7 +205,7 @@
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/laundromat)
 "acJ" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -344,13 +344,6 @@
 	},
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/salubri)
-"aeI" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/closet/cardboard,
-/turf/open/floor/city/plating,
-/area/vtm/interior/strip)
 "aeP" = (
 /obj/effect/spawner/random/occult/artifact,
 /obj/item/melee/baseball_bat/vamp,
@@ -424,14 +417,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/cog/caern)
-"afH" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "afM" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/toy/redbutton,
@@ -477,9 +462,15 @@
 /turf/open/misc/grass,
 /area/vtm/outside/forest)
 "agl" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f2)
+"agp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "agr" = (
 /obj/effect/decal/pallet,
 /turf/open/misc/grass,
@@ -542,7 +533,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "ahl" = (
 /obj/machinery/light/small/directional/west,
@@ -579,7 +570,7 @@
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
 "ahy" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/plating/granite/black,
@@ -711,7 +702,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower)
 "ajk" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/misc/grass,
@@ -823,23 +814,6 @@
 "akw" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/outside/pacificheights/forest)
-"akx" = (
-/obj/structure/hedge,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 2
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "aky" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -850,7 +824,7 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
 "akA" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -932,7 +906,7 @@
 /area/vtm/interior/millennium_tower/ventrue)
 "alt" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "alu" = (
 /obj/effect/turf_decal/siding/white{
@@ -988,7 +962,7 @@
 	pixel_y = 8
 	},
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "amg" = (
 /obj/structure/railing{
@@ -1109,10 +1083,6 @@
 /obj/item/reagent_containers/blood/ab_plus,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/f3)
-"aoa" = (
-/obj/effect/decal/wallpaper/light,
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/trujah)
 "aob" = (
 /obj/structure/vampdoor/reinf,
 /obj/machinery/door/poddoor/preopen{
@@ -1224,7 +1194,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/giovanni/basement)
 "apL" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/shop/pharmacy)
 "apN" = (
 /obj/machinery/lift_indicator/directional/north{
@@ -1329,7 +1299,7 @@
 /area/vtm/interior/shop/gunshop)
 "arh" = (
 /obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "arj" = (
 /turf/open/floor/iron/stairs/right,
@@ -1341,7 +1311,7 @@
 	maxbloodpool = 10;
 	name = "Cain"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "aro" = (
 /obj/effect/turf_decal/bordur{
@@ -1469,7 +1439,7 @@
 /area/vtm/interior/sewer)
 "asA" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/carpet/darkpack/redsilver,
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "asD" = (
 /obj/structure/table,
@@ -1689,6 +1659,18 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/baali)
+"auT" = (
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/access/federal,
+/obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "ava" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -1750,6 +1732,16 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"avA" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "avB" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/city/plating,
@@ -1769,7 +1761,7 @@
 "avQ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "avT" = (
 /obj/effect/turf_decal/bordur{
@@ -1788,7 +1780,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
 "awb" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/rough,
@@ -1818,6 +1810,11 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/five,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
+"awq" = (
+/obj/structure/table/wood,
+/obj/machinery/fax/admin/fbi,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "awv" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth,
@@ -1895,7 +1892,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "axg" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
 "axk" = (
@@ -1946,10 +1943,10 @@
 /mob/living/carbon/human/npc/shop{
 	resistant_to_disciplines = 1
 	},
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "ayq" = (
 /obj/structure/railing{
@@ -1980,18 +1977,12 @@
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/music_store)
-"ayE" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/strip)
 "ayL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/machinery/light/dim/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "ayM" = (
 /obj/effect/turf_decal/bordur{
@@ -2159,10 +2150,6 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/plant)
-"aAG" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/chantry)
 "aAH" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/toilet,
@@ -2304,7 +2291,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/theatre)
 "aCX" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/city/church,
@@ -2439,10 +2426,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
-"aEq" = (
-/obj/weapon_showcase,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/museum)
 "aEv" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry/basement)
@@ -2515,7 +2498,7 @@
 	dir = 1;
 	pixel_y = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "aFr" = (
 /obj/structure/vampdoor/old,
@@ -2584,7 +2567,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
 "aGu" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
@@ -2646,7 +2629,7 @@
 "aHn" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "aHp" = (
 /obj/structure/coclock,
@@ -2683,7 +2666,7 @@
 /obj/underplate/stuff{
 	pixel_y = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "aHW" = (
 /obj/structure/vampdoor/simple{
@@ -2712,20 +2695,28 @@
 /obj/structure/hydrant,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
+"aIf" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/structure/platform/lowwall/old,
+/obj/structure/table,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/strip)
 "aIi" = (
 /obj/structure/table/wood,
 /obj/item/vampirebook/quran,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/banu)
 "aIl" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
 "aIo" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "aIr" = (
 /obj/effect/turf_decal/siding/white{
@@ -2749,7 +2740,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "aIz" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/rough,
@@ -2797,7 +2788,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
 "aJb" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/citizen/priest,
@@ -2813,7 +2804,7 @@
 "aJu" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "aJD" = (
 /obj/machinery/light/directional/north,
@@ -2854,8 +2845,19 @@
 /area/vtm/interior/chantry/basement)
 "aKk" = (
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
+"aKn" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/ammo_box/darkpack/arrows,
+/obj/item/ammo_box/darkpack/arrows,
+/obj/item/ammo_box/darkpack/arrows,
+/obj/item/ammo_box/darkpack/arrows,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/museum)
 "aKu" = (
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/city,
@@ -3008,6 +3010,13 @@
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f3)
+"aMo" = (
+/obj/effect/turf_decal/bordur/corner,
+/obj/structure/roofstuff/vent_end{
+	pixel_y = 6
+	},
+/turf/open/floor/plating/rough,
+/area/vtm)
 "aMr" = (
 /obj/effect/turf_decal/trimline/dark_green/corner{
 	dir = 1
@@ -3015,7 +3024,7 @@
 /turf/open/floor/iron/small,
 /area/vtm/interior/endron_facility/restricted)
 "aMu" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
@@ -3079,7 +3088,7 @@
 "aNs" = (
 /obj/machinery/jukebox,
 /obj/machinery/light/small/pink/directional/north,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "aNK" = (
 /turf/open/floor/plating/sidewalk/old,
@@ -3119,7 +3128,7 @@
 /turf/open/floor/cult,
 /area/vtm/interior/chantry/basement)
 "aOc" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/landmark/start/darkpack/citizen/club_worker,
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -3159,17 +3168,25 @@
 /turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "aOC" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/triad/red_pole,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"aOI" = (
+/obj/structure/retail/library{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "aOK" = (
-/turf/open/floor/city/toilet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/concrete,
 /area/vtm/interior/police/fed)
 "aON" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating_mono,
@@ -3302,14 +3319,8 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
 "aQs" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/platform/lowwall/bar,
-/obj/vampire_computer,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/trujah)
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "aQC" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/rough,
@@ -3331,7 +3342,7 @@
 /obj/effect/spawner/random/bedsheet/any,
 /obj/structure/bed,
 /obj/structure/coclock,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "aRc" = (
 /obj/structure/table/wood,
@@ -3354,6 +3365,16 @@
 /obj/item/clothing/mask/vampire/venetian_mask/jester,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic/haven)
+"aRs" = (
+/obj/effect/turf_decal/bordur/corner{
+	dir = 4
+	},
+/obj/structure/roofstuff/vent_end{
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/rough,
+/area/vtm)
 "aRv" = (
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/vampire/pentex_labcoat,
@@ -3408,7 +3429,7 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/tzimisce_manor)
 "aRH" = (
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
 "aRT" = (
@@ -3539,11 +3560,11 @@
 /area/vtm/interior/chantry/basement)
 "aSQ" = (
 /obj/structure/table/wood,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "aSU" = (
 /obj/effect/turf_decal/siding/grey{
@@ -3555,7 +3576,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "aTa" = (
 /obj/machinery/light/small/directional/east,
@@ -3598,17 +3619,21 @@
 /area/vtm/interior/shop/smoke_shop)
 "aTj" = (
 /obj/machinery/light/directional/west,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "aTm" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plating/granite/black,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/strip)
 "aTn" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "aTp" = (
@@ -3666,6 +3691,32 @@
 /obj/machinery/light/prince/directional/east,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/tzimisce_manor)
+"aUf" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/vampire/jacket/fbi,
+/obj/item/clothing/suit/vampire/jacket/fbi,
+/obj/item/clothing/suit/vampire/vest/police/fbivest,
+/obj/item/clothing/suit/vampire/vest/police/fbivest,
+/obj/item/clothing/mask/vampire/balaclava,
+/obj/item/clothing/mask/vampire/balaclava,
+/obj/item/ammo_box/darkpack/c9mm/plus,
+/obj/item/ammo_box/darkpack/c9mm/plus,
+/obj/item/binoculars,
+/obj/item/binoculars,
+/obj/item/ammo_box/darkpack/c45acp/hp,
+/obj/item/ammo_box/darkpack/c45acp/hp,
+/obj/item/clothing/head/vampire/darkpack_ert/swat_helmet/fbi,
+/obj/item/clothing/head/vampire/darkpack_ert/swat_helmet/fbi,
+/obj/item/clothing/under/vampire/police/fbi/utility,
+/obj/item/clothing/under/vampire/police/fbi/utility,
+/obj/item/clothing/under/vampire/police/fbi/pants,
+/obj/item/clothing/under/vampire/police/fbi/pants,
+/obj/item/clothing/under/vampire/police/fbi,
+/obj/item/clothing/under/vampire/police/fbi,
+/obj/item/storage/belt/security/police,
+/obj/item/storage/belt/security/police,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "aUi" = (
 /turf/open/misc/grass,
 /area/vtm/outside/northbeach)
@@ -3737,7 +3788,7 @@
 /area/vtm)
 "aUU" = (
 /mob/living/carbon/human/npc/bouncer/elysium/theatre,
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -3752,9 +3803,11 @@
 /area/vtm/interior/giovanni/basement)
 "aUZ" = (
 /obj/effect/turf_decal/siding/white{
-	dir = 9
+	dir = 1
 	},
-/obj/item/kirbyplants/random,
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
+	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "aVi" = (
@@ -3787,7 +3840,7 @@
 /area/vtm/graveyard)
 "aVz" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "aVI" = (
@@ -3812,7 +3865,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "aVW" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/pentex/sec,
@@ -3901,6 +3954,7 @@
 /obj/effect/turf_decal/darkpack/grass{
 	dir = 4
 	},
+/obj/item/seeds/poppy/lily,
 /turf/open/misc/dirt,
 /area/vtm)
 "aXH" = (
@@ -3960,7 +4014,7 @@
 "aYj" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "aYr" = (
 /obj/machinery/oven/range,
@@ -4005,7 +4059,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/npcwall,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "aZm" = (
 /obj/item/kirbyplants/random/dead{
@@ -4088,6 +4142,12 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"aZZ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "bac" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -4186,7 +4246,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/museum)
 "bbH" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/concrete,
@@ -4231,9 +4291,9 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/pawnshop)
 "bcq" = (
-/obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/open/floor/carpet,
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "bcr" = (
 /obj/structure/closet/crate/bin,
@@ -4301,9 +4361,15 @@
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/smoke_shop)
+"bdr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "bds" = (
 /obj/structure/table/wood,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
 "bdB" = (
@@ -4325,7 +4391,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "bdN" = (
 /obj/machinery/light/directional/north,
@@ -4342,6 +4408,11 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
+"bdU" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/item/seeds/poppy/geranium,
+/turf/open/misc/grass,
+/area/vtm)
 "bep" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
@@ -4435,10 +4506,6 @@
 /obj/effect/decal/support,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/tzimisce_manor)
-"bfe" = (
-/obj/item/lighter,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/hotel)
 "bff" = (
 /obj/structure/platform/lowwall/city/window,
 /turf/open/floor/plating/rough,
@@ -4552,7 +4619,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
 "bgp" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -4626,6 +4693,13 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/giovanni/courtyard)
+"bhz" = (
+/obj/structure/table/wood/fancy/cyan,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "bhG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4676,7 +4750,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "bip" = (
 /obj/structure/roadsign/warningpedestrian,
@@ -4967,7 +5041,7 @@
 "blP" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "blQ" = (
 /obj/machinery/light/directional/north,
@@ -5019,10 +5093,13 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
 "bmu" = (
-/obj/structure/table/modern,
-/obj/effect/spawner/random/occult/artifact,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/weapon_showcase,
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "bmx" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/grass,
@@ -5097,7 +5174,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
 "bna" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -5121,6 +5198,7 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/ten,
 /obj/effect/mapping_helpers/door/lock_difficulty/ten,
 /obj/effect/mapping_helpers/door/access/primogen_malkavian,
+/obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic/haven)
 "bns" = (
@@ -5129,7 +5207,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "bnt" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/techshop)
 "bnv" = (
 /obj/structure/toilet{
@@ -5260,10 +5338,6 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior)
-"bpj" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "bpk" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 8
@@ -5294,10 +5368,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
 "bpz" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
+/obj/structure/chair/sofa/corp/right{
+	dir = 8;
+	color = "#CD5C5C"
 	},
-/turf/open/floor/plating/granite/black,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/strip)
 "bpF" = (
 /obj/effect/turf_decal/siding/white{
@@ -5479,7 +5554,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "brD" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
@@ -5491,6 +5566,18 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
+"brI" = (
+/obj/structure/vampdoor/simple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "brJ" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/carpet/darkpack/old,
@@ -5555,7 +5642,7 @@
 /obj/structure/table/wood,
 /obj/item/masquerade_contract,
 /obj/vampire_computer,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "bsy" = (
 /turf/open/floor/wood/smooth,
@@ -5616,7 +5703,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
 "btF" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -5631,7 +5718,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "btP" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/concrete,
@@ -5643,7 +5730,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
 "btU" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/plant)
 "bug" = (
@@ -5668,9 +5755,8 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "buv" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/triad/blue_lanterns,
 /turf/open/floor/plating/concrete,
@@ -5709,9 +5795,11 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
 "buS" = (
-/obj/structure/chair,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "buY" = (
 /obj/fusebox,
 /turf/open/floor/wood/smooth/old,
@@ -5903,7 +5991,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "bxr" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5981,7 +6069,7 @@
 /area/vtm/interior/shop/gummaguts)
 "bym" = (
 /obj/structure/table/wood/fancy/red,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "byn" = (
 /turf/open/floor/wood/smooth/old,
@@ -6005,7 +6093,7 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/chinatown)
 "byv" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/bacotell,
@@ -6065,13 +6153,11 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/clothing_store)
 "byX" = (
-/obj/structure/stairs/west{
-	dir = 1
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/effect/decal/wallpaper/paper/fancy/stripe,
+/turf/closed/wall/vampwall/rich/old,
+/area/vtm/interior/museum)
 "bzd" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/police_armory_guy,
@@ -6098,9 +6184,14 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/graveyard)
+"bzo" = (
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "bzp" = (
+/obj/structure/stairs/east,
 /turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "bzD" = (
 /obj/machinery/light/prince/directional/west,
 /obj/structure/chair/pew/right{
@@ -6108,10 +6199,14 @@
 	},
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
+"bzF" = (
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "bzN" = (
 /obj/structure/dresser,
 /obj/item/storage/box/aquarium_props,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "bzU" = (
 /obj/structure/vampdoor/simple{
@@ -6158,7 +6253,7 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/prince/directional/north,
 /obj/item/reagent_containers/cup/glass/baggie/meth/cocaine,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "bAi" = (
 /obj/structure/chair/sofa/left/brown,
@@ -6227,6 +6322,15 @@
 /obj/structure/platform/lowwall/rich/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"bAW" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "bAY" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -6259,10 +6363,10 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/old)
 "bBf" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "bBl" = (
 /obj/structure/table/wood,
@@ -6397,7 +6501,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/endron_facility/restricted)
 "bCR" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cardboard,
@@ -6633,7 +6737,7 @@
 /area/vtm/interior/endron_facility/restricted)
 "bGN" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "bGY" = (
 /obj/structure/fence/door{
@@ -6669,6 +6773,13 @@
 /obj/item/reagent_containers/cup/glass/baggie/meth/cocaine,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/police)
+"bHr" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "bHt" = (
 /obj/structure/railing{
 	dir = 8;
@@ -6687,7 +6798,7 @@
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic)
 "bHC" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -6723,7 +6834,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "bId" = (
 /obj/machinery/sprinkler/area_managed,
@@ -6787,7 +6898,7 @@
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/jazzclub)
 "bIE" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/city/church,
@@ -6821,7 +6932,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "bIY" = (
 /obj/structure/stairs/west,
@@ -6924,7 +7035,7 @@
 /area/vtm/interior/millennium_tower/f2)
 "bKC" = (
 /obj/effect/decal/pallet,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /mob/living/carbon/human/npc/guard,
@@ -6976,10 +7087,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "bLe" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -7056,7 +7167,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm)
 "bLX" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/roofwalk/cobblestones,
@@ -7077,10 +7188,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "bMn" = (
-/obj/machinery/light/directional/east,
-/obj/structure/hedge,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/item/gun/ballistic/revolver/darkpack/magnum{
+	pin = null
+	},
+/turf/open/misc/beach/sand,
+/area/vtm/interior/museum)
 "bMx" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -7111,7 +7223,7 @@
 "bMM" = (
 /obj/structure/bed,
 /obj/machinery/light/warm/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "bMP" = (
 /obj/structure/table/wood,
@@ -7326,7 +7438,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/community)
 "bQc" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -7338,7 +7450,7 @@
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry/basement)
 "bQi" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth,
@@ -7353,7 +7465,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -7384,13 +7496,19 @@
 /obj/structure/table/wood,
 /obj/item/camera/detective,
 /obj/item/camera/detective,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "bRd" = (
-/obj/machinery/light/directional/west,
-/obj/weapon_showcase,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/food/burger/rib{
+	pixel_y = 5;
+	name = "stale mcrib"
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "bRh" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -7428,18 +7546,12 @@
 "bRG" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/item/ammo_box/darkpack/c50,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "bRI" = (
 /obj/effect/decal/support,
 /turf/open/misc/grass,
 /area/vtm/outside/northbeach)
-"bRL" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "bRM" = (
 /obj/item/kirbyplants/random,
 /obj/structure/railing{
@@ -7491,7 +7603,7 @@
 "bSx" = (
 /obj/machinery/light/directional/west,
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
 "bSC" = (
@@ -7550,7 +7662,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/granite/black,
@@ -7699,12 +7811,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "bUX" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/floor/plating/granite/black,
+/turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
 "bVb" = (
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -7982,6 +8089,10 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
+"bXn" = (
+/obj/effect/decal/wallpaper/grey,
+/turf/closed/wall/vampwall/rich/old,
+/area/vtm/interior/museum)
 "bXC" = (
 /obj/structure/rack/tall/store_shelf_metal,
 /obj/item/clothing/suit/vampire/vest{
@@ -8053,7 +8164,7 @@
 /obj/item/reagent_containers/cup/glass/bottle/wine,
 /obj/item/reagent_containers/cup/glass/bottle/wine,
 /obj/item/storage/box/drinkingglasses,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "bYc" = (
 /obj/effect/decal/pallet{
@@ -8103,7 +8214,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/endron_facility/restricted)
 "bYD" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -8289,7 +8400,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "cbj" = (
 /obj/structure/stairs/east,
@@ -8313,7 +8424,7 @@
 /area/vtm/interior/salubri)
 "cbE" = (
 /obj/structure/chair/sofa/corp/right,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "cbJ" = (
 /obj/effect/turf_decal/siding/white,
@@ -8390,7 +8501,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "cdd" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
 "cdv" = (
@@ -8428,9 +8539,8 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/upstairs)
 "cdA" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
@@ -8485,8 +8595,9 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "cek" = (
-/obj/structure/table,
-/obj/effect/spawner/random/occult/artifact,
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "cen" = (
@@ -8494,7 +8605,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/ventrue)
 "ceo" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
@@ -8564,7 +8675,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "cfm" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -8736,7 +8847,9 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/clinic/haven)
 "chz" = (
-/mob/living/carbon/human/npc/shop,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "chB" = (
@@ -8919,6 +9032,7 @@
 	pixel_y = -6
 	},
 /obj/item/cultivator/rake,
+/obj/item/seeds/rose,
 /turf/open/misc/grass,
 /area/vtm)
 "ckf" = (
@@ -9016,7 +9130,7 @@
 /obj/structure/railing{
 	pixel_y = -2
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -9171,6 +9285,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
+/obj/structure/carving_block,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "cnm" = (
@@ -9203,7 +9318,7 @@
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/f2)
 "cnt" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
 "cnA" = (
@@ -9227,7 +9342,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/financialdistrict)
 "cnQ" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
@@ -9291,7 +9406,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/baali)
 "coO" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/plating/concrete,
@@ -9357,6 +9472,15 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
+"cpu" = (
+/obj/structure/chair/office/darkpack/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "cpD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -9565,7 +9689,7 @@
 /area/vtm/interior/sewer)
 "csF" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/setite)
 "csJ" = (
 /obj/structure/coclock,
@@ -9599,10 +9723,10 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "ctc" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/landmark/start/darkpack/triad/blue_lanterns,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
@@ -9638,16 +9762,6 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
-"ctx" = (
-/obj/structure/table/modern,
-/obj/machinery/light/directional/west,
-/obj/item/claymore/longsword{
-	anchored = 1;
-	desc = "A classic weapon of knightly use. Now a museum piece, supposedly a donation from the Old Church by the pier.";
-	name = "Old longsword"
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/museum)
 "ctB" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -9744,6 +9858,14 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
+"cuA" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "cuJ" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -9830,6 +9952,7 @@
 /area/vtm/interior/jazzclub)
 "cwn" = (
 /obj/structure/vampdoor/old,
+/obj/effect/mapping_helpers/door/access/malkavian,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
 "cwp" = (
@@ -9978,7 +10101,7 @@
 /area/vtm)
 "cyc" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/tzimisce_manor)
 "cyg" = (
 /obj/effect/turf_decal/bordur{
@@ -10007,11 +10130,8 @@
 /turf/open/floor/plating,
 /area/vtm/interior/clinic/haven)
 "cyA" = (
-/obj/structure/pole{
-	pixel_w = -16
-	},
-/mob/living/carbon/human/npc/stripper,
-/turf/open/floor/plating/granite/black,
+/obj/structure/table,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/strip)
 "cyC" = (
 /obj/structure/chair/sofa/right/brown,
@@ -10075,13 +10195,6 @@
 /obj/effect/turf_decal/siding/grey,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
-"czj" = (
-/obj/structure/chair/comfy/brown{
-	color = "#50C878";
-	dir = 8
-	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "czm" = (
 /obj/structure/table,
 /obj/structure/fluff/tv{
@@ -10223,7 +10336,7 @@
 "cBa" = (
 /obj/structure/bookcase/random/religion,
 /obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "cBo" = (
 /obj/effect/decal/cleanable/trash,
@@ -10260,7 +10373,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "cBI" = (
 /obj/machinery/light/small/directional/east,
@@ -10317,7 +10430,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "cCE" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -10372,7 +10485,7 @@
 /area/vtm/interior/mansion)
 "cDr" = (
 /obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "cDt" = (
 /obj/effect/turf_decal/bordur{
@@ -10440,7 +10553,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "cEr" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -10455,9 +10568,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"cEB" = (
-/turf/open/openspace,
-/area/vtm/interior/trujah)
 "cED" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/turf_decal/weather/dirt{
@@ -10678,7 +10788,7 @@
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "cHf" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -10792,13 +10902,13 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "cIl" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "cIm" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic/haven)
@@ -10911,7 +11021,7 @@
 "cKa" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/baali)
 "cKh" = (
 /obj/effect/turf_decal/siding/white{
@@ -10946,17 +11056,17 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
 "cKv" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "cKw" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/grey{
 	dir = 10
+	},
+/obj/structure/chair/darkpack/blue{
+	dir = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic)
@@ -10987,7 +11097,7 @@
 /area/vtm/outside/park)
 "cKP" = (
 /obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "cLa" = (
 /obj/effect/turf_decal/siding/wood{
@@ -11028,7 +11138,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/church/haven)
 "cLC" = (
 /obj/structure/rack/clothing/rand{
@@ -11078,7 +11188,7 @@
 /area/vtm/interior/millennium_tower/f4)
 "cLJ" = (
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "cLX" = (
 /obj/effect/decal/cleanable/trash{
@@ -11093,11 +11203,14 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/community)
+"cMn" = (
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "cMr" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "cMt" = (
 /obj/effect/landmark/npcwall,
@@ -11112,7 +11225,7 @@
 "cMC" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "cME" = (
 /obj/structure/chair/office/darkpack/red{
@@ -11200,21 +11313,6 @@
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
-"cNw" = (
-/obj/structure/hedge,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 2
-	},
-/obj/machinery/light/prince/directional/south,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "cNA" = (
 /obj/effect/decal/rugs,
 /obj/machinery/camera/directional/north{
@@ -11233,6 +11331,13 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
+"cNK" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/structure/carving_block,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "cNN" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth,
@@ -11258,15 +11363,8 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/cog/pantry)
-"cOj" = (
-/obj/structure/curtain/bounty,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "cOq" = (
-/obj/structure/table,
+/obj/structure/table/wood,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "cOC" = (
@@ -11306,7 +11404,7 @@
 "cOQ" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/cannabis,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "cPh" = (
 /obj/structure/flora/bush/stalky/style_random,
@@ -11398,15 +11496,8 @@
 "cQK" = (
 /obj/structure/bookcase/random/religion,
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
-"cQR" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/vampdoor/simple,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "cRf" = (
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/chantry/basement)
@@ -11417,11 +11508,22 @@
 "cRE" = (
 /obj/structure/table,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
+"cRF" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/vampdoor/old,
+/obj/effect/mapping_helpers/door/access/chantry,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/bash_difficulty/seven,
+/obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior/library)
 "cRG" = (
-/obj/effect/decal/shadow,
-/turf/open/openspace,
+/obj/machinery/jukebox,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/strip)
 "cRK" = (
 /obj/effect/landmark/event_spawn/sarcophagus,
@@ -11433,7 +11535,7 @@
 /turf/open/misc/beach/vamp,
 /area/vtm)
 "cRP" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -11493,7 +11595,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/jazzclub)
 "cSu" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/banu/haven)
 "cSx" = (
@@ -11556,7 +11658,7 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	pixel_y = -6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "cTr" = (
 /obj/structure/ladder/manhole/up,
@@ -11601,6 +11703,10 @@
 /obj/lettermachine,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/pawnshop)
+"cTM" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "cTT" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 4
@@ -11608,7 +11714,7 @@
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/clinic)
 "cTV" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -11698,11 +11804,11 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f3)
 "cUX" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "cVa" = (
 /obj/machinery/light/directional/north,
@@ -11718,7 +11824,7 @@
 /area/vtm/outside/fishermanswharf/ghetto)
 "cVm" = (
 /obj/effect/landmark/start/darkpack/supply/dealer,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /obj/effect/decal/carpet,
@@ -11774,7 +11880,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/table,
+/obj/structure/table/wood,
 /turf/open/floor/city/plating,
 /area/vtm/interior/museum)
 "cWr" = (
@@ -12040,6 +12146,13 @@
 /obj/item/food/grown/cannabis,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/police)
+"dbm" = (
+/obj/structure/hedge,
+/obj/machinery/light/directional/east,
+/obj/structure/decoration/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "dbz" = (
 /obj/effect/turf_decal/bordur,
 /obj/darkpack_car/track/volkswagen,
@@ -12081,6 +12194,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
+"dbT" = (
+/obj/structure/hedge,
+/obj/effect/decal/painting/third{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/decoration/bush/flowers_pp/style_random,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "dbV" = (
 /obj/effect/decal/support,
 /obj/structure/railing{
@@ -12142,7 +12265,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
 "dcP" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -12358,7 +12481,7 @@
 /area/vtm/interior/banu/haven)
 "dfe" = (
 /obj/effect/landmark/navigate_destination,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "dfj" = (
 /obj/structure/chair/pew/left{
@@ -12489,7 +12612,7 @@
 /area/vtm/interior/shop/smoke_shop)
 "dgC" = (
 /obj/effect/turf_decal/siding/white,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "dgM" = (
 /obj/structure/rack,
@@ -12501,7 +12624,7 @@
 	pixel_x = 7;
 	pixel_y = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/shop/pharmacy)
 "dgW" = (
 /obj/structure/table,
@@ -12529,7 +12652,10 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
 "dha" = (
-/obj/structure/table/glass,
+/obj/structure/retail/smoke_menu{
+	dir = 1
+	},
+/obj/structure/table,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "dhb" = (
@@ -12596,8 +12722,17 @@
 	},
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
+"dic" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "dih" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -12606,7 +12741,7 @@
 /area/vtm/outside/fishermanswharf/lower)
 "dii" = (
 /obj/effect/decal/cleanable/trash,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "din" = (
 /obj/machinery/atm{
@@ -12663,7 +12798,7 @@
 /turf/open/misc/dirt,
 /area/vtm)
 "diX" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
@@ -12674,9 +12809,13 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "djg" = (
-/obj/structure/chair/sofa/corp/right,
-/mob/living/carbon/human/npc/incel,
-/turf/open/floor/plating/granite/black,
+/obj/effect/turf_decal/siding/grey/inner_corner{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/strip)
 "dji" = (
 /obj/effect/turf_decal/bordur/end{
@@ -12746,23 +12885,6 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
-"dkE" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/closet,
-/obj/item/clothing/suit/vampire/jacket/fbi,
-/obj/item/clothing/suit/vampire/jacket/fbi,
-/obj/item/clothing/suit/vampire/vest/police/fbivest,
-/obj/item/clothing/suit/vampire/vest/police/fbivest,
-/obj/item/clothing/mask/vampire/balaclava,
-/obj/item/clothing/mask/vampire/balaclava,
-/obj/item/ammo_box/darkpack/c45acp,
-/obj/item/ammo_box/darkpack/c9mm/plus,
-/obj/item/storage/box/evidence,
-/obj/item/storage/box/evidence,
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "dkH" = (
 /obj/effect/decal/rugs,
 /turf/open/floor/city/plating_mono,
@@ -12866,6 +12988,11 @@
 /obj/machinery/light/red/directional/north,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f3)
+"dlN" = (
+/obj/structure/hedge,
+/obj/structure/ladder/manhole/down,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/strip)
 "dlW" = (
 /obj/machinery/light/directional/north,
 /obj/structure/dresser,
@@ -12876,7 +13003,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "dmd" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -12897,7 +13024,7 @@
 /area/vtm/interior/tzimisce_manor)
 "dmg" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "dml" = (
 /obj/effect/turf_decal/bordur{
@@ -12980,7 +13107,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "dnH" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -12997,11 +13124,15 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "dnT" = (
-/obj/effect/decal/wallpaper/stone/low,
-/obj/structure/curtain/cloth/fancy,
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/trujah)
+/obj/item/clothing/suit/vampire/noddist,
+/obj/item/clothing/suit/vampire/noddist,
+/obj/item/clothing/suit/vampire/noddist,
+/obj/effect/turf_decal/siding/grey{
+	dir = 5
+	},
+/obj/structure/table/wood/fancy/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "dnU" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/rough/cave,
@@ -13120,6 +13251,10 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
+"dpo" = (
+/obj/structure/bury_pit,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "dpp" = (
 /obj/structure/table,
 /obj/item/cigarette/rollie/cannabis,
@@ -13188,9 +13323,9 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
 "dpT" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /mob/living/carbon/human/npc/business,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "dqa" = (
 /obj/structure/hedge,
@@ -13269,10 +13404,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/tzimisce_manor)
-"dqK" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/hotel)
 "dqM" = (
 /obj/structure/vampfence/corner{
 	dir = 1
@@ -13287,7 +13418,7 @@
 /area/vtm/interior/tzimisce_manor)
 "dqZ" = (
 /obj/effect/decal/cleanable/cardboard,
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/structure/cable/layer1,
@@ -13306,7 +13437,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "drv" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -13340,11 +13471,11 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior)
 "drS" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "drT" = (
 /obj/machinery/light/directional/west,
@@ -13360,8 +13491,18 @@
 /obj/structure/table/wood,
 /obj/item/melee/vamp/tire,
 /obj/item/melee/vamp/tire,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
+"dsf" = (
+/obj/effect/spawner/random/occult/artifact,
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 1;
+	pixel_y = 32
+	},
+/obj/structure/platform/lowwall/brick,
+/obj/structure/table/wood,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "dsk" = (
 /obj/item/bikehorn/rubberducky,
 /obj/structure/railing{
@@ -13393,7 +13534,7 @@
 	},
 /obj/item/flashlight,
 /obj/structure/coclock,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "dsw" = (
 /turf/open/floor/carpet/red,
@@ -13445,6 +13586,7 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/one,
 /obj/effect/mapping_helpers/door/bash_difficulty/ten,
 /obj/effect/mapping_helpers/door/access/primogen_malkavian,
+/obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic/haven)
 "dtG" = (
@@ -13464,6 +13606,21 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
+"dtY" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/access/kiasyd,
+/obj/structure/vampdoor/wood,
+/obj/effect/mapping_helpers/door/bash_difficulty/six,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/turf_decal/siding/grey{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/grey,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "dtZ" = (
 /obj/structure/rack/clothing_hanger,
 /turf/open/floor/wood/smooth/old,
@@ -13614,9 +13771,9 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
 "dvL" = (
-/obj/structure/platform/lowwall/market/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/trujah)
+/obj/effect/decal/wallpaper/paper/fancy/red,
+/turf/closed/wall/vampwall/rich/old,
+/area/vtm/interior/museum)
 "dvM" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/northbeach)
@@ -13733,6 +13890,15 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
+"dxv" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire,
+/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/museum)
 "dxy" = (
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/baali)
@@ -13754,11 +13920,11 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
 "dxQ" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /mob/living/carbon/human/npc/business,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "dxT" = (
 /obj/machinery/light/small/directional/east,
@@ -13772,7 +13938,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer/nosferatu_town)
 "dxZ" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "dya" = (
@@ -13788,6 +13954,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower)
+"dyq" = (
+/obj/machinery/light/small/pink/directional/east,
+/obj/structure/chair/sofa/corp/left{
+	color = "#CD5C5C";
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/strip)
 "dyB" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
@@ -13833,18 +14007,6 @@
 /obj/structure/platform/lowwall/old/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/chantry)
-"dzd" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/machinery/light/small/directional/west,
-/obj/item/clothing/under/costume/redcoat,
-/obj/structure/sign/flag/usa{
-	pixel_y = 32
-	},
-/turf/open/floor/city/toilet,
-/area/vtm/interior/museum)
 "dze" = (
 /obj/structure/bed/medical/emergency,
 /obj/item/bodybag,
@@ -13930,31 +14092,23 @@
 /obj/structure/vampfence/corner,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
-"dzK" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8;
-	color = "#636363"
-	},
-/obj/structure/vampdoor/simple{
-	dir = 8
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/museum)
 "dzV" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/city/plating,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/museum)
 "dzX" = (
 /obj/structure/bed/medical/emergency,
 /turf/open/floor/city/circled,
 /area/vtm/interior/setite/basement)
-"dAi" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/museum)
 "dAn" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sink/directional/south,
@@ -13988,7 +14142,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/fishermanswharf/lower)
 "dAN" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "dAR" = (
 /obj/machinery/light/small/directional/west,
@@ -14046,9 +14200,8 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
 "dCa" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
@@ -14209,7 +14362,7 @@
 /obj/item/clothing/under/suit/tan,
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/suit/white,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "dDX" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -14447,7 +14600,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -14502,7 +14655,7 @@
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/tzimisce_sanctum)
 "dIr" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/tzimisce_manor)
 "dIx" = (
 /obj/effect/turf_decal/siding/white{
@@ -14516,7 +14669,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
 "dID" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/plating/concrete,
@@ -14690,6 +14843,17 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
+"dKg" = (
+/obj/structure/sign/flag/usa{
+	pixel_y = 29;
+	pixel_x = 19
+	},
+/obj/weapon_showcase,
+/obj/structure/railing/darkpack/metal{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "dKk" = (
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalkalt,
@@ -14743,7 +14907,7 @@
 /area/vtm/interior/hotel)
 "dKW" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/shop/pharmacy)
 "dKX" = (
 /obj/effect/spawner/random/occult/artifact,
@@ -14760,7 +14924,7 @@
 /area/vtm/interior/anarch/basement)
 "dLg" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "dLh" = (
 /obj/structure/table,
@@ -14915,6 +15079,16 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
+"dNd" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/structure/platform/lowwall/brick,
+/obj/structure/vampstatue{
+	pixel_y = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "dNf" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -14932,7 +15106,7 @@
 /turf/open/openspace,
 /area/vtm/interior/techshop)
 "dNp" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/rough,
@@ -14947,7 +15121,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -14998,7 +15172,7 @@
 /area/vtm/interior/shop/flower_shop)
 "dOl" = (
 /obj/effect/landmark/start/darkpack/citizen/citizen,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "dOw" = (
 /obj/structure/table/wood/fancy/red,
@@ -15031,10 +15205,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
-"dPn" = (
-/obj/effect/landmark/start/darkpack/law_enforcement/fbi,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/police/fed)
 "dPo" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 1
@@ -15054,7 +15224,7 @@
 "dPv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "dPw" = (
 /obj/machinery/light/prince/directional/north,
@@ -15176,7 +15346,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -15201,9 +15371,8 @@
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/wyrm_corrupted)
 "dQT" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
@@ -15362,9 +15531,9 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/banu/haven)
 "dTq" = (
-/obj/effect/turf_decal/siding/white,
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/city/toilet,
+/obj/structure/closet,
+/obj/item/storage/box/evidence,
+/turf/open/misc/dirt,
 /area/vtm/interior/police/fed)
 "dTr" = (
 /obj/effect/turf_decal/siding/white{
@@ -15424,7 +15593,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "dTW" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
@@ -15435,7 +15604,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
 "dUf" = (
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "dUg" = (
 /obj/effect/turf_decal/bordur{
@@ -15523,7 +15692,7 @@
 /turf/open/floor/city/industrial,
 /area/vtm/interior/shop/hardware_store)
 "dVw" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/cardboard,
@@ -15566,7 +15735,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "dWa" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/old,
@@ -15577,6 +15746,21 @@
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
+"dWc" = (
+/obj/structure/filingcabinet/medical{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/filingcabinet/security{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/filingcabinet/medical{
+	pixel_x = -11;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "dWf" = (
 /obj/structure/hedge,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -15802,7 +15986,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "dZd" = (
 /obj/effect/turf_decal/bordur/corner,
@@ -15892,7 +16076,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "eaA" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/ornate,
@@ -15943,7 +16127,7 @@
 /area/vtm/interior)
 "eaK" = (
 /obj/structure/closet/cardboard,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "eaL" = (
 /obj/machinery/vending/cola{
@@ -15953,7 +16137,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "eaR" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/trash{
@@ -15966,10 +16150,6 @@
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"eaY" = (
-/obj/structure/mannequin/plastic/napoleon,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/museum)
 "ebg" = (
 /obj/structure/railing{
 	dir = 8
@@ -15986,6 +16166,10 @@
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
+"ebl" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "ebo" = (
 /turf/open/floor/plating/sidewalkalt{
 	color = "#8a8a8a"
@@ -16066,7 +16250,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "eci" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer)
@@ -16087,7 +16271,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "ecG" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/city/plating_mono,
@@ -16131,7 +16315,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "edn" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -16252,7 +16436,7 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
 "eeP" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/police/static,
@@ -16358,7 +16542,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "efY" = (
 /obj/effect/decal/cleanable/blood,
@@ -16382,7 +16566,7 @@
 	pixel_y = 8
 	},
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "egm" = (
 /obj/structure/vampdoor/reinf{
@@ -16453,7 +16637,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
 "eha" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -16582,14 +16766,6 @@
 "eiL" = (
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/jazzclub)
-"eiP" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/open/floor/light,
-/area/vtm/interior/strip)
 "eiR" = (
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/f3)
@@ -16615,7 +16791,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer)
 "ejo" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/hobo,
@@ -16680,7 +16856,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/endron_facility/restricted)
 "ekf" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -16707,6 +16883,14 @@
 /obj/structure/curtain/cloth,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior)
+"ekv" = (
+/mob/living/carbon/human/npc/shop,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/structure/chair/office/darkpack/black,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "ekG" = (
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/city/industrial,
@@ -16723,7 +16907,7 @@
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/clinic/haven)
 "ekL" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -16753,8 +16937,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet,
+/obj/structure/chair/stool/bar/darkpack/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/setite)
 "elu" = (
 /obj/effect/landmark/npcactivity,
@@ -16784,7 +16968,7 @@
 /area/vtm/interior)
 "elM" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/ghetto)
 "elR" = (
 /obj/structure/table/wood/fancy/black,
@@ -16860,6 +17044,40 @@
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"emP" = (
+/obj/structure/table,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/obj/item/camera_film{
+	pixel_y = 12;
+	pixel_x = -5
+	},
+/obj/item/taperecorder{
+	pixel_y = 12;
+	pixel_x = 9
+	},
+/obj/item/camera_film{
+	pixel_y = 12;
+	pixel_x = -5
+	},
+/obj/item/taperecorder{
+	pixel_y = 12;
+	pixel_x = 9
+	},
+/obj/item/camera{
+	pixel_y = -1;
+	pixel_x = -11
+	},
+/obj/item/camera{
+	pixel_y = -1;
+	pixel_x = -11
+	},
+/obj/item/detective_scanner/darkpack,
+/obj/item/detective_scanner/darkpack,
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "emW" = (
 /mob/living/carbon/human/npc/business,
 /turf/open/floor/plating/rough/cave,
@@ -17019,6 +17237,9 @@
 /obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled,
 /turf/open/misc/sandy_dirt,
 /area/vtm/interior/bianchiBank)
+"eoG" = (
+/turf/closed/wall/vampwall/rich/old,
+/area/vtm/interior/library)
 "eoL" = (
 /obj/structure/railing{
 	dir = 8
@@ -17213,11 +17434,11 @@
 "ers" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "ert" = (
 /obj/effect/landmark/start/darkpack/supply/tech,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /obj/effect/decal/rugs,
@@ -17235,14 +17456,17 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
 "erZ" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
 "esa" = (
-/turf/open/floor/wood/old,
-/area/vtm/interior/trujah)
+/obj/machinery/modular_computer/preset/curator{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "esd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -17250,7 +17474,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "esg" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /turf/open/floor/city/circled,
 /area/vtm/interior/salubri)
 "esp" = (
@@ -17314,12 +17538,12 @@
 	},
 /obj/structure/table/wood/fancy/black,
 /obj/item/ammo_box/darkpack/c50ae,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "etL" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/machinery/light/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/baali)
 "etQ" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -17512,6 +17736,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/endron_facility/restricted)
+"ewD" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/carving_block,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "ewI" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop)
@@ -17549,7 +17780,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "exf" = (
 /obj/structure/bed,
@@ -17558,7 +17789,7 @@
 "exj" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "exk" = (
 /obj/structure/platform/lowwall/city/window,
@@ -17602,7 +17833,7 @@
 "exB" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "exJ" = (
 /obj/structure/vampfence/rich{
 	dir = 8
@@ -17614,7 +17845,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "exW" = (
 /obj/structure/table/wood/fancy,
@@ -17728,7 +17959,7 @@
 "ezt" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/coclock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "ezG" = (
 /mob/living/basic/pet/cat/darkpack,
@@ -17742,6 +17973,12 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
+"ezY" = (
+/obj/structure/sign/painting/large{
+	pixel_y = 32
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "ezZ" = (
 /obj/structure/table/wood,
 /obj/item/folder/documents,
@@ -17801,7 +18038,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood/fancy/black,
 /obj/item/vampirebook/bible,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "eAC" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/end{
@@ -17818,7 +18055,7 @@
 /turf/closed/wall/vampwall/rock,
 /area/vtm)
 "eBp" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -17869,6 +18106,14 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
+"eCl" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/vending/snack{
+	pixel_y = 20;
+	density = 0
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/museum)
 "eCn" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/city/toilet,
@@ -17895,13 +18140,6 @@
 /obj/structure/vampdoor/simple,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"eCD" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/police/fed)
 "eCE" = (
 /obj/structure/arc{
 	dir = 5
@@ -17978,7 +18216,7 @@
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/blood/vitae,
 /obj/item/reagent_containers/blood/vitae,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "eDr" = (
 /obj/structure/table,
@@ -17998,6 +18236,10 @@
 /obj/structure/hedge,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/library)
+"eDE" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "eDI" = (
 /obj/structure/hedge{
 	pixel_y = 6
@@ -18021,7 +18263,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "eDS" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /mob/living/carbon/human/npc/shop,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/pawnshop)
@@ -18067,7 +18309,7 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights/community)
 "eEr" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/setite)
 "eEu" = (
 /obj/structure/closet/crate/bin,
@@ -18107,7 +18349,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
 "eEL" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/decal/carpet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
@@ -18474,7 +18716,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
 "eJj" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "eJq" = (
 /obj/structure/mirror{
@@ -18498,7 +18740,7 @@
 /area/vtm/interior/millennium_tower)
 "eJT" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "eJX" = (
 /obj/structure/table,
@@ -18596,7 +18838,7 @@
 "eKL" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "eKQ" = (
 /turf/open/water/beach/vamp/deep,
@@ -18621,7 +18863,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -18638,6 +18880,10 @@
 /obj/structure/flora/rock/darkpack,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
+"eLl" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/city/toilet,
+/area/vtm/interior/museum)
 "eLs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -18868,12 +19114,6 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
-"eOk" = (
-/obj/transfer_point_vamp/umbral/exit{
-	id = "umbra_dora"
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "eOl" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/smooth/old,
@@ -18902,7 +19142,7 @@
 /area/vtm/interior/police)
 "eOE" = (
 /obj/machinery/light/small/red/directional/south,
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/misc/dirt,
 /area/vtm/interior/sewer/nosferatu_town)
 "eOF" = (
@@ -18964,6 +19204,14 @@
 /obj/effect/turf_decal/siding/wood/dark/corner,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic)
+"ePk" = (
+/obj/structure/table,
+/turf/open/floor/city/plating,
+/area/vtm/interior/strip)
+"ePv" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "ePC" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -18986,13 +19234,13 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior)
 "ePG" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/grey{
 	dir = 5
 	},
 /obj/effect/landmark/start/darkpack/hospital/clinic_guard,
+/obj/structure/chair/darkpack/blue{
+	dir = 8
+	},
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic)
 "ePK" = (
@@ -19055,7 +19303,7 @@
 "eQo" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "eQw" = (
 /turf/open/floor/iron/stairs/right{
@@ -19082,7 +19330,7 @@
 /area/vtm/interior/sewer)
 "eQK" = (
 /obj/effect/turf_decal/stripes/white/line,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -19092,6 +19340,11 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
+"eQX" = (
+/obj/effect/decal/support,
+/obj/effect/decal/support,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/strip)
 "eRh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -19234,7 +19487,7 @@
 "eSU" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "eSV" = (
 /obj/effect/turf_decal/bordur{
@@ -19250,7 +19503,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/antiques)
 "eSW" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "eTf" = (
 /obj/machinery/hydroponics/simple/plastic,
@@ -19259,13 +19512,13 @@
 "eTj" = (
 /obj/structure/hedge,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "eTG" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "eTM" = (
 /obj/structure/roadblock/alt{
@@ -19313,7 +19566,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
 "eUr" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -19342,6 +19595,13 @@
 /mob/living/basic/frog,
 /turf/open/water/beach/vamp/deep,
 /area/vtm/outside/pacificheights/forest)
+"eUL" = (
+/obj/effect/turf_decal/bordur,
+/obj/structure/railing/darkpack/metal{
+	dir = 5
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "eUO" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/smooth/old,
@@ -19363,6 +19623,12 @@
 /obj/item/clothing/under/vampire/graveyard,
 /turf/open/floor/city/saint,
 /area/vtm/interior/church/staff)
+"eUU" = (
+/obj/structure/stairs/north{
+	dir = 8
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/strip)
 "eVb" = (
 /obj/machinery/processor,
 /obj/machinery/light/small/directional/east,
@@ -19447,7 +19713,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "eWK" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/machinery/light/prince/directional/east,
@@ -19471,7 +19737,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "eWX" = (
 /obj/effect/turf_decal/siding/white/corner,
@@ -19502,7 +19768,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "eXr" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/concrete,
@@ -19537,6 +19803,14 @@
 /obj/structure/filingcabinet/white,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"eYc" = (
+/obj/item/statuebust{
+	anchored = 1;
+	pixel_y = 10
+	},
+/obj/structure/table/countertop,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "eYf" = (
 /obj/effect/decal/cleanable/trash,
 /obj/effect/turf_decal/weather/dirt,
@@ -19544,7 +19818,7 @@
 /area/vtm/interior/cog/caern)
 "eYh" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
 "eYp" = (
@@ -19689,7 +19963,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/bianchiBank)
 "eZZ" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -19727,6 +20001,32 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm)
+"faw" = (
+/obj/structure/rack/tall/store_shelf_metal,
+/obj/item/ammo_box/darkpack/c45acp/silver{
+	pixel_y = 7;
+	pixel_x = -6
+	},
+/obj/item/ammo_box/darkpack/c45acp/silver{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/gun/ballistic/shotgun/vampire{
+	pixel_y = 29
+	},
+/obj/item/ammo_box/darkpack/c12g/buck{
+	pixel_y = 18
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = -7;
+	pixel_x = -7
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = -7;
+	pixel_x = 7
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "faE" = (
 /obj/structure/transport/linear/public,
 /obj/effect/abstract/elevator_music_zone{
@@ -19770,11 +20070,11 @@
 /turf/open/floor/city/circled,
 /area/vtm/interior/clinic)
 "faZ" = (
-/obj/structure/chair/greyscale,
 /obj/effect/turf_decal/siding/grey{
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/chair/darkpack/blue,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "fbf" = (
@@ -19794,7 +20094,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "fbq" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/toilet,
@@ -19814,7 +20114,7 @@
 "fbA" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/dresser,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "fbJ" = (
 /obj/machinery/light/small/directional/south,
@@ -19896,25 +20196,16 @@
 /obj/structure/musician/piano{
 	icon_state = "piano"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/setite)
 "fcy" = (
-/obj/structure/hedge,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/table/wood/fancy/cyan,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 2
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "fcB" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -19941,15 +20232,11 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "fda" = (
-/obj/structure/table/wood,
-/obj/item/paper{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "fdf" = (
 /obj/structure/table/wood,
@@ -20037,7 +20324,7 @@
 	},
 /area/vtm/interior/strip)
 "fdO" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/misc/dirt,
 /area/vtm/interior/sewer/nosferatu_town)
 "fdU" = (
@@ -20100,7 +20387,7 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/ventrue)
 "feV" = (
 /obj/effect/decal/graffiti/large,
@@ -20116,11 +20403,6 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/shop/antiques)
-"ffb" = (
-/obj/structure/chair/sofa/corp,
-/obj/machinery/light/small/pink/directional/north,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "ffd" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 1
@@ -20194,7 +20476,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "ffH" = (
 /obj/structure/chair/wood/darkpack/red{
@@ -20213,7 +20495,7 @@
 "fgd" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/occult/artifact,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "fgr" = (
 /obj/structure/vampdoor/glass{
@@ -20316,7 +20598,7 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
 "fhh" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/toilet,
@@ -20376,7 +20658,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/music_store)
 "fhS" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "fhT" = (
@@ -20411,7 +20693,7 @@
 /area/vtm/interior/vjanitor)
 "fih" = (
 /obj/structure/hedge,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "fir" = (
 /obj/effect/turf_decal/bordur{
@@ -20433,8 +20715,12 @@
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/oldchurch)
+"fjm" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "fjs" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/concrete,
@@ -20489,6 +20775,10 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
+"fjS" = (
+/obj/machinery/sprinkler/area_managed,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "fjW" = (
 /obj/effect/turf_decal/bordur,
 /obj/machinery/light/floor/lamppost/sidewalk/chinese{
@@ -20626,7 +20916,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/old)
 "flU" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/city/plating,
 /area/vtm/interior/techshop)
 "flY" = (
@@ -20660,7 +20950,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior)
 "fmy" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating_stone,
@@ -20755,7 +21045,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "fno" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "fns" = (
@@ -20962,7 +21252,7 @@
 	icon_state = "shadow-alt";
 	pixel_y = 34
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "fqE" = (
 /obj/structure/chair/sofa/right/brown{
@@ -20990,7 +21280,7 @@
 /turf/open/misc/dirt,
 /area/vtm/interior/sewer)
 "frh" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
@@ -21028,10 +21318,6 @@
 /obj/machinery/light/floor/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
-"frP" = (
-/obj/effect/landmark/navigate_destination,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "frR" = (
 /obj/effect/decal/carpet,
 /turf/open/floor/wood/smooth/old,
@@ -21057,7 +21343,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "fsi" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "fsk" = (
@@ -21088,6 +21374,10 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
+"fsH" = (
+/obj/effect/decal/wallpaper/red,
+/turf/closed/wall/vampwall/rich/old,
+/area/vtm/interior/museum)
 "fsK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -21100,7 +21390,7 @@
 /area/vtm/interior/strip)
 "fsT" = (
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "fsV" = (
 /obj/effect/decal/cleanable/trash{
@@ -21257,7 +21547,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/outside/park)
 "fvi" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "fvo" = (
 /obj/effect/turf_decal/bordur{
@@ -21299,7 +21589,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
 "fvE" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
@@ -21458,9 +21748,8 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/jazzclub)
 "fxt" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
@@ -21587,8 +21876,13 @@
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm)
+"fyO" = (
+/obj/fusebox,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "fyR" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights/community)
 "fyW" = (
@@ -21615,12 +21909,12 @@
 /area/vtm/interior/millennium_tower/f2)
 "fzh" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "fzj" = (
 /obj/effect/spawner/random/bedsheet/any,
 /obj/structure/bed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/techshop)
 "fzn" = (
 /obj/structure/table,
@@ -21657,6 +21951,10 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf/ghetto)
+"fzH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "fzI" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -21671,7 +21969,7 @@
 /area/vtm/outside/financialdistrict)
 "fzL" = (
 /obj/structure/vampdoor/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "fzO" = (
 /obj/structure/table/wood,
@@ -21715,7 +22013,7 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/financialdistrict)
 "fAp" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
@@ -21734,7 +22032,7 @@
 /area/vtm/interior/theatre)
 "fAv" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "fAz" = (
 /obj/effect/decal/cleanable/cardboard,
@@ -21863,15 +22161,11 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "fBJ" = (
-/obj/structure/hedge,
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
+/obj/structure/chair/wood/darkpack/red{
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/smooth/old,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "fBS" = (
 /obj/structure/hedge,
@@ -21994,14 +22288,14 @@
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
 /obj/machinery/light/blacklight/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "fDv" = (
 /obj/structure/roofstuff/alt1,
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "fDw" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
@@ -22035,7 +22329,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "fDZ" = (
 /turf/closed/wall/vampwall/brick_old,
@@ -22055,7 +22349,7 @@
 /area/vtm/outside/unionsquare)
 "fEr" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "fEs" = (
 /obj/structure/closet/crate/bin,
@@ -22079,7 +22373,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
 "fEJ" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /obj/fusebox,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
@@ -22128,7 +22422,7 @@
 	pixel_y = 6;
 	pixel_x = 0
 	},
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/old,
@@ -22289,7 +22583,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "fHa" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/decal/graffiti,
@@ -22300,18 +22594,6 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"fHr" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/item/fish/darkpack/catfish,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/water,
-/area/vtm/interior/chantry)
 "fHu" = (
 /obj/structure/sign/eyechart/directional/north,
 /turf/open/floor/iron/white/textured_large,
@@ -22357,6 +22639,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"fHM" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/strip)
 "fHQ" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -22367,7 +22653,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "fHU" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -22392,7 +22678,7 @@
 /area/vtm/outside/ghetto)
 "fIB" = (
 /obj/effect/decal/cleanable/cardboard,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "fIC" = (
 /obj/structure/table/wood,
@@ -22497,7 +22783,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "fJH" = (
 /obj/machinery/sprinkler/area_managed,
@@ -22597,17 +22883,13 @@
 /obj/item/chair/plastic,
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
-"fLh" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "fLj" = (
 /obj/machinery/hydroponics/simple/plastic,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
 /obj/machinery/light/warm/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "fLm" = (
 /obj/structure/toilet{
@@ -22621,6 +22903,17 @@
 /obj/item/food/grown/banana/bunch,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/grocery)
+"fLp" = (
+/obj/machinery/light/directional/north,
+/obj/item/statuebust/hippocratic{
+	desc = "A bust of the famous Greek physician Hippocrates of Kos, often referred to as the father of western medicine. Stop... Is that a black mark in the shape of a rose?...";
+	pixel_x = 2;
+	pixel_y = 14;
+	anchored = 1
+	},
+/obj/structure/table/countertop,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "fLs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -22735,7 +23028,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "fNb" = (
 /obj/machinery/light/dim/directional/west,
@@ -22871,6 +23164,13 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
+"fOQ" = (
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/obj/machinery/computer/operating,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "fOT" = (
 /obj/structure/chair/pew/left,
 /turf/open/floor/city/plating_stone,
@@ -22880,7 +23180,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
 "fPj" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -22914,7 +23214,7 @@
 	},
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "fPu" = (
 /obj/structure/flora/rock/darkpack_big,
@@ -22925,7 +23225,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/anarch/emissary,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "fPD" = (
 /obj/machinery/sprinkler/area_managed,
@@ -22942,7 +23242,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "fPO" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth,
@@ -23046,7 +23346,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "fQI" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/old,
@@ -23111,13 +23411,13 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/fishermanswharf)
 "fRs" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "fRv" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
 "fRx" = (
@@ -23138,19 +23438,6 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/forest)
-"fRV" = (
-/obj/structure/vampdoor/simple{
-	name = "STAFF ONLY";
-	locked = 1;
-	lockpick_difficulty = 20;
-	dir = 4;
-	lock_id = "tmr"
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "fRY" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 6
@@ -23207,18 +23494,18 @@
 /turf/open/misc/beach/vamp,
 /area/vtm)
 "fSG" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "fSL" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "fSQ" = (
 /obj/effect/turf_decal/bordur{
@@ -23445,7 +23732,7 @@
 /area/vtm/interior/endron_facility/restricted)
 "fVo" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /obj/effect/landmark/start/darkpack/forest_wolves/keeper,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
@@ -23462,7 +23749,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "fVv" = (
 /obj/structure/railing{
@@ -23480,15 +23767,6 @@
 /obj/structure/roadsign/noparking,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
-"fVy" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/fusebox,
-/obj/vampire_computer,
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "fWf" = (
 /obj/machinery/light/small/red/dim/directional/west,
 /turf/open/floor/plating/rough/cave,
@@ -23671,13 +23949,21 @@
 /obj/effect/decal/wallpaper/blue,
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/shop/clothing_store)
+"fYX" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/platform/lowwall/brick,
+/obj/structure/vampstatue/angel{
+	pixel_y = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "fYY" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "fZa" = (
 /obj/fusebox,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -23769,7 +24055,7 @@
 "gaB" = (
 /obj/structure/coclock,
 /obj/structure/rack/clothing_hanger,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "gaJ" = (
 /obj/structure/curtain/bounty,
@@ -23807,6 +24093,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/endron_facility/restricted)
+"gba" = (
+/obj/structure/chair/office/darkpack/green{
+	dir = 4
+	},
+/obj/effect/landmark/start/darkpack/law_enforcement/fbi,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "gbb" = (
 /obj/effect/decal/wallpaper/red/low,
 /obj/structure/window/reinforced/tinted/spawner/directional/south{
@@ -23821,7 +24114,7 @@
 /turf/open/floor/city/saint,
 /area/vtm/interior/chantry/basement)
 "gbw" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/decal/graffiti,
@@ -23904,6 +24197,10 @@
 	},
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/clinic)
+"gcs" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/hotel)
 "gct" = (
 /obj/structure/rack,
 /obj/item/clothing/head/vampire/pentex_whitehardhat,
@@ -24051,9 +24348,14 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/jazzclub)
+"geM" = (
+/obj/structure/closet,
+/obj/item/storage/box/evidence,
+/obj/machinery/light/small/directional/west,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "geN" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/closet/cardboard,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/museum)
 "gfa" = (
@@ -24108,7 +24410,7 @@
 /area/vtm/interior/endron_facility/restricted)
 "gfM" = (
 /obj/machinery/light/small/pink/directional/east,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "gfN" = (
 /obj/effect/decal/wallpaper/red,
@@ -24169,6 +24471,12 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/library)
+"ggx" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "ggB" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
@@ -24176,7 +24484,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/tzimisce_manor)
 "ggF" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -24243,7 +24551,7 @@
 /area/vtm/interior/church)
 "ggZ" = (
 /mob/living/carbon/human/npc/hobo,
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -24257,7 +24565,7 @@
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/vjanitor)
 "ghf" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/glass,
@@ -24340,8 +24648,18 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
+"ghZ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "gic" = (
 /obj/effect/landmark/event_spawn/sarcophagus,
 /turf/open/floor/plating/rough/cave,
@@ -24352,7 +24670,7 @@
 /area/vtm/graveyard)
 "gii" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "gij" = (
 /obj/effect/turf_decal/bordur{
@@ -24371,7 +24689,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/supply)
 "gis" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/litter,
@@ -24381,7 +24699,7 @@
 "giH" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/blood/vitae,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "giN" = (
 /obj/structure/flora/tree/vamp,
@@ -24430,7 +24748,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm)
 "gje" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -24491,7 +24809,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "gjJ" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -24527,11 +24845,11 @@
 /area/vtm/interior/church)
 "gkm" = (
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "gkw" = (
 /obj/structure/dresser,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "gkH" = (
 /obj/structure/vampdoor/simple{
@@ -24579,13 +24897,13 @@
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior)
 "gle" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "glg" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -24611,7 +24929,7 @@
 /area/vtm/interior/salubri)
 "glm" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -24702,7 +25020,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
 "gmj" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -24797,6 +25115,22 @@
 /obj/structure/sign/poster/random,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior)
+"gnU" = (
+/obj/structure/chair/plastic/darkpack,
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 6;
+	pixel_y = -12
+	},
+/obj/item/rag{
+	pixel_y = -12;
+	pixel_x = -4
+	},
+/obj/item/restraints/handcuffs/cable/zipties{
+	pixel_x = -21
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "gnW" = (
 /obj/structure/chair/sofa/corp,
 /obj/effect/landmark/start/darkpack/camarilla/harpy,
@@ -24817,7 +25151,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
 "gol" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -24864,7 +25198,7 @@
 /area/vtm/interior/shop/antiques)
 "goL" = (
 /obj/effect/decal/cleanable/trash,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "goM" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -24894,6 +25228,10 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/strip)
+"gpb" = (
+/obj/structure/secure_safe/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/strip)
 "gpk" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/city/plating_mono,
@@ -24903,7 +25241,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/vtm/interior/endron_facility/restricted)
 "gpH" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/toilet,
@@ -25045,7 +25383,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
 "grD" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -25093,7 +25431,7 @@
 /area/vtm/interior/millennium_tower/f2)
 "gsk" = (
 /obj/structure/bookcase/random/religion,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "gst" = (
 /obj/effect/turf_decal/siding/white{
@@ -25247,18 +25585,18 @@
 /turf/closed/wall/vampwall/market,
 /area/vtm/outside/ghetto)
 "gtT" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/grey{
 	dir = 6
+	},
+/obj/structure/chair/darkpack/blue{
+	dir = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic)
 "gtU" = (
 /obj/structure/table/wood,
 /obj/machinery/fax/anarch,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "gtX" = (
 /obj/structure/table/wood,
@@ -25267,11 +25605,6 @@
 	},
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
-"gua" = (
-/obj/effect/decal/wallpaper/stone,
-/obj/effect/decal/wallpaper/stone,
-/turf/closed/wall/vampwall/rich/old,
-/area/vtm/interior/trujah)
 "gum" = (
 /obj/structure/railing{
 	dir = 4
@@ -25378,7 +25711,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
 "gvK" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
@@ -25407,7 +25740,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "gwm" = (
 /obj/effect/turf_decal/crosswalk{
@@ -25565,7 +25898,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
 "gyX" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/ventrue)
 "gzc" = (
@@ -25678,7 +26011,7 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
 "gAj" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -25722,9 +26055,11 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
 "gAH" = (
-/obj/structure/table/wood,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/effect/turf_decal/siding/grey{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "gBs" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -25784,7 +26119,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/museum)
 "gBM" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/endronsecurity{
@@ -25851,7 +26186,7 @@
 	icon_state = "mirror_broke";
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/church/haven)
 "gCo" = (
 /obj/effect/turf_decal/bordur{
@@ -25916,7 +26251,7 @@
 /area/vtm/interior/anarch/basement)
 "gDa" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -26093,7 +26428,7 @@
 /area/vtm/outside/pacificheights/forest)
 "gFt" = (
 /mob/living/basic/ghost,
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
 "gFy" = (
@@ -26111,7 +26446,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/forest)
 "gFJ" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -26130,7 +26465,7 @@
 /area/vtm/interior/clinic)
 "gFP" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
@@ -26147,7 +26482,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/forest)
 "gFY" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -26457,6 +26792,34 @@
 /obj/structure/platform/lowwall/rich/window/reinforced,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f3)
+"gJx" = (
+/obj/structure/rack/tall/store_shelf_metal,
+/obj/item/clothing/mask/vampire/balaclava{
+	pixel_x = 8;
+	pixel_y = 28
+	},
+/obj/item/clothing/mask/vampire/balaclava{
+	pixel_x = 12;
+	pixel_y = 30
+	},
+/obj/item/clothing/head/vampire/blackbag{
+	pixel_y = 20;
+	pixel_x = -9
+	},
+/obj/item/clothing/head/vampire/blackbag{
+	pixel_y = 23;
+	pixel_x = -3
+	},
+/obj/item/gas_can/full{
+	pixel_y = 8;
+	pixel_x = 12
+	},
+/obj/item/lighter/greyscale{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "gJB" = (
 /obj/structure/table,
 /obj/structure/retail/costume_store{
@@ -26465,7 +26828,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/clothing_store)
 "gJH" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch)
 "gJM" = (
@@ -26540,7 +26903,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "gLr" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "gLx" = (
@@ -26618,7 +26981,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "gMu" = (
 /obj/machinery/light/dim/directional/east,
@@ -26742,7 +27105,7 @@
 /area/vtm/interior/millennium_tower/ventrue)
 "gOl" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "gOn" = (
 /obj/structure/rack/wide/wood_shelf,
@@ -27075,7 +27438,7 @@
 "gRU" = (
 /obj/structure/table/wood/fancy/black,
 /obj/vampire_computer/prince,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "gRZ" = (
 /obj/structure/city_map,
@@ -27088,6 +27451,11 @@
 /obj/machinery/light/red/directional/south,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f3)
+"gSc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "gSh" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -27138,9 +27506,9 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/sewer/nosferatu_town)
 "gSx" = (
-/obj/structure/curtain,
-/obj/item/soap,
-/obj/machinery/shower/directional/east,
+/obj/structure/toilet{
+	dir = 4
+	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/chantry)
 "gSy" = (
@@ -27243,7 +27611,7 @@
 /area/vtm/interior/graveyard)
 "gTY" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "gUe" = (
@@ -27353,7 +27721,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
 "gVs" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
 "gVA" = (
@@ -27497,7 +27865,7 @@
 /area/vtm/interior/tzimisce_manor)
 "gXh" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "gXq" = (
 /obj/machinery/light/floor/lamppost/one{
@@ -27564,7 +27932,7 @@
 /area/vtm/interior/police)
 "gYs" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/grey/corner,
@@ -27617,7 +27985,7 @@
 	dir = 8
 	},
 /obj/effect/decal/carpet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "gZe" = (
 /obj/item/kirbyplants/random,
@@ -27656,6 +28024,11 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
+"gZD" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/broken/directional/north,
+/turf/open/floor/city/toilet,
+/area/vtm/interior/chantry)
 "gZL" = (
 /obj/effect/decal/wallpaper/gold/alt,
 /turf/closed/wall/vampwall/rich,
@@ -27748,7 +28121,7 @@
 /turf/open/floor/iron/stairs/medium,
 /area/vtm/interior)
 "haZ" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/carpet/orange,
 /area/vtm/interior)
 "hbc" = (
@@ -27773,7 +28146,7 @@
 	dir = 4;
 	pixel_x = 5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "hbl" = (
 /obj/structure/rack/clothing/rand{
@@ -27800,7 +28173,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/smoke_shop)
 "hbz" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/citizen/priest,
@@ -27839,13 +28212,18 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/old,
 /area/vtm/interior/oldchurch)
+"hbM" = (
+/obj/structure/table/optable,
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "hbN" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
 "hbT" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "hbW" = (
 /obj/structure/fuelstation,
@@ -27920,7 +28298,7 @@
 /area/vtm/interior/giovanni)
 "hcO" = (
 /obj/structure/stairs/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
 "hcP" = (
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
@@ -27982,7 +28360,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
 "hdD" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "hdE" = (
@@ -27992,7 +28370,7 @@
 	locked = 1;
 	lockpick_difficulty = 15
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "hdM" = (
 /obj/structure/table/wood,
@@ -28093,7 +28471,7 @@
 /area/vtm/interior/library)
 "hfp" = (
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "hfq" = (
 /obj/effect/decal/wallpaper/trim/green,
@@ -28122,6 +28500,14 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/jazzclub)
+"hfK" = (
+/obj/machinery/light/directional/south,
+/obj/structure/easel,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "hfL" = (
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/shop)
@@ -28176,7 +28562,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/park)
 "hgL" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "hgM" = (
@@ -28431,11 +28817,11 @@
 /area/vtm)
 "hjY" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
 "hjZ" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/plating,
@@ -28491,6 +28877,11 @@
 /mob/living/carbon/human/npc/gummaguts,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/gummaguts)
+"hkF" = (
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/siding/grey/corner,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/strip)
 "hkI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -28508,6 +28899,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
+"hkZ" = (
+/obj/effect/landmark/start/darkpack/citizen/club_worker,
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/strip)
 "hla" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -28536,10 +28934,10 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/glasswalker)
 "hlt" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "hlw" = (
 /obj/effect/turf_decal/bordur{
@@ -28551,10 +28949,10 @@
 /turf/open/floor/wood/smooth,
 /area/vtm)
 "hlI" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "hlM" = (
 /obj/structure/railing{
@@ -28774,6 +29172,16 @@
 "hoA" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"hoC" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/platform/lowwall/brick,
+/obj/structure/vampstatue/cloaked{
+	pixel_y = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "hoF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28800,7 +29208,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
 "hoT" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/grey{
@@ -28830,7 +29238,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "hpj" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/haven)
 "hpl" = (
@@ -28876,7 +29284,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "hpR" = (
 /obj/effect/turf_decal/siding/wood/dark/corner{
@@ -28914,14 +29322,14 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "hqt" = (
 /obj/machinery/computer/security,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "hqz" = (
 /obj/structure/flora/bush/style_random,
@@ -28960,7 +29368,7 @@
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer/nosferatu_town)
 "hqP" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/concrete,
@@ -29171,7 +29579,7 @@
 /obj/structure/railing{
 	pixel_y = -1
 	},
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -29299,6 +29707,10 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
+"hvx" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/anarch)
 "hvy" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/bacotell,
@@ -29362,7 +29774,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "hwm" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/triad/blue_lanterns,
@@ -29384,7 +29796,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "hwC" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/plating/concrete,
@@ -29407,7 +29819,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
 "hwL" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/glass,
@@ -29466,16 +29878,16 @@
 /turf/closed/wall/vampwall/metal/alt,
 /area/vtm/interior/endron_facility/plant)
 "hxI" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "hxQ" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "hxX" = (
 /obj/structure/chair/sofa/city_bench/metal{
@@ -29503,7 +29915,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/shop/arts)
 "hyt" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/machinery/light/small/directional/east,
@@ -29515,9 +29927,9 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "hyJ" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/darkpack/law_enforcement/fbi,
-/turf/open/floor/wood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/concrete,
 /area/vtm/interior/police/fed)
 "hyK" = (
 /obj/structure/closet/crate/coffin,
@@ -29536,7 +29948,7 @@
 /area/vtm/interior/millennium_tower/f3)
 "hzi" = (
 /obj/structure/aquarium,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "hzo" = (
 /obj/machinery/light/directional/north,
@@ -29811,7 +30223,7 @@
 "hCY" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "hDa" = (
 /obj/machinery/griddle,
@@ -29858,6 +30270,7 @@
 /area/vtm/outside/pacificheights/community)
 "hDq" = (
 /mob/living/carbon/human/npc/bacotell,
+/obj/structure/chair/darkpack/red,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
 "hDt" = (
@@ -29928,7 +30341,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
 "hDK" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/voivode/voivode,
@@ -29945,9 +30358,8 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/salubri)
 "hDZ" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/ventrue)
@@ -30058,10 +30470,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/unionsquare)
-"hFE" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "hFL" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
@@ -30084,7 +30492,7 @@
 "hGi" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "hGm" = (
 /obj/structure/vampdoor/wood{
@@ -30099,7 +30507,7 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/five,
 /obj/effect/mapping_helpers/door/lock_difficulty/four,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "hGw" = (
 /obj/structure/bed/medical/emergency,
@@ -30176,13 +30584,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf)
 "hHn" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/hemostat,
-/obj/item/cautery,
-/obj/item/scalpel,
-/obj/item/surgical_drapes,
-/turf/open/floor/city/toilet,
+/turf/open/floor/plating/concrete,
 /area/vtm/interior/police/fed)
 "hHu" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -30232,7 +30634,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/millennium_tower/ventrue)
 "hHK" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/dirt,
@@ -30276,7 +30678,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f4)
 "hIz" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -30703,11 +31105,19 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
 "hNO" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower)
+"hNQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/large{
+	anchored = 1
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "hNZ" = (
 /turf/open/openspace,
 /area/vtm/interior/clinic)
@@ -30752,7 +31162,7 @@
 /obj/structure/railing{
 	pixel_y = -2
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -30788,10 +31198,6 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
-"hOP" = (
-/obj/structure/sink/directional/east,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/trujah)
 "hOS" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -31068,14 +31474,14 @@
 /turf/open/misc/grass,
 /area/vtm/interior/church)
 "hSz" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "hSC" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "hSD" = (
 /obj/effect/turf_decal/bordur,
@@ -31091,7 +31497,7 @@
 	dir = 5
 	},
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "hTf" = (
 /obj/structure/vampdoor/old,
@@ -31154,12 +31560,6 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
-"hUb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/carpet/cyan,
-/area/vtm/interior/hotel)
 "hUe" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/flower_shop)
@@ -31215,7 +31615,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
 "hVo" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/triad/deputy_mountain_master,
@@ -31227,7 +31627,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "hVx" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/landmark/start/darkpack/pentex/secchief,
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
@@ -31263,7 +31663,7 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
 "hVU" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -31286,7 +31686,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "hWB" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/item/clothing/shoes/vampire/jackboots{
@@ -31350,7 +31750,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "hXm" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "hXn" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -31373,7 +31773,7 @@
 /area/vtm/interior/laundromat)
 "hXK" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/camarilla/towerwork,
@@ -31435,6 +31835,17 @@
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"hYI" = (
+/obj/structure/table/wood,
+/obj/item/surgery_tray/full{
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/vampire/latex,
+/obj/item/clothing/gloves/vampire/latex,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "hYP" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/toilet{
@@ -31447,7 +31858,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/ghetto)
 "hYW" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "hYY" = (
 /obj/structure/bath/sabbatbath,
@@ -31587,7 +31998,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "iaW" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/rough,
@@ -31646,7 +32057,7 @@
 "ibG" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/dresser,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "ibH" = (
 /obj/effect/decal/cleanable/trash,
@@ -31858,10 +32269,6 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/mineral/plastitanium/red,
 /area/vtm/interior/millennium_tower/ventrue)
-"ieV" = (
-/mob/living/carbon/human/npc/guard,
-/turf/open/floor/city/plating,
-/area/vtm/interior/museum)
 "ieW" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plating/rough/cave,
@@ -31904,7 +32311,7 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
 "ifx" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/pentex/employee,
@@ -31920,7 +32327,7 @@
 /turf/open/umbra,
 /area/vtm)
 "ifB" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/misc/beach/vamp,
@@ -32007,17 +32414,23 @@
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
 "igv" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/bianchiBank)
 "igE" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
 "igG" = (
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/grey{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "igL" = (
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/brick,
@@ -32090,7 +32503,7 @@
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/shop/smoke_shop)
 "iih" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -32182,7 +32595,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "ijA" = (
 /obj/effect/landmark/npcbeacon,
@@ -32206,6 +32619,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
+"ijU" = (
+/obj/structure/easel,
+/obj/item/canvas/fortyfive_twentyseven{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "ikz" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/toilet{
@@ -32283,7 +32704,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "iln" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -32298,7 +32719,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "ilD" = (
 /obj/structure/rack,
@@ -32394,8 +32815,11 @@
 /turf/open/floor/wood/old,
 /area/vtm/outside/pacificheights/forest)
 "imN" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/city/toilet,
+/obj/structure/closet/crate/large{
+	anchored = 1
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/concrete,
 /area/vtm/interior/police/fed)
 "ine" = (
 /obj/effect/decal/cleanable/litter,
@@ -32491,7 +32915,7 @@
 	},
 /obj/machinery/light/prince/directional/east,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "ioj" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
@@ -32649,7 +33073,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "iqA" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/triad/blue_lanterns,
@@ -32670,9 +33094,13 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
 "iqG" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
+"iqJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "iqV" = (
 /obj/structure/flora/rock/stalagmite,
 /obj/structure/glowshroom/extreme,
@@ -32700,7 +33128,7 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/bianchiBank)
 "irE" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/ornate,
@@ -32721,6 +33149,19 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/misc/grass,
 /area/vtm/interior/millennium_tower/f4)
+"irU" = (
+/obj/effect/mapping_helpers/door/lock,
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/lock_difficulty/ten,
+/obj/effect/mapping_helpers/door/access/federal,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/bash_difficulty/ten,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "irW" = (
 /obj/structure/platform/lowwall/rich/old,
 /obj/structure/gargoyle{
@@ -32834,7 +33275,23 @@
 /area/vtm/outside/northbeach)
 "itp" = (
 /obj/effect/turf_decal/siding/white,
-/obj/item/kirbyplants/random,
+/obj/structure/closet/cabinet,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/thirtysix_twentyfour,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
+/obj/item/canvas/nineteen_nineteen,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "itr" = (
@@ -32932,12 +33389,12 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/techshop)
 "iui" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /mob/living/carbon/human/npc/walkby/club,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "iuE" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer)
 "iuJ" = (
@@ -32956,13 +33413,13 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/oldchurch)
 "iuW" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/glass,
 /area/vtm/interior/tzimisce_manor)
 "iuY" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth,
@@ -33015,7 +33472,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
 "ivz" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/litter,
@@ -33080,7 +33537,7 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/pacificheights/forest)
 "iwp" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
 "iwq" = (
@@ -33158,8 +33615,17 @@
 "ixq" = (
 /turf/open/floor/city/plating,
 /area/vtm/interior/wyrm_corrupted)
+"ixr" = (
+/obj/structure/flora/grass/jungle,
+/obj/item/clothing/mask/gas/tiki_mask{
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/obj/machinery/light/directional/south,
+/turf/open/misc/grass,
+/area/vtm/interior/museum)
 "ixB" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -33226,11 +33692,24 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/circuit,
 /area/vtm/interior/glasswalker)
+"iyV" = (
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 1;
+	pixel_y = 32
+	},
+/obj/structure/platform/lowwall/brick,
+/obj/structure/table/wood,
+/obj/item/clothing/suit/vampire/jacket/punk{
+	name = "worn leather jacket";
+	desc = "The old and worn leather jacket of a long since dead punk singer. They say he overdosed on coke wearing it."
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "iza" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -33280,20 +33759,17 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/community)
 "iAj" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/jazzclub)
 "iAk" = (
-/obj/structure/vampdoor/simple{
-	dir = 8;
-	lock_id = "tmr";
-	lockpick_difficulty = 15;
-	locked = 1
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/trujah)
+/obj/structure/table/wood,
+/obj/structure/platform/lowwall/rich/old,
+/obj/machinery/photocopier/gratis/prebuilt,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "iAm" = (
 /obj/structure/bed/maint,
 /turf/open/floor/plating/concrete,
@@ -33347,6 +33823,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/wyrm_corrupted)
+"iAZ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/platform/lowwall/old,
+/obj/structure/table,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/strip)
 "iBb" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -33435,9 +33920,7 @@
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer/nosferatu_town)
 "iCd" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "iCf" = (
@@ -33489,7 +33972,7 @@
 	dir = 8;
 	pixel_x = -3
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "iCG" = (
 /obj/machinery/light/prince/directional/south,
@@ -33539,7 +34022,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer/nosferatu_town)
 "iDf" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/plating,
@@ -33693,10 +34176,6 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/bubway)
-"iFf" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/city/plating,
-/area/vtm/interior/museum)
 "iFg" = (
 /obj/machinery/light/small/directional/west,
 /obj/item/kirbyplants/random,
@@ -33704,7 +34183,7 @@
 	accesslocks = list("laundromat");
 	name = "Laundromat Keys"
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "iFk" = (
 /obj/effect/decal/graffiti,
@@ -33781,21 +34260,16 @@
 /obj/structure/vampdoor/glass{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/door/access/clinic,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
 /obj/effect/mapping_helpers/door/bash_difficulty/seven,
+/obj/effect/mapping_helpers/door/access/malkavian,
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
 "iGI" = (
 /obj/item/ritual_tome/arcane,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
-"iGL" = (
-/obj/structure/hedge,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "iGO" = (
 /obj/machinery/light/floor/lamppost/one{
 	dir = 1
@@ -33889,7 +34363,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f4)
 "iHO" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -34001,12 +34475,6 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/church)
-"iJc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/vtm/interior/hotel)
 "iJj" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 9
@@ -34092,7 +34560,7 @@
 	pixel_x = 28
 	},
 /obj/structure/rack/wide/metal_shelf,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/shop/pharmacy)
 "iKd" = (
 /obj/structure/platform/lowwall/painted/window/reinforced,
@@ -34112,11 +34580,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
-"iKx" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "iKD" = (
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sabbat_lair)
@@ -34132,6 +34595,12 @@
 /obj/structure/chair/greyscale,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"iKX" = (
+/obj/effect/turf_decal/siding/grey{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "iLa" = (
 /obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/access/giovanni,
@@ -34302,7 +34771,7 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/ventrue)
 "iNK" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -34312,7 +34781,7 @@
 	pixel_x = 12;
 	pixel_y = 3
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "iNR" = (
 /obj/structure/table/wood,
@@ -34324,7 +34793,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -34356,7 +34825,7 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
 "iOA" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/pharmacystore,
@@ -34403,8 +34872,8 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "iPi" = (
-/obj/effect/turf_decal/siding/white/corner,
 /obj/machinery/sprinkler/area_managed,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "iPo" = (
@@ -34571,6 +35040,15 @@
 /obj/effect/turf_decal/stock,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/hotel)
+"iRj" = (
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "iRm" = (
 /obj/structure/lattice/catwalk{
 	pixel_x = 1
@@ -34578,6 +35056,10 @@
 /obj/structure/ladder/manhole/down,
 /turf/open/openspace,
 /area/vtm)
+"iRu" = (
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "iRx" = (
 /obj/structure/table,
 /obj/vampire_computer,
@@ -34590,6 +35072,26 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/supply)
+"iRZ" = (
+/obj/structure/table/no_smooth/wood/cablereel{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = -9;
+	pixel_y = 17
+	},
+/obj/item/wirecutters/pliers/bad{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/structure/roadblock{
+	dir = 1;
+	pixel_y = 17;
+	density = 0
+	},
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "iSb" = (
 /obj/structure/vampdoor,
 /turf/open/floor/plating/rough,
@@ -34630,6 +35132,14 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
+"iSt" = (
+/obj/structure/table/countertop,
+/obj/item/statuebust{
+	anchored = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "iSy" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/outside/fishermanswharf)
@@ -34652,9 +35162,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
 "iSI" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/chair/darkpack{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "iSJ" = (
 /obj/effect/turf_decal/bordur{
 	dir = 6
@@ -34743,7 +35258,7 @@
 "iTu" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "iTx" = (
 /obj/effect/landmark/npcability,
@@ -34759,7 +35274,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/community)
 "iTE" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34847,7 +35362,7 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/ventrue)
 "iUL" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
@@ -34858,7 +35373,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/photocopier/prebuilt,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "iVd" = (
 /obj/effect/turf_decal/siding/white{
@@ -34870,7 +35385,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
 "iVe" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
@@ -34885,14 +35400,14 @@
 /area/vtm/outside/unionsquare)
 "iVj" = (
 /obj/structure/vampdoor/glass,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "iVl" = (
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
 "iVq" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/structure/railing{
@@ -34986,7 +35501,7 @@
 	},
 /area/vtm)
 "iWo" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -35041,7 +35556,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "iWU" = (
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
@@ -35285,9 +35800,13 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/cog/caern)
 "jaW" = (
-/obj/effect/decal/wallpaper/stone,
-/turf/closed/wall/vampwall/rich/old,
-/area/vtm/interior/trujah)
+/obj/item/vampirebook/noddist,
+/obj/effect/turf_decal/siding/grey{
+	dir = 9
+	},
+/obj/structure/table/wood/fancy/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "jaX" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -35341,7 +35860,7 @@
 /area/vtm/interior/tzimisce_manor)
 "jbv" = (
 /obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "jbw" = (
 /obj/structure/transport/linear/public,
@@ -35357,7 +35876,7 @@
 /turf/open/floor/city/industrial,
 /area/vtm/interior/shop/hardware_store)
 "jbT" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -35399,11 +35918,6 @@
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
-"jcs" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/museum)
 "jcx" = (
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
@@ -35417,6 +35931,15 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/clothing_store)
+"jcU" = (
+/obj/effect/turf_decal/bordur{
+	dir = 8
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "jcY" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
@@ -35477,11 +36000,6 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/library)
-"jdP" = (
-/obj/machinery/shower/directional/east,
-/obj/structure/curtain,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/chantry)
 "jdR" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/hedge,
@@ -35655,17 +36173,16 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/graveyard)
 "jgA" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 16
+/obj/structure/railing/darkpack/metal{
+	dir = 10
 	},
-/turf/open/floor/plating/rough,
+/turf/open/openspace,
 /area/vtm/interior)
 "jgC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "jgI" = (
 /obj/fusebox,
@@ -35706,7 +36223,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/unionsquare)
 "jhf" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -35939,7 +36456,7 @@
 /area/vtm/interior/church)
 "jkD" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/ghetto)
 "jkM" = (
 /obj/structure/railing{
@@ -36057,7 +36574,7 @@
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/smoke_shop)
 "jlN" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/plating/rough/cave,
@@ -36135,11 +36652,8 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/upstairs)
 "jmO" = (
-/turf/closed/wall/vampwall/rich/old{
-	density = 0;
-	name = "oddly shaped rich-looking wall"
-	},
-/area/vtm/interior/trujah)
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/museum)
 "jmT" = (
 /obj/effect/turf_decal/bordur{
 	dir = 5
@@ -36370,13 +36884,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/city/plating,
 /area/vtm/interior/techshop)
-"jqn" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/plating/rough,
-/area/vtm/interior/sewer/nosferatu_town)
 "jqq" = (
 /obj/effect/decal/rugs,
 /turf/open/floor/plating/concrete,
@@ -36390,6 +36897,15 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/bubway)
+"jqz" = (
+/obj/effect/turf_decal/bordur/corner{
+	dir = 1
+	},
+/obj/structure/roofstuff/vent_end{
+	dir = 8
+	},
+/turf/open/floor/plating/rough,
+/area/vtm)
 "jqB" = (
 /obj/effect/decal/cleanable/trash,
 /obj/structure/pole{
@@ -36475,6 +36991,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"jrK" = (
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/turf/open/openspace,
+/area/vtm/interior/strip)
 "jrM" = (
 /obj/structure/vampdoor,
 /obj/effect/mapping_helpers/door/access/malkavian,
@@ -36607,18 +37129,6 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
-"jtL" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/ammo_box/darkpack/arrows,
-/obj/item/ammo_box/darkpack/arrows,
-/obj/item/ammo_box/darkpack/arrows,
-/obj/item/ammo_box/darkpack/arrows,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "jtM" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -36770,16 +37280,20 @@
 /turf/open/misc/grass,
 /area/vtm/outside/unionsquare)
 "juZ" = (
-/obj/structure/table/wood,
-/obj/vampire_computer,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/grey{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "jva" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "jvo" = (
 /obj/effect/turf_decal/bordur/corner{
@@ -36849,7 +37363,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
 "jws" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/grey{
@@ -36920,11 +37434,11 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop)
 "jxo" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "jxu" = (
 /obj/effect/decal/wallpaper/light,
@@ -36961,7 +37475,7 @@
 /obj/structure/table/wood,
 /obj/vampire_computer,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "jxT" = (
 /obj/machinery/light/prince/directional/east,
@@ -37038,10 +37552,6 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
-"jyW" = (
-/obj/structure/stairs/east,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/strip)
 "jzb" = (
 /obj/structure/ladder/manhole/up,
 /obj/machinery/light/small/directional/east,
@@ -37051,8 +37561,21 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "jzn" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /obj/machinery/light/directional/south,
+/obj/structure/chair/wood/darkpack/red{
+	dir = 1
+	},
 /turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
+"jzw" = (
+/obj/structure/hedge,
+/obj/machinery/light/directional/south,
+/obj/structure/decoration/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior/museum)
 "jzy" = (
 /obj/machinery/light/prince/directional/north,
@@ -37127,19 +37650,12 @@
 /obj/structure/werewolf_totem/generic/wyrm,
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/wyrm_corrupted)
-"jAh" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/support,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "jAm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "jAn" = (
 /obj/structure/chair/pew/left,
@@ -37248,18 +37764,11 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/dirt,
 /area/vtm/outside/pacificheights/forest)
-"jBn" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 12
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "jBp" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "jBr" = (
 /mob/living/carbon/human/npc/guard,
@@ -37333,11 +37842,20 @@
 /obj/effect/turf_decal/bordur{
 	dir = 4
 	},
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm/outside/park)
+"jCh" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "jCl" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -37409,6 +37927,10 @@
 /obj/structure/stairs/north,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
+"jDF" = (
+/obj/structure/platform/lowwall/market/window,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "jDG" = (
 /obj/structure/table,
 /turf/open/floor/plating/sidewalkalt,
@@ -37446,8 +37968,17 @@
 /obj/item/clothing/under/vampire/turtleneck_white,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry)
+"jDQ" = (
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/grey{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "jDS" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -37528,11 +38059,16 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry/basement)
 "jFg" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
+"jFh" = (
+/obj/structure/platform/lowwall/rich/old/window,
+/obj/effect/decal/wallpaper/paper/fancy/stripe/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "jFk" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -37579,12 +38115,8 @@
 	dir = 8;
 	pixel_x = -3
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
-"jFH" = (
-/obj/structure/ladder/manhole/up,
-/turf/open/floor/carpet/darkpack/redsilver,
-/area/vtm/interior/chantry)
 "jFI" = (
 /obj/effect/decal/cleanable/litter,
 /obj/structure/closet/crate/dumpster,
@@ -37592,6 +38124,7 @@
 /area/vtm/interior/sewer)
 "jFK" = (
 /obj/structure/vampdoor/old,
+/obj/effect/mapping_helpers/door/access/malkavian,
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
 "jFV" = (
@@ -37602,9 +38135,9 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "jFZ" = (
-/obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
-/turf/open/floor/carpet,
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "jGc" = (
 /obj/item/storage/box/lights/mixed,
@@ -37720,6 +38253,13 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior)
+"jIc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "jId" = (
 /obj/structure/table/wood,
 /obj/structure/retail/gummaguts_menu{
@@ -37859,11 +38399,11 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "jKu" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "jKx" = (
 /obj/machinery/light/directional/south,
@@ -37913,7 +38453,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/outside/park)
 "jKJ" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
 "jKL" = (
@@ -38012,11 +38552,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/ten,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f3)
-"jLV" = (
-/obj/structure/hedge,
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "jLW" = (
 /obj/structure/flora/rock/pile/darkpack,
 /obj/structure/vampfence/rich,
@@ -38078,6 +38613,10 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
+"jMG" = (
+/obj/structure/carving_block,
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "jMI" = (
 /obj/machinery/camera/directional/north{
 	network = list("Endron");
@@ -38107,12 +38646,6 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/misc/dirt,
 /area/vtm/outside/fishermanswharf)
-"jMP" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/vtm/interior)
 "jMU" = (
 /obj/structure/bed,
 /obj/machinery/light/prince/broken/directional/north,
@@ -38128,12 +38661,25 @@
 /area/vtm/outside/pacificheights/forest)
 "jNp" = (
 /obj/machinery/light/directional/east,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /mob/living/carbon/human/npc/shop,
 /turf/open/floor/wood/herring,
 /area/vtm/interior/shop/clothing_store)
+"jNs" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/item/wirecutters,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/turf/open/floor/light,
+/area/vtm/interior/strip)
 "jNw" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -38266,6 +38812,11 @@
 	},
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
+"jPv" = (
+/obj/structure/sink/directional/west,
+/obj/effect/decal/cleanable/cardboard,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "jPw" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -38304,7 +38855,7 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sabbat_lair)
 "jPT" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -38406,7 +38957,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "jQK" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/trash,
@@ -38616,7 +39167,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "jUb" = (
 /obj/machinery/light/directional/north,
@@ -38654,6 +39205,12 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
+"jUz" = (
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "jUA" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -38673,7 +39230,7 @@
 /obj/effect/mapping_helpers/door/access/giovanni,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /obj/effect/mapping_helpers/door/bash_difficulty/seven,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "jUH" = (
 /obj/structure/closet/crate/dumpster,
@@ -38726,7 +39283,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "jWk" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/rough,
@@ -38765,7 +39322,7 @@
 "jWz" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "jWC" = (
 /obj/structure/vampdoor/wood{
@@ -38823,9 +39380,8 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "jXc" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/plating/granite,
 /area/vtm/interior)
@@ -38873,7 +39429,7 @@
 /turf/open/water,
 /area/vtm/outside/pacificheights/old)
 "jYc" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
 "jYj" = (
@@ -38931,6 +39487,14 @@
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/misc/grass,
 /area/vtm/interior/hotel)
+"jYX" = (
+/obj/machinery/photocopier/gratis/prebuilt{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "jZa" = (
 /obj/structure/table,
 /obj/item/newspaper,
@@ -38946,11 +39510,6 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/endron_facility/restricted)
-"jZi" = (
-/obj/structure/curtain/cloth/fancy,
-/obj/structure/platform/lowwall/market/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/trujah)
 "jZo" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -38989,7 +39548,7 @@
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
 "kaf" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/city/saint,
@@ -39083,6 +39642,15 @@
 /obj/structure/noticeboard/directional/north,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"kbr" = (
+/obj/structure/chair/darkpack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "kbw" = (
 /obj/structure/vampfence,
 /turf/open/floor/plating/concrete,
@@ -39215,6 +39783,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"kdb" = (
+/obj/machinery/sprinkler/area_managed,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "kdd" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/wood{
@@ -39360,6 +39935,10 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
+"kex" = (
+/obj/effect/decal/wallpaper/paper/purple,
+/turf/closed/wall/vampwall/brick_old,
+/area/vtm/interior/hotel)
 "keA" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -39395,12 +39974,12 @@
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
 /obj/machinery/light/small/pink/directional/south,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "kfe" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /mob/living/carbon/human/npc/shop,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "kfj" = (
 /obj/effect/decal/wallpaper/grey,
@@ -39417,7 +39996,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
 "kfs" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/shop,
@@ -39434,10 +40013,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
-"kfO" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/anarch)
 "kfS" = (
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
@@ -39447,6 +40022,15 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
+"kgk" = (
+/obj/effect/turf_decal/siding/grey{
+	dir = 9
+	},
+/obj/structure/chair/darkpack/blue{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/clinic)
 "kgu" = (
 /turf/open/floor/city/circled,
 /area/vtm/interior/laundromat)
@@ -39516,11 +40100,26 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
+"khg" = (
+/obj/structure/sign/flag/spain{
+	pixel_y = 29;
+	pixel_x = 17
+	},
+/obj/structure/table/wood/fancy/orange,
+/obj/item/claymore/longsword{
+	desc = "A classic weapon of knightly use. Now a museum piece, supposedly a donation from the Old Church by the pier.";
+	name = "old longsword"
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "khl" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/reagent_containers/blood/a_minus,
@@ -39538,7 +40137,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/laundromat)
 "kht" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
@@ -39632,7 +40231,9 @@
 /turf/open/misc/grass,
 /area/vtm/interior/hotel)
 "kjv" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
 "kjB" = (
@@ -39672,21 +40273,26 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
-"kkd" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/strip)
 "kkh" = (
 /obj/effect/turf_decal/asphaltline,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/financialdistrict)
+"kki" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "kkj" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "kkn" = (
 /obj/machinery/shower/directional/west,
@@ -39718,7 +40324,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
 "kkR" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -39759,13 +40365,6 @@
 "klB" = (
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
-"klF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/hotel)
 "klP" = (
 /obj/effect/turf_decal/asphalt{
 	icon_state = "decal9"
@@ -39779,7 +40378,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/outside/fishermanswharf/ghetto)
 "klR" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /mob/living/carbon/human/npc/shop,
@@ -39796,9 +40395,8 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f4)
 "kmb" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
@@ -39806,7 +40404,7 @@
 /obj/structure/chair/sofa/corner/brown{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "kmd" = (
 /obj/structure/toilet{
@@ -39828,7 +40426,7 @@
 /area/vtm/outside/forest)
 "kmi" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "kmm" = (
 /turf/open/water/beach/vamp,
@@ -39922,15 +40520,31 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/graveyard)
+"knf" = (
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/obj/structure/rack/tall/wood_shelf,
+/obj/item/storage/box/syringes{
+	pixel_x = 9;
+	pixel_y = 18
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "knj" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/weapon_showcase,
-/turf/open/floor/plating/granite/black,
+/turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
 "knk" = (
 /obj/machinery/light/directional/north,
@@ -39962,13 +40576,6 @@
 "kno" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"knr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/cyan,
-/area/vtm/interior/hotel)
 "kns" = (
 /obj/effect/decal/cleanable/garbage{
 	pixel_x = 10;
@@ -40022,15 +40629,18 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights/old)
 "kog" = (
-/obj/structure/mannequin/plastic/napoleon,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/mannequin/plastic/conquistador,
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "kok" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/baali)
 "kos" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/iron/small,
@@ -40054,7 +40664,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "kpd" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
 "kpe" = (
@@ -40072,7 +40682,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "kpu" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/triad/red_pole,
@@ -40090,7 +40700,7 @@
 "kpE" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "kpI" = (
 /obj/item/chair/wood,
@@ -40109,19 +40719,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm)
-"kpP" = (
-/obj/structure/table/wood,
-/obj/item/lighter,
-/obj/item/storage/briefcase/secure{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/storage/briefcase{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "kpW" = (
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/rough,
@@ -40139,7 +40736,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "kqo" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/effect/landmark/start/darkpack/law_enforcement/sergeant,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
@@ -40150,7 +40747,7 @@
 /area/vtm/interior/ghetto)
 "kqJ" = (
 /obj/effect/landmark/start/darkpack/citizen/citizen,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "kqV" = (
 /obj/structure/closet/crate/coffin,
@@ -40351,6 +40948,14 @@
 	},
 /turf/open/misc/grass,
 /area/vtm)
+"ktg" = (
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 1;
+	pixel_y = 32
+	},
+/obj/weapon_showcase,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "ktj" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/hedge,
@@ -40363,6 +40968,10 @@
 	},
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/sewer)
+"ktA" = (
+/obj/item/shovel/vamp,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "ktE" = (
 /turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/church/haven)
@@ -40374,7 +40983,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "ktP" = (
 /obj/effect/turf_decal/siding/white,
@@ -40411,6 +41020,15 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
+"kuq" = (
+/obj/effect/turf_decal/bordur{
+	dir = 4
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "kut" = (
 /obj/effect/turf_decal/bordur,
 /turf/closed/wall/vampwall/market,
@@ -40431,7 +41049,7 @@
 /area/vtm/interior/millennium_tower)
 "kuH" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "kuN" = (
 /obj/effect/landmark/start/darkpack/law_enforcement/sergeant,
@@ -40460,7 +41078,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "kvt" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
@@ -40524,7 +41142,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "kwk" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/concrete,
@@ -40536,7 +41154,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/caern)
 "kwr" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -40551,7 +41169,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "kwC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40569,7 +41187,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "kwW" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/iron/white/corner{
@@ -40593,7 +41211,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "kxf" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/clothing_store)
 "kxh" = (
@@ -40617,7 +41235,7 @@
 /obj/structure/table/wood,
 /obj/structure/coclock,
 /obj/machinery/light/small/pink/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "kxy" = (
 /obj/effect/turf_decal/bordur{
@@ -40657,6 +41275,12 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"kxV" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/museum)
 "kxY" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth/old,
@@ -40664,14 +41288,9 @@
 "kxZ" = (
 /turf/open/misc/dirt,
 /area/vtm/outside/pacificheights/old)
-"kyt" = (
-/obj/structure/table/countertop/bacotell,
-/obj/structure/retail/bacotell_menu,
-/turf/open/floor/city/bacotell,
-/area/vtm/interior/shop/bacotell)
 "kyu" = (
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "kyB" = (
 /turf/open/floor/wood/smooth/old,
@@ -40704,7 +41323,7 @@
 "kyT" = (
 /obj/structure/hedge,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "kyY" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -40845,7 +41464,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
 "kBp" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -40905,11 +41524,11 @@
 /area/vtm/interior/tzimisce_manor)
 "kBQ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "kCh" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "kCj" = (
 /obj/structure/railing,
@@ -40973,11 +41592,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/giovanni/courtyard)
-"kDc" = (
-/obj/machinery/photocopier/prebuilt,
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "kDd" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk,
@@ -41018,9 +41632,11 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
 "kDz" = (
-/obj/structure/mannequin/plastic/conquistador,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1
+	},
 /turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "kDJ" = (
 /obj/structure/railing{
 	dir = 4
@@ -41031,20 +41647,9 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
-"kDM" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/vampdoor/old,
-/obj/effect/mapping_helpers/door/access/chantry,
-/obj/effect/mapping_helpers/door/lock,
-/obj/effect/mapping_helpers/door/bash_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock_difficulty/eight,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm/interior/chantry)
 "kDN" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "kDR" = (
@@ -41072,7 +41677,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "kEk" = (
 /obj/machinery/light/floor/lamppost/one{
@@ -41107,7 +41712,7 @@
 /area/vtm/interior)
 "kEC" = (
 /obj/machinery/light/directional/west,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/plating,
@@ -41209,6 +41814,13 @@
 /obj/vampire_computer,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/baali)
+"kFU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "kFZ" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating/rough,
@@ -41236,13 +41848,17 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/anarch)
+"kGi" = (
+/obj/effect/decal/wallpaper/red,
+/turf/closed/wall/vampwall/brick_old,
+/area/vtm/interior/hotel)
 "kGl" = (
 /turf/open/water/beach/vamp/deep,
 /area/vtm/interior/cog/caern)
 "kGu" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "kGw" = (
 /obj/structure/table,
@@ -41261,12 +41877,18 @@
 /obj/structure/bed/maint,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/giovanni/basement)
+"kGG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/greengold,
+/area/vtm/interior/hotel)
 "kGM" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /mob/living/carbon/human/npc/guard,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "kGT" = (
 /mob/living/carbon/human/npc/endronexecsecurity,
@@ -41274,7 +41896,7 @@
 /area/vtm/interior/wyrm_corrupted)
 "kGV" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -41298,11 +41920,6 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
-"kHg" = (
-/obj/structure/filingcabinet/white,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/carpet/darkpack/redsilver,
-/area/vtm/interior/chantry)
 "kHm" = (
 /obj/structure/city_map,
 /obj/effect/turf_decal/bordur{
@@ -41320,10 +41937,10 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
 "kHp" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "kHq" = (
 /obj/structure/railing{
@@ -41378,7 +41995,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "kIs" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/old,
@@ -41387,7 +42004,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -41411,11 +42028,30 @@
 	pixel_x = 5;
 	pixel_y = -4
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
+"kIQ" = (
+/obj/structure/bed/maint,
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/obj/structure/vampipe{
+	icon_state = "piping4";
+	pixel_y = 32
+	},
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
+"kIU" = (
+/obj/effect/turf_decal/siding/grey/inner_corner,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/strip)
 "kIZ" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -41426,7 +42062,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -41441,6 +42077,10 @@
 /obj/structure/sign/city/chinese/directional/west,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/chinatown)
+"kJo" = (
+/obj/effect/landmark/start/darkpack/citizen/citizen,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/hotel)
 "kJp" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/light/prince/directional/east,
@@ -41482,12 +42122,12 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "kKa" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
 "kKf" = (
 /obj/effect/decal/cleanable/trash,
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/litter,
@@ -41536,7 +42176,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/vjanitor)
 "kKV" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /mob/living/basic/pet/cat/darkpack,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/wood/smooth,
@@ -41584,6 +42224,12 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
+"kLF" = (
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "kLG" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -41596,7 +42242,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "kMb" = (
 /obj/structure/table,
@@ -41646,17 +42292,20 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
-"kMx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/black,
-/area/vtm/interior/hotel)
 "kMP" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
+"kMQ" = (
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "kMR" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth/old,
@@ -41665,13 +42314,6 @@
 /obj/item/clothing/head/costume/crown,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer/nosferatu_town)
-"kMU" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/mob/living/carbon/human/npc/incel,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "kMW" = (
 /obj/effect/decal/wallpaper/trim/green,
 /turf/closed/wall/vampwall/market,
@@ -41687,11 +42329,11 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic)
 "kNo" = (
-/obj/structure/chair/greyscale,
 /obj/effect/turf_decal/siding/grey{
 	dir = 10
 	},
 /obj/effect/landmark/start/darkpack/hospital/clinic_guard,
+/obj/structure/chair/darkpack/blue,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "kNr" = (
@@ -41826,7 +42468,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop/bacotell)
 "kOE" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/trash,
@@ -41864,13 +42506,13 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "kPd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "kPe" = (
 /obj/effect/decal/pallet{
@@ -41939,14 +42581,8 @@
 /area/vtm/interior/supply)
 "kPT" = (
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
-"kPZ" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "kQc" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -42147,7 +42783,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/music_store)
 "kSg" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
@@ -42186,7 +42822,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/granite/black,
@@ -42210,7 +42846,7 @@
 	dir = 1;
 	pixel_y = 3
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "kSU" = (
 /obj/structure/vampfence{
@@ -42237,9 +42873,8 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/techshop)
 "kSY" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer)
@@ -42248,12 +42883,6 @@
 /obj/structure/platform/lowwall/city,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/salubri)
-"kTa" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/city/church,
-/area/vtm/interior/church/haven)
 "kTd" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -42264,7 +42893,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "kTe" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/vjanitor)
@@ -42437,7 +43066,7 @@
 "kVA" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "kVB" = (
 /obj/structure/closet/cabinet,
@@ -42504,15 +43133,15 @@
 /area/vtm/interior/chantry/basement)
 "kWl" = (
 /obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "kWn" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "kWp" = (
-/obj/structure/table/wood,
 /obj/item/flashlight,
+/obj/structure/table/wood/bar,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "kWq" = (
@@ -42554,7 +43183,7 @@
 /turf/open/water/bloodwave,
 /area/vtm/interior/chantry/basement)
 "kWI" = (
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/jazzclub)
 "kWJ" = (
@@ -42671,7 +43300,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "kYe" = (
 /turf/open/water/vamp_sewer,
@@ -42735,7 +43364,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "kZn" = (
 /obj/effect/turf_decal/bordur{
@@ -42761,7 +43390,7 @@
 /area/vtm)
 "kZE" = (
 /obj/effect/turf_decal/siding/white,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -42862,6 +43491,13 @@
 	},
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/smoke_shop)
+"laC" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "laG" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/white{
@@ -42963,17 +43599,12 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
-"lbB" = (
-/obj/structure/table/wood/fancy/red,
-/obj/structure/retail/library,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "lbE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "lbH" = (
 /obj/structure/vampdoor/simple{
@@ -43120,7 +43751,7 @@
 /area/vtm/interior/hotel)
 "ldr" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /obj/item/reagent_containers/blood/a_minus,
 /turf/open/floor/wood,
 /area/vtm/interior/church/haven)
@@ -43202,7 +43833,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/tzimisce_manor)
 "lem" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -43284,7 +43915,7 @@
 /turf/open/lava,
 /area/vtm/interior)
 "lfk" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/old,
@@ -43390,12 +44021,6 @@
 /obj/structure/barrels/rand,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/ghetto)
-"lgP" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/clothing/suit/vampire/noddist,
-/obj/item/clothing/suit/vampire/noddist,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "lgU" = (
 /obj/structure/hedge,
 /obj/structure/railing{
@@ -43426,7 +44051,7 @@
 	pixel_x = -3;
 	pixel_y = 9
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "lgX" = (
 /obj/machinery/light/warm/directional/south,
@@ -43434,10 +44059,10 @@
 /area/vtm/interior/bianchiBank)
 "lgZ" = (
 /obj/structure/table/wood/billiard,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "lhd" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/bacotell,
@@ -43491,13 +44116,13 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower)
 "lhF" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "lhU" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk,
@@ -43587,7 +44212,7 @@
 /area/vtm/interior/sewer)
 "ljt" = (
 /obj/effect/landmark/start/darkpack/citizen/citizen,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "lju" = (
 /obj/structure/table/wood/fancy/royalblack,
@@ -43749,7 +44374,7 @@
 /obj/structure/chair/sofa/corp/corner,
 /mob/living/carbon/human/npc/incel,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "lmu" = (
 /obj/structure/platform/lowwall/market/window,
@@ -43772,7 +44397,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/tzimisce_manor)
 "lmZ" = (
@@ -43828,17 +44453,17 @@
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "lnC" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "lnH" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "lnN" = (
 /obj/effect/turf_decal/siding/white,
@@ -43853,7 +44478,7 @@
 "lnX" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/fork,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "lod" = (
 /obj/machinery/light/directional/west,
@@ -43905,15 +44530,6 @@
 /obj/item/clothing/suit/vampire/jacket,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
-"loD" = (
-/obj/structure/table/wood,
-/obj/item/flashlight,
-/obj/structure/coclock,
-/obj/item/molotov,
-/obj/item/molotov,
-/obj/item/molotov,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/hotel)
 "loG" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth/old,
@@ -44017,7 +44633,7 @@
 /area/vtm/outside/fishermanswharf)
 "lpX" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "lqg" = (
 /obj/structure/bed/maint,
@@ -44028,7 +44644,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
 "lqk" = (
@@ -44048,6 +44664,12 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
+"lqu" = (
+/obj/effect/decal/cleanable/trash{
+	icon_state = "trash7"
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "lqw" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -44090,7 +44712,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "lqN" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /mob/living/carbon/human/npc/shop,
 /obj/effect/mapping_helpers/mob_buckler,
 /obj/structure/sign/painting/library{
@@ -44236,7 +44858,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/ghetto)
 "ltF" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "ltN" = (
@@ -44411,7 +45033,7 @@
 /obj/item/flashlight/flare/candle/infinite{
 	anchored = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "lwn" = (
 /turf/open/floor/plating/canal,
@@ -44459,6 +45081,13 @@
 /obj/structure/stairs/east,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
+"lxt" = (
+/obj/structure/chair/stool/bar/darkpack/black,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "lxx" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/pallet{
@@ -44526,7 +45155,7 @@
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/jazzclub)
 "lya" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk,
@@ -44615,7 +45244,7 @@
 /area/vtm/interior/millennium_tower/f3)
 "lzn" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "lzw" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -44644,7 +45273,7 @@
 /turf/open/floor/city/circled,
 /area/vtm/interior/salubri)
 "lzT" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/landmark/start/darkpack/citizen/janitor,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
@@ -44660,7 +45289,7 @@
 	pixel_x = -2;
 	pixel_y = 23
 	},
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/hospital/doctor,
@@ -44742,14 +45371,14 @@
 /obj/structure/vampdoor/glass{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/door/access/clinic,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
 /obj/effect/mapping_helpers/door/bash_difficulty/seven,
+/obj/effect/mapping_helpers/door/access/malkavian,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
 "lCf" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -44990,7 +45619,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/hecata/squadra,
@@ -45184,7 +45813,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/setite)
 "lGZ" = (
 /obj/effect/turf_decal/bordur/corner{
@@ -45230,7 +45859,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 6
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "lHx" = (
@@ -45240,7 +45868,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
 "lHF" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
 "lHG" = (
@@ -45279,14 +45907,21 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "lHX" = (
-/obj/structure/hedge,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/table/wood/fancy/blue,
+/obj/item/melee/sabre/rapier{
+	name = "old rapier";
+	desc = "An engraved and brittle rapier with a bent tip. Supposedly, it was used in some historic battle."
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "lHY" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "lIb" = (
 /obj/effect/decal/cleanable/litter,
@@ -45309,10 +45944,10 @@
 	dir = 4
 	},
 /obj/machinery/light/warm/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "lIB" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/misc/dirt,
 /area/vtm/interior/sewer/nosferatu_town)
 "lID" = (
@@ -45366,7 +46001,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
 "lJI" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "lJP" = (
@@ -45378,12 +46013,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"lJY" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "lJZ" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/mapping_helpers/door/access/claimable,
@@ -45391,7 +46020,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/ghetto)
 "lKb" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /mob/living/carbon/human/npc/guard,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
@@ -45399,11 +46028,6 @@
 /obj/structure/fluff/beach_umbrella/syndi,
 /turf/open/misc/beach/vamp,
 /area/vtm/outside/northbeach)
-"lKj" = (
-/obj/structure/chair/stool/bar,
-/mob/living/carbon/human/npc/incel,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "lKq" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -45529,11 +46153,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf)
-"lLK" = (
-/obj/machinery/jukebox,
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/city/plating,
-/area/vtm/interior/strip)
 "lLW" = (
 /obj/effect/turf_decal/asphaltline/yellow{
 	pixel_x = 0;
@@ -45551,7 +46170,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "lMf" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/pentex/employee,
@@ -45669,6 +46288,10 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"lNy" = (
+/obj/structure/table,
+/turf/open/floor/light,
+/area/vtm/interior/strip)
 "lND" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -45763,11 +46386,10 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
 "lOV" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/table/wood/fancy/cyan,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "lPc" = (
 /obj/machinery/light/floor/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk,
@@ -45853,9 +46475,8 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm/interior/tzimisce_manor)
 "lQN" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/techshop)
@@ -45870,7 +46491,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "lQT" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -45890,7 +46511,7 @@
 "lRB" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/darkpack/camarilla/sheriff,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "lRD" = (
 /mob/living/basic/pet/dog/pug,
@@ -45902,10 +46523,10 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer/nosferatu_town)
 "lRG" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "lRM" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -45915,7 +46536,7 @@
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/millennium_tower)
 "lRU" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/camarilla/sheriff,
@@ -45931,7 +46552,7 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/tzimisce_manor)
 "lSb" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
 "lSc" = (
@@ -45947,10 +46568,6 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/financialdistrict)
-"lSe" = (
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "lSg" = (
 /obj/effect/turf_decal/darkpack/rough{
 	dir = 1
@@ -46103,7 +46720,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "lTY" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth,
@@ -46159,6 +46776,32 @@
 /obj/machinery/sprinkler,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/gummaguts)
+"lUC" = (
+/obj/structure/rack/tall/store_shelf_metal,
+/obj/item/vampire_stake{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/vampire_stake{
+	pixel_y = 4;
+	pixel_x = 6
+	},
+/obj/item/gun/ballistic/shotgun/vampire{
+	pixel_y = 29
+	},
+/obj/item/ammo_box/darkpack/c12g/buck{
+	pixel_y = 18
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = -7;
+	pixel_x = -7
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = -7;
+	pixel_x = 7
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "lUE" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6;
@@ -46180,7 +46823,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
 "lUN" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/banu)
 "lUO" = (
@@ -46205,7 +46848,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
 "lVa" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -46229,7 +46872,7 @@
 /area/vtm/interior/ghetto)
 "lVk" = (
 /obj/effect/decal/cleanable/trash,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -46351,15 +46994,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/ghetto)
-"lWx" = (
-/obj/structure/table/wood,
-/obj/item/clothing/gloves/vampire/latex,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes/variety,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/police/fed)
 "lWA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -46450,7 +47084,7 @@
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
 "lXw" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/captain,
@@ -46469,7 +47103,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "lXK" = (
 /obj/item/stack/dollar/five,
@@ -46480,15 +47114,6 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"lXQ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire,
-/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "lXR" = (
 /turf/open/floor/iron/stairs,
 /area/vtm/interior/tzimisce_manor)
@@ -46635,7 +47260,7 @@
 /area/vtm)
 "mab" = (
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "mai" = (
 /obj/effect/decal/cleanable/litter,
@@ -46664,7 +47289,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/shop/camping_store)
 "maD" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "maF" = (
@@ -46675,13 +47300,6 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
-"mbl" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/automatic/pistol/darkpack/m1911,
-/obj/item/card/hunter,
-/obj/vampire_computer,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/hotel)
 "mbn" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -46761,7 +47379,7 @@
 "mcK" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/cannabis,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "mcS" = (
 /obj/effect/turf_decal/siding/dark_blue/corner{
@@ -46796,7 +47414,7 @@
 /area/vtm/interior/millennium_tower/f4)
 "mdj" = (
 /obj/machinery/vending/dinnerware,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "mdm" = (
 /obj/machinery/shower/directional/south,
@@ -46833,13 +47451,20 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/closed/wall/vampwall/rock,
 /area/vtm/outside/forest)
+"mdy" = (
+/obj/machinery/light/prince/directional/east,
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/chantry)
 "mdC" = (
 /obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/access/banu,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "mdD" = (
 /obj/machinery/vending/snack{
@@ -46847,6 +47472,17 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
+"mdN" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/decal/shadow,
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "mdQ" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -46900,7 +47536,7 @@
 "mej" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/darkpack/society_of_leopold/abbe,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "mes" = (
 /turf/closed/wall/vampwall/junk/alt,
@@ -46923,13 +47559,13 @@
 	dir = 1;
 	pixel_y = 3
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
 "meV" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "meW" = (
 /obj/effect/turf_decal/bordur{
@@ -46988,7 +47624,7 @@
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "mfA" = (
 /obj/structure/sign/city/store/bacotell/directional/north{
@@ -47187,6 +47823,9 @@
 /area/vtm/interior/clinic)
 "mhN" = (
 /obj/machinery/light/small/directional/east,
+/obj/structure/railing/darkpack/metal{
+	dir = 8
+	},
 /turf/open/openspace,
 /area/vtm/interior)
 "mhP" = (
@@ -47254,7 +47893,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "miV" = (
 /obj/structure/sink/directional/south,
@@ -47309,14 +47948,14 @@
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "mjA" = (
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
 "mjB" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -47355,7 +47994,7 @@
 /turf/open/misc/dirt,
 /area/vtm)
 "mkd" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/baali)
 "mke" = (
 /obj/structure/table/wood,
@@ -47419,8 +48058,8 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "mlE" = (
-/obj/structure/chair/wood,
-/turf/open/floor/carpet,
+/obj/structure/chair/wood/darkpack/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "mlG" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -47578,7 +48217,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "mnC" = (
 /obj/effect/turf_decal/siding/wood,
@@ -47608,7 +48247,7 @@
 	pixel_y = 15
 	},
 /obj/machinery/light/directional/south,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/hospital/doctor,
@@ -47694,7 +48333,7 @@
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "moX" = (
 /turf/open/misc/dirt,
@@ -47705,14 +48344,6 @@
 /obj/item/circular_saw,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/tzimisce_sanctum)
-"mpf" = (
-/obj/structure/vampdoor/simple{
-	lockpick_difficulty = 15;
-	lock_id = "tmr";
-	locked = 1
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "mpn" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth/old,
@@ -47819,10 +48450,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "mqR" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/siding/grey/inner_corner{
+	dir = 1
 	},
-/turf/open/floor/plating/granite/black,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/strip)
 "mqV" = (
 /obj/effect/turf_decal/siding/white{
@@ -47889,7 +48524,7 @@
 "msg" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/occult/artifact,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/sewer/nosferatu_town)
 "msq" = (
 /turf/open/floor/plating/sidewalk/poor,
@@ -47960,7 +48595,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/forest)
 "mtQ" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
@@ -47975,7 +48610,7 @@
 "mtU" = (
 /obj/structure/table,
 /obj/item/storage/medkit/darkpack/standard,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "mtY" = (
 /obj/structure/roofstuff/alt1,
@@ -47990,15 +48625,23 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/northbeach)
 "mul" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/machinery/light/directional/west,
+/obj/item/clothing/neck/vampire/prayerbeads{
+	pixel_x = 0;
+	pixel_y = 13
 	},
-/obj/structure/vampstatue{
-	name = "statue to the Del'Roh"
+/obj/item/clothing/neck/vampire/prayerbeads{
+	pixel_x = 7;
+	pixel_y = 6
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/item/card/noddist,
+/obj/item/card/noddist,
+/obj/effect/turf_decal/siding/grey{
+	dir = 10
+	},
+/obj/structure/table/wood/fancy/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "mum" = (
 /obj/effect/landmark/npcwall,
 /obj/structure/vampfence/corner/rich{
@@ -48021,7 +48664,7 @@
 /area/vtm/interior/bianchiBank)
 "mux" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "muB" = (
 /obj/item/clothing/head/vampire/skull,
@@ -48032,14 +48675,6 @@
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/old)
-"muI" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/obj/machinery/light/directional/south,
-/mob/living/carbon/human/npc/guard,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/museum)
 "muJ" = (
 /obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/access/npc,
@@ -48059,7 +48694,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "muW" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -48153,19 +48788,21 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/jazzclub)
 "mwz" = (
+/obj/effect/turf_decal/siding/grey{
+	dir = 1
+	},
 /obj/structure/railing{
-	pixel_y = -2
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/effect/decal/wallpaper/papers/random{
+	pixel_y = 27
 	},
-/mob/living/carbon/human/npc/shop,
-/turf/open/floor/city/plating_mono,
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/strip)
 "mwA" = (
-/obj/structure/chair/greyscale,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/grey,
+/obj/structure/chair/darkpack/blue,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "mwB" = (
@@ -48375,12 +49012,11 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
 "myU" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "myX" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /obj/machinery/light/prince/directional/west,
 /turf/open/floor/wood/smooth/old,
@@ -48389,7 +49025,7 @@
 /obj/structure/railing{
 	pixel_y = -1
 	},
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -48416,20 +49052,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
 "mzn" = (
-/obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
+/obj/structure/table/wood/bar,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "mzq" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/misc/dirt,
 /area/vtm/interior/supply)
-"mzr" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/trujah)
 "mzs" = (
 /obj/structure/cargo_put,
 /turf/open/floor/plating/rough,
@@ -48447,7 +49077,7 @@
 /area/vtm/outside/fishermanswharf/lower)
 "mzA" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "mzP" = (
 /obj/effect/turf_decal/bordur,
@@ -48480,7 +49110,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/police)
 "mAw" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
@@ -48490,6 +49120,13 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/giovanni/courtyard)
+"mAA" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/end,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "mAB" = (
 /obj/item/toy/crayon/spraycan,
 /turf/open/floor/plating/sidewalk,
@@ -48507,7 +49144,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "mAL" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "mAU" = (
 /obj/structure/vampdoor/wood,
@@ -48518,8 +49155,8 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
 "mAW" = (
-/obj/structure/chair/wood/wings,
-/turf/open/floor/plating/sidewalk/poor,
+/obj/structure/platform/lowwall/rich/old/window,
+/turf/open/floor/plating/rough,
 /area/vtm/interior/library)
 "mBa" = (
 /obj/effect/turf_decal/siding/grey/corner{
@@ -48594,7 +49231,7 @@
 "mCj" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "mCk" = (
 /turf/open/floor/plating/concrete,
@@ -48653,7 +49290,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "mDa" = (
 /obj/structure/closet/crate/dumpster,
@@ -48695,7 +49332,7 @@
 /area/vtm/interior/clinic)
 "mDw" = (
 /obj/structure/ladder/manhole/up,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "mDx" = (
 /obj/effect/decal/pallet{
@@ -48714,7 +49351,7 @@
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/radio,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "mDF" = (
 /obj/structure/table/wood/shuttle_bar,
@@ -48723,6 +49360,10 @@
 "mDG" = (
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/upstairs)
+"mDI" = (
+/obj/structure/table/wood,
+/turf/open/floor/city/toilet,
+/area/vtm/interior/chantry)
 "mDK" = (
 /obj/structure/table/wood,
 /obj/item/paper{
@@ -48734,7 +49375,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "mDQ" = (
 /obj/machinery/light/directional/north,
@@ -48840,17 +49481,12 @@
 /area/vtm/interior)
 "mFk" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/church/haven)
 "mFl" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
-"mFB" = (
-/obj/machinery/light/directional/east,
-/obj/weapon_showcase,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "mFC" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough,
@@ -48878,7 +49514,7 @@
 "mFU" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "mGb" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sink/directional/south,
@@ -48915,7 +49551,7 @@
 "mGM" = (
 /obj/effect/decal/cleanable/cardboard,
 /obj/machinery/light/warm/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "mGQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -49009,6 +49645,13 @@
 /obj/effect/abstract/cargo_landing_spot,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
+"mHK" = (
+/obj/effect/turf_decal/bordur/corner{
+	dir = 8
+	},
+/obj/structure/roofstuff/vent_end,
+/turf/open/floor/plating/rough,
+/area/vtm)
 "mHV" = (
 /obj/effect/decal/wallpaper/stone,
 /obj/keypad/panic_room,
@@ -49234,7 +49877,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "mKv" = (
 /obj/structure/table/wood,
@@ -49255,6 +49898,10 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/millennium_tower/ventrue)
+"mKT" = (
+/obj/effect/decal/wallpaper,
+/turf/closed/wall/vampwall/rich/old,
+/area/vtm/interior/museum)
 "mKV" = (
 /obj/structure/roofstuff/vent_end,
 /turf/open/floor/wood/old,
@@ -49265,13 +49912,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
-"mKY" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/mask/vampire/balaclava,
-/obj/item/shovel/vamp,
-/obj/item/clothing/suit/vampire/trench,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/hotel)
 "mLa" = (
 /obj/structure/table,
 /obj/underplate{
@@ -49330,12 +49970,12 @@
 "mLF" = (
 /obj/structure/table,
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "mLG" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/sewer/nosferatu_town)
 "mLS" = (
 /obj/effect/turf_decal/bordur{
@@ -49405,13 +50045,13 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "mME" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
 "mMP" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/plating_mono,
@@ -49423,7 +50063,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "mMW" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -49432,25 +50072,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
-"mNa" = (
-/obj/structure/chair/comfy/brown{
-	color = "#50C878";
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/chantry)
 "mNb" = (
-/obj/structure/vampstatue{
-	name = "statue to the Del'Roh"
-	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "mNd" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -49593,7 +50218,7 @@
 /obj/structure/railing{
 	pixel_y = -2
 	},
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -49632,8 +50257,8 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/glasswalker)
 "mPa" = (
-/obj/structure/chair/office,
-/turf/open/floor/carpet,
+/obj/structure/chair/office/darkpack/black,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "mPc" = (
 /obj/structure/table,
@@ -49727,11 +50352,11 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
 "mQe" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/structure/sign/city/order{
 	pixel_y = 26
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "mQp" = (
 /obj/effect/turf_decal/siding/white{
@@ -49893,11 +50518,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "mRW" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/baali)
 "mSe" = (
 /obj/effect/decal/cleanable/litter,
@@ -49934,9 +50559,8 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
@@ -49959,13 +50583,16 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/park)
 "mSF" = (
-/obj/structure/railing{
-	pixel_y = -2
+/obj/effect/turf_decal/siding/grey{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/effect/turf_decal/siding/white,
-/obj/structure/retail/smoke_menu,
-/turf/open/floor/city/plating_mono,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/strip)
 "mSI" = (
 /obj/effect/turf_decal/siding/white,
@@ -50005,7 +50632,7 @@
 /area/vtm/interior/millennium_tower/ventrue)
 "mSW" = (
 /obj/machinery/light/small/pink/directional/west,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "mSZ" = (
 /obj/effect/turf_decal/bordur,
@@ -50063,7 +50690,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "mTM" = (
 /obj/structure/ladder/manhole/up,
@@ -50114,7 +50741,7 @@
 /obj/item/taperecorder{
 	pixel_x = 3
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "mUV" = (
 /obj/effect/turf_decal/asphalt{
@@ -50153,7 +50780,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/anarch)
 "mVc" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "mVg" = (
 /turf/open/floor/iron/stairs,
@@ -50181,7 +50808,7 @@
 /area/vtm/interior/graveyard)
 "mVz" = (
 /obj/item/fishing_rod,
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/old,
@@ -50267,6 +50894,15 @@
 /obj/item/pushbroom,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/clinic)
+"mWJ" = (
+/obj/effect/turf_decal/bordur/corner{
+	dir = 8
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "mWL" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror{
@@ -50390,7 +51026,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
 "mXR" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/bandit,
@@ -50400,7 +51036,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "mXS" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/structure/coclock,
 /obj/structure/sign/poster/random/directional/north,
 /mob/living/carbon/human/npc/shop,
@@ -50436,7 +51072,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "mYy" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white,
@@ -50524,6 +51160,12 @@
 "mZu" = (
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f2)
+"mZy" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "mZA" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice/d6,
@@ -50586,7 +51228,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "nac" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/pentex/sec,
@@ -50695,7 +51337,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior)
 "nbr" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
@@ -50711,9 +51353,9 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/bianchiBank)
 "nby" = (
-/obj/structure/coclock,
-/turf/open/floor/wood/old,
-/area/vtm/interior/trujah)
+/obj/structure/stairs/west,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "nbz" = (
 /obj/effect/decal/cleanable/trash,
 /obj/structure/cable/layer1,
@@ -50790,8 +51432,12 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/bianchiBank)
 "ncV" = (
-/obj/structure/mannequin/plastic/conquistador,
-/turf/open/floor/city/plating,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/darkpack/black,
+/obj/item/paint_palette,
+/turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
 "nda" = (
 /obj/effect/turf_decal/bordur{
@@ -50922,7 +51568,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
 "neS" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/city/circled,
@@ -51088,13 +51734,6 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/forest)
-"nhh" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
-/area/vtm/interior/hotel)
 "nhk" = (
 /obj/structure/city_map,
 /turf/closed/wall/vampwall/painted,
@@ -51103,7 +51742,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars,
 /obj/item/lighter,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "nhn" = (
 /obj/effect/turf_decal/stock{
@@ -51115,6 +51754,13 @@
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
+"nhp" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior/library)
 "nhr" = (
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 4
@@ -51176,7 +51822,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "nhU" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
@@ -51222,10 +51868,10 @@
 /obj/item/instrument/violin{
 	name = "violin"
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "niy" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -51321,9 +51967,10 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "njS" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/grey,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "njT" = (
 /obj/effect/decal/cleanable/trash,
 /obj/effect/turf_decal/asphaltline/alt/white{
@@ -51426,10 +52073,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
-"nlC" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "nlD" = (
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/carpet/green,
@@ -51446,7 +52089,7 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f4)
 "nlY" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "nmd" = (
 /obj/structure/vampdoor/old,
@@ -51480,7 +52123,7 @@
 /area/vtm/interior/cog/caern)
 "nmC" = (
 /obj/effect/landmark/start/darkpack/citizen/citizen,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "nmQ" = (
 /obj/structure/bookcase/random,
@@ -51494,13 +52137,13 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
 "nmU" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "nmY" = (
 /obj/structure/bed,
@@ -51574,10 +52217,6 @@
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/junk,
 /area/vtm/interior/clinic/haven)
-"noj" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/trujah)
 "non" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/turf_decal/bordur{
@@ -51617,7 +52256,7 @@
 "not" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/dresser,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "nox" = (
 /obj/machinery/light/directional/south,
@@ -51651,18 +52290,18 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
 "npg" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/effect/turf_decal/siding/grey{
+	dir = 6
 	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "npj" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "npw" = (
 /obj/item/kirbyplants/random,
@@ -51752,7 +52391,7 @@
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "nqZ" = (
 /obj/structure/vampdoor/glass{
@@ -51810,7 +52449,7 @@
 /area/vtm/interior/jazzclub)
 "nrD" = (
 /obj/structure/bookcase/random/religion,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "nrH" = (
 /obj/machinery/light/small/red/directional/north,
@@ -51899,6 +52538,10 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/gummaguts)
+"nsO" = (
+/obj/effect/decal/wallpaper/grey,
+/turf/closed/wall/vampwall/brick_old,
+/area/vtm/interior/hotel)
 "nsS" = (
 /obj/machinery/button/door{
 	id = "pentexhq_storage"
@@ -51958,6 +52601,15 @@
 /obj/item/newspaper,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower)
+"ntE" = (
+/obj/structure/chair/office/darkpack/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "ntK" = (
 /obj/structure/flora/bush/sparsegrass/style_random{
 	icon_state = "ywflowers_1"
@@ -52010,7 +52662,7 @@
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior/tzimisce_sanctum)
 "num" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/citizen/priest,
@@ -52036,7 +52688,7 @@
 	dir = 1;
 	pixel_y = 12
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "nuC" = (
 /obj/structure/rack,
@@ -52108,10 +52760,10 @@
 /area/vtm/interior/police/morgue)
 "nvL" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "nvR" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -52320,7 +52972,7 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "nyL" = (
 /obj/structure/table/wood/fancy/black,
@@ -52416,7 +53068,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
 "nAq" = (
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
 "nAM" = (
@@ -52427,7 +53079,7 @@
 "nAW" = (
 /obj/structure/table/wood,
 /obj/item/bong,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "nBd" = (
 /obj/effect/turf_decal/bordur{
@@ -52569,13 +53221,13 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
 "nCp" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "nCv" = (
 /obj/structure/closet/crate{
@@ -52729,7 +53381,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm)
 "nEm" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/landmark/start/darkpack/citizen/janitor,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/vjanitor)
@@ -52756,7 +53408,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/community)
 "nEv" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -52804,8 +53456,8 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
 "nEU" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet,
+/obj/structure/chair/stool/bar/darkpack/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "nFa" = (
 /obj/effect/turf_decal/bordur,
@@ -52838,6 +53490,12 @@
 	},
 /turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/sewer)
+"nFF" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "nFL" = (
 /obj/structure/flora/tree/vamp/pine,
 /obj/structure/vampfence/rich,
@@ -52921,8 +53579,11 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/shop/clothing_store)
 "nGZ" = (
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/trujah)
+/obj/structure/hedge,
+/obj/structure/decoration/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "nHe" = (
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/item/cigarette/pipe,
@@ -52997,7 +53658,7 @@
 "nHT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/blood/vitae,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/sewer/nosferatu_town)
 "nHW" = (
 /obj/structure/table,
@@ -53144,7 +53805,7 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "nJL" = (
 /obj/structure/table/wood,
@@ -53161,18 +53822,18 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "nJU" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "nJZ" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/shop,
 /obj/effect/mapping_helpers/mob_buckler,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/shop/pharmacy)
 "nKb" = (
 /obj/structure/closet,
@@ -53234,7 +53895,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
 "nKP" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/small/red/dim/directional/north,
 /turf/open/floor/plating/rough/cave,
@@ -53384,7 +54045,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "nMl" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
@@ -53392,7 +54053,7 @@
 "nMn" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/techshop)
 "nMs" = (
 /obj/effect/turf_decal/siding/white{
@@ -53468,6 +54129,13 @@
 /obj/item/wirecutters,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/baali)
+"nNj" = (
+/obj/structure/vampipe{
+	icon_state = "piping3";
+	pixel_y = 32
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "nNk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/concrete,
@@ -53481,17 +54149,10 @@
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
 "nNu" = (
-/obj/structure/chair/comfy/brown{
-	color = "#50C878";
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 6
+	dir = 5
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "nNz" = (
 /obj/effect/turf_decal/trimline/dark_green/corner{
@@ -53515,8 +54176,15 @@
 /obj/item/reagent_containers/blood/o_minus,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"nNN" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "nNQ" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -53626,6 +54294,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"nPg" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "nPi" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/coffee/vampire/robust,
@@ -53688,7 +54362,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "nPJ" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/ghetto)
 "nPL" = (
 /obj/effect/turf_decal/darkpack/dirt/corner,
@@ -53807,7 +54481,7 @@
 "nQP" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/pink/directional/south,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "nQQ" = (
 /obj/machinery/atm{
@@ -53855,8 +54529,13 @@
 /obj/structure/roadsign/fourway,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"nRp" = (
+/obj/structure/bookcase/random/fiction,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "nRt" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /mob/living/carbon/human/npc/shop,
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/circled,
@@ -53867,7 +54546,7 @@
 /area/vtm/interior/setite/basement)
 "nRB" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "nRD" = (
 /obj/effect/decal/cleanable/cardboard,
@@ -53967,7 +54646,7 @@
 "nSp" = (
 /obj/structure/pole,
 /mob/living/carbon/human/npc/stripper,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "nSq" = (
 /obj/structure/vampipe{
@@ -54008,19 +54687,19 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "nSO" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "nSY" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
 /obj/machinery/light/directional/south,
-/turf/open/floor/plating/granite/black,
+/obj/structure/easel,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
 "nTe" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/city/plating_mono,
@@ -54256,18 +54935,34 @@
 	pixel_y = 10
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "nWO" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
+"nWU" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/water,
+/area/vtm/interior/chantry)
 "nXb" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -54275,7 +54970,7 @@
 /area/vtm/interior/millennium_tower/f2)
 "nXc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating_mono,
@@ -54319,7 +55014,7 @@
 /area/vtm/interior/glasswalker)
 "nXw" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -54376,13 +55071,19 @@
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
 "nYo" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
 "nYp" = (
 /obj/darkpack_car/rand,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf/ghetto)
+"nYq" = (
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "nYv" = (
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/market,
@@ -54455,7 +55156,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 10
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "nZz" = (
 /obj/effect/turf_decal/siding/white,
@@ -54463,7 +55164,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
 "nZA" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /mob/living/carbon/human/npc/bandit,
@@ -54496,12 +55197,17 @@
 "nZL" = (
 /obj/structure/table/wood,
 /obj/item/bong,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "nZO" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"nZS" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/city/toilet,
+/area/vtm/interior/museum)
 "nZW" = (
 /obj/structure/coclock,
 /turf/open/floor/city/plating,
@@ -54552,7 +55258,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "oaP" = (
 /obj/item/flashlight/flare/candle/infinite,
@@ -54581,7 +55287,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "oaV" = (
 /obj/structure/closet/crate/large,
@@ -54632,7 +55338,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "obW" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/grey{
@@ -54673,20 +55379,6 @@
 	},
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/salubri)
-"ocu" = (
-/obj/structure/hedge,
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 2
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "ocv" = (
 /obj/structure/vampdoor/simple{
 	lockpick_difficulty = 9
@@ -54718,6 +55410,13 @@
 "ocR" = (
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
+"ocV" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "odu" = (
 /obj/effect/landmark/npcability,
 /obj/structure/roadsign/busstop,
@@ -54754,6 +55453,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/ghetto)
+"oer" = (
+/obj/structure/chair/stool/bar/darkpack/black,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/item/chisel,
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "oet" = (
 /obj/structure/sacrificealtar,
 /obj/item/clothing/suit/vampire/noddist,
@@ -54781,7 +55488,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "oeX" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "ofe" = (
@@ -54797,7 +55504,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/caern)
 "ofj" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/structure/curtain/bounty{
@@ -54820,8 +55527,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop)
+"ofw" = (
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "ofx" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
 "ofB" = (
@@ -54843,7 +55556,7 @@
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/shop/clothing_store)
 "ofL" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -54853,7 +55566,18 @@
 /area/vtm/interior/endron_facility/restricted)
 "ofV" = (
 /obj/machinery/shower/directional/south,
-/obj/structure/curtain,
+/obj/structure/curtain{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/stock{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/stock{
+	dir = 4;
+	pixel_x = -10
+	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/chantry)
 "ofW" = (
@@ -54960,6 +55684,23 @@
 /obj/structure/coclock,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"ohu" = (
+/obj/machinery/shower/directional/south,
+/obj/item/soap,
+/obj/structure/curtain{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/stock{
+	dir = 4;
+	pixel_x = -10
+	},
+/obj/effect/turf_decal/stock{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/turf/open/floor/city/toilet,
+/area/vtm/interior/chantry)
 "ohx" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/asphalt,
@@ -55007,8 +55748,11 @@
 /obj/structure/railing{
 	pixel_y = -2
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
+"oic" = (
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "oih" = (
 /obj/effect/landmark/npcwall,
 /obj/structure/flora/rock/pile/darkpack,
@@ -55087,7 +55831,7 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/ventrue)
 "oiP" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/pentex/affairs,
@@ -55118,6 +55862,14 @@
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
+"ojm" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/gun/ballistic/automatic/darkpack/ar15,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/museum)
 "ojw" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/vampfence/rich{
@@ -55226,7 +55978,7 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/techshop)
 "okQ" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
@@ -55302,6 +56054,14 @@
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
+"omk" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/platform/lowwall/brick,
+/obj/structure/statue/sandstone/venus{
+	pixel_y = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "oml" = (
 /obj/machinery/light/floor/lamppost/one{
 	dir = 1
@@ -55379,6 +56139,9 @@
 /obj/machinery/sprinkler,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/grocery)
+"ont" = (
+/turf/closed/wall/vampwall/rust,
+/area/vtm/interior/police/fed)
 "onz" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 1
@@ -55505,7 +56268,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "opq" = (
 /obj/structure/hedge{
@@ -55556,7 +56319,7 @@
 /area/vtm/graveyard)
 "opP" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "oqa" = (
 /obj/structure/vampfence/rich{
@@ -55584,7 +56347,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
 "oqj" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
@@ -55663,7 +56426,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "oqD" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/structure/fireplace,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
@@ -55723,10 +56486,10 @@
 /turf/open/floor/city/circled,
 /area/vtm/interior/laundromat)
 "ory" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "orI" = (
 /obj/effect/turf_decal/bordur{
@@ -55866,7 +56629,9 @@
 /area/vtm/interior/mansion)
 "otl" = (
 /obj/structure/table/wood/fancy/red,
-/obj/vampire_computer,
+/obj/structure/retail/library{
+	dir = 1
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "oto" = (
@@ -55895,6 +56660,13 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/unionsquare)
+"otS" = (
+/obj/effect/turf_decal/bordur/corner,
+/obj/structure/railing/darkpack/metal{
+	dir = 10
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "otT" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -55944,7 +56716,7 @@
 /area/vtm/interior/shop/bacotell)
 "oul" = (
 /obj/structure/closet/crate/coffin,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "oun" = (
 /obj/effect/turf_decal/bordur{
@@ -56066,9 +56838,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/millennium_tower/ventrue)
 "ovR" = (
-/obj/effect/decal/wallpaper/grey,
-/turf/closed/wall/vampwall/market,
-/area/vtm/interior/trujah)
+/obj/structure/railing/darkpack/metal{
+	dir = 9
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "ovT" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior/sabbat_lair)
@@ -56086,11 +56860,11 @@
 /turf/open/misc/grass,
 /area/vtm/outside/park)
 "ovZ" = (
-/obj/structure/chair/sofa/corp{
+/obj/structure/chair/sofa/corp/left{
+	color = "#CD5C5C";
 	dir = 1
 	},
-/obj/machinery/light/small/pink/directional/south,
-/turf/open/floor/plating/granite/black,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/strip)
 "owf" = (
 /obj/structure/sign/warning/directional/north,
@@ -56125,7 +56899,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "owt" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/landmark/start/darkpack/pentex/executive,
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 1
@@ -56133,13 +56907,8 @@
 /turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/endron_facility/restricted)
 "owv" = (
-/obj/structure/table/modern,
 /obj/machinery/light/directional/east,
-/obj/item/melee/vamp/brick{
-	anchored = 1;
-	name = "Scorched brick";
-	desc = "A visibly burnt piece of rubble, once trash now on display - A memory of a supposed explosion, from where? Nobody can quite recall..."
-	},
+/obj/structure/hedge,
 /turf/open/floor/city/plating,
 /area/vtm/interior/museum)
 "owz" = (
@@ -56437,7 +57206,7 @@
 /obj/item/paper_bin{
 	pixel_y = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "oAu" = (
 /obj/structure/railing{
@@ -56460,7 +57229,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "oAE" = (
 /obj/structure/hedge,
@@ -56549,7 +57318,7 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "oBy" = (
 /obj/structure/vampdoor/simple{
@@ -56706,7 +57475,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/sewer/nosferatu_town)
 "oDm" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "oDo" = (
@@ -56862,7 +57631,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/baali)
 "oFg" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -56936,7 +57705,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
 "oFO" = (
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/bianchiBank)
@@ -56972,11 +57741,18 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/cog/caern)
+"oGC" = (
+/obj/effect/decal/cleanable/trash{
+	icon_state = "trash7"
+	},
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "oGI" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "oGM" = (
 /obj/item/stack/dollar/hundred,
@@ -57026,7 +57802,7 @@
 /obj/item/clothing/shoes/vampire/heels/red,
 /obj/item/clothing/shoes/vampire/jackboots/punk,
 /obj/item/clothing/shoes/vampire/jackboots/high,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "oHy" = (
 /obj/item/stack/rods/ten,
@@ -57195,7 +57971,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop/bacotell)
 "oJk" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
 "oJp" = (
@@ -57293,7 +58069,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f3)
 "oKy" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/hecata/nonni,
@@ -57304,11 +58080,6 @@
 	dir = 4
 	},
 /area/vtm/interior/shop/arts)
-"oKF" = (
-/obj/structure/table/wood,
-/obj/structure/microscope,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/police/fed)
 "oKK" = (
 /obj/effect/decal/rugs,
 /obj/structure/closet/crate,
@@ -57346,7 +58117,7 @@
 /obj/effect/turf_decal/bordur{
 	dir = 1
 	},
-/turf/closed/wall/vampwall/rich/old,
+/turf/closed/wall/vampwall/redbrick,
 /area/vtm/interior/museum)
 "oLm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -57408,7 +58179,7 @@
 /area/vtm)
 "oLX" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -57432,25 +58203,19 @@
 	dir = 8
 	},
 /area/vtm)
-"oMk" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "oMm" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/giovanni/basement)
 "oMn" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "oMp" = (
 /obj/machinery/light/prince/directional/north,
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth,
@@ -57580,7 +58345,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "oNS" = (
 /obj/structure/table/wood,
@@ -57692,7 +58457,7 @@
 /area/vtm/interior/tzimisce_manor)
 "oPD" = (
 /obj/machinery/light/prince/directional/west,
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth,
@@ -57708,6 +58473,12 @@
 /obj/item/bong,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/outside/forest)
+"oPO" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "oPU" = (
 /obj/effect/decal/wallpaper/paper/darkred,
 /obj/structure/table/wood,
@@ -57804,7 +58575,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -57878,7 +58649,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower)
 "oRd" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/landmark/start/darkpack/triad/red_pole,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
@@ -57892,7 +58663,7 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	pixel_y = -6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "oRl" = (
 /obj/machinery/sprinkler,
@@ -57912,7 +58683,7 @@
 /turf/open/floor/city/industrial,
 /area/vtm/interior/shop/hardware_store)
 "oRz" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -57950,7 +58721,7 @@
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "oSa" = (
 /obj/structure/closet/crate/freezer,
@@ -58003,7 +58774,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/giovanni/courtyard)
 "oSQ" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -58039,7 +58810,7 @@
 /area/vtm/outside/northbeach)
 "oTf" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "oTi" = (
@@ -58057,7 +58828,7 @@
 /area/vtm/interior/millennium_tower/ventrue)
 "oTy" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/sewer/nosferatu_town)
 "oTA" = (
 /obj/structure/vampdoor/simple{
@@ -58098,7 +58869,7 @@
 /area/vtm/interior/police)
 "oTS" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -58121,7 +58892,7 @@
 	pixel_y = 13
 	},
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "oUp" = (
 /obj/effect/turf_decal/siding/white,
@@ -58162,7 +58933,7 @@
 /area/vtm/interior/jazzclub)
 "oVh" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/wood/ornate,
@@ -58187,13 +58958,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "oVy" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/structure/platform/lowwall/bar,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/trujah)
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "oVA" = (
 /obj/effect/turf_decal/bordur,
 /obj/darkpack_car/retro/rand,
@@ -58331,6 +59100,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/baali)
+"oXF" = (
+/obj/structure/roofstuff,
+/obj/effect/turf_decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "oXG" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/blood/vitae,
@@ -58364,7 +59140,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "oXZ" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/carpet/purple,
@@ -58406,7 +59182,7 @@
 /area/vtm/interior/endron_facility/restricted)
 "oYN" = (
 /obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "oYQ" = (
 /obj/effect/turf_decal/bordur,
@@ -58618,7 +59394,7 @@
 /area/vtm/interior/sewer/nosferatu_town)
 "pbI" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -58640,7 +59416,7 @@
 /obj/machinery/light/prince/directional/west,
 /obj/structure/table/wood/fancy,
 /obj/vampire_computer,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/tzimisce_manor)
 "pbZ" = (
 /obj/machinery/light/directional/east,
@@ -58659,7 +59435,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/techshop)
 "pco" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth,
@@ -58697,7 +59473,7 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/pacificheights/forest)
 "pdc" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/effect/landmark/start/darkpack/triad/mountain_master,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior)
@@ -58715,7 +59491,7 @@
 /area/vtm/outside/fishermanswharf/lower)
 "pds" = (
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/tzimisce_manor)
 "pdv" = (
 /obj/structure/bed/maint,
@@ -58776,6 +59552,12 @@
 /obj/structure/platform/lowwall/rich/window/reinforced,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f3)
+"pei" = (
+/obj/transfer_point_vamp/umbral/exit{
+	id = "umbra_dora"
+	},
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/vtm/interior/strip)
 "pek" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
@@ -58797,7 +59579,7 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
 "pew" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/toilet,
@@ -58982,7 +59764,7 @@
 /area/vtm/interior/anarch)
 "php" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -59034,7 +59816,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
 "phY" = (
@@ -59103,9 +59885,17 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/salubri)
 "piZ" = (
-/obj/weapon_showcase,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/item/clothing/suit/costume/poncho{
+	pixel_x = -4;
+	pixel_y = -9
+	},
+/obj/item/clothing/head/costume/sombrero{
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/bandana/red,
+/obj/machinery/light/directional/north,
+/turf/open/misc/beach/sand,
+/area/vtm/interior/museum)
 "pjb" = (
 /obj/structure/vampdoor/simple{
 	dir = 4;
@@ -59117,7 +59907,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "pjd" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/iron/white/corner{
@@ -59207,7 +59997,7 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/endron_facility/plant)
 "pjU" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -59240,7 +60030,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/forest)
 "pkX" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/iron/small,
@@ -59294,7 +60084,7 @@
 /area/vtm)
 "plK" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "plS" = (
 /turf/open/floor/plating/canal,
@@ -59418,7 +60208,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "pnT" = (
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -59592,7 +60382,7 @@
 /area/vtm/interior/clinic/haven)
 "ppP" = (
 /obj/machinery/light/warm/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "ppU" = (
 /obj/machinery/light/small/directional/east,
@@ -59645,13 +60435,13 @@
 /obj/structure/table/wood,
 /obj/item/book/bible,
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "pra" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "prc" = (
 /obj/structure/vampdoor/simple{
@@ -59669,6 +60459,15 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"pre" = (
+/obj/effect/turf_decal/siding/grey{
+	dir = 10
+	},
+/obj/structure/chair/darkpack/blue{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/clinic)
 "prk" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -59683,10 +60482,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/mansion)
 "prx" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/structure/chair/sofa/corp/corner{
+	color = "#CD5C5C"
 	},
-/turf/open/floor/plating/granite/black,
+/obj/effect/decal/shadow,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/strip)
 "prA" = (
 /obj/structure/closet/crate,
@@ -59749,6 +60549,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"pse" = (
+/obj/structure/easel,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "psj" = (
 /obj/structure/platform/lowwall/painted/window/reinforced,
 /obj/structure/window/reinforced/tinted/spawner/directional/east{
@@ -59788,7 +60595,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/smoke_shop)
 "psQ" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -59849,16 +60656,6 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
-"ptM" = (
-/obj/structure/vampdoor/simple{
-	name = "STAFF ONLY";
-	locked = 1;
-	lockpick_difficulty = 20;
-	dir = 4;
-	lock_id = "tmr"
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "ptN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -59921,7 +60718,7 @@
 /area/vtm/interior/theatre)
 "puv" = (
 /obj/effect/decal/cleanable/trash,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "puw" = (
 /obj/effect/turf_decal/bordur{
@@ -60013,7 +60810,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "pvs" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "pvu" = (
@@ -60033,17 +60830,17 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "pvy" = (
 /obj/effect/decal/shadow,
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/tzimisce_manor)
-"pvz" = (
-/obj/structure/filingcabinet/white,
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
+"pvE" = (
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "pvI" = (
 /obj/structure/railing,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -60052,7 +60849,7 @@
 "pvN" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "pvR" = (
 /turf/open/floor/city/toilet,
@@ -60116,7 +60913,7 @@
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/banu/haven)
 "pwO" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/camarilla/hound,
@@ -60243,7 +61040,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "pyi" = (
 /obj/structure/bed,
@@ -60257,10 +61054,10 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "pyy" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
 "pyL" = (
@@ -60286,7 +61083,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/ornate,
@@ -60304,9 +61101,15 @@
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/banu)
 "pze" = (
-/obj/structure/table/modern,
+/obj/structure/hedge,
+/obj/effect/decal/painting/second{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/decoration/bush/flowers_pp/style_random,
 /turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "pzf" = (
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/rich/old,
@@ -60382,11 +61185,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
 "pzW" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
 "pzZ" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/interior/jazzclub)
 "pAc" = (
@@ -60427,10 +61230,6 @@
 /obj/item/seeds/cannabis,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
-"pAT" = (
-/obj/item/melee/vamp/brick,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/hotel)
 "pAU" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -60447,13 +61246,20 @@
 /obj/item/paper{
 	pixel_y = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "pBb" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/directional/east,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/baali)
+"pBf" = (
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior/library)
 "pBh" = (
 /obj/structure/vampfence/rich,
 /obj/structure/vampfence/rich,
@@ -60494,7 +61300,7 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "pBV" = (
 /obj/item/food/badrecipe{
@@ -60510,7 +61316,7 @@
 /obj/item/storage/backpack/duffelbag,
 /obj/item/clothing/shoes/swagshoes,
 /obj/item/vamp/keys/techstore,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/techshop)
 "pCd" = (
 /obj/effect/turf_decal/bordur{
@@ -60646,9 +61452,6 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/clinic)
-"pDp" = (
-/turf/open/floor/plating/rough,
-/area/vtm/interior/police/fed)
 "pDq" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/stairs/black/left,
@@ -60656,7 +61459,7 @@
 "pDs" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "pDv" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
@@ -60691,6 +61494,13 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/misc/dirt/rails,
 /area/vtm/interior/supply)
+"pDM" = (
+/obj/effect/landmark/navigate_destination,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "pDY" = (
 /obj/structure/vampdoor/old,
 /obj/effect/decal/cleanable/dirt,
@@ -60712,7 +61522,7 @@
 "pEg" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/litter,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -60726,7 +61536,7 @@
 /area/vtm/interior/endron_facility/restricted)
 "pEq" = (
 /obj/effect/turf_decal/siding/white,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "pEu" = (
 /obj/effect/landmark/npcwall,
@@ -60758,7 +61568,7 @@
 /area/vtm/interior/millennium_tower/f3)
 "pEO" = (
 /obj/structure/fluff/tv,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "pEQ" = (
 /obj/structure/roofstuff,
@@ -60794,21 +61604,21 @@
 /obj/item/paper_bin{
 	pixel_y = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "pFn" = (
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/millennium_tower)
 "pFo" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "pFs" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth,
@@ -61051,13 +61861,6 @@
 /obj/item/gun/ballistic/shotgun/vampire,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/graveyard)
-"pJn" = (
-/obj/structure/vampdoor/simple,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/strip)
 "pJo" = (
 /obj/structure/bonfire/prelit/alt,
 /turf/open/misc/beach/vamp,
@@ -61122,6 +61925,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/bubway)
+"pJZ" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/platform/lowwall/brick,
+/obj/structure/statue/sandstone/venus{
+	dir = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "pKc" = (
 /obj/structure/railing{
 	dir = 1;
@@ -61166,7 +61978,7 @@
 /area/vtm/interior/shop/smoke_shop)
 "pKk" = (
 /obj/effect/decal/cleanable/cardboard,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "pKm" = (
 /obj/effect/turf_decal/trimline/dark_green/filled,
@@ -61195,7 +62007,7 @@
 /area/vtm/interior/millennium_tower/f4)
 "pKp" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "pKt" = (
 /obj/effect/turf_decal/siding/white,
@@ -61268,7 +62080,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "pKQ" = (
 /obj/effect/decal/cleanable/litter,
@@ -61359,10 +62171,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
-"pMc" = (
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "pMg" = (
 /obj/structure/table/wood/fancy/purple,
 /obj/item/food/cake/chocolate,
@@ -61378,7 +62186,7 @@
 /turf/open/misc/grass,
 /area/vtm)
 "pMr" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -61386,12 +62194,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
-"pMv" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "pMC" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
@@ -61407,7 +62209,7 @@
 /area/vtm/interior/millennium_tower/f2)
 "pMO" = (
 /obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "pMW" = (
 /obj/structure/chair/wood/wings{
@@ -61511,7 +62313,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sabbat_lair)
 "pOm" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth,
@@ -61660,7 +62462,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "pQM" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/triad/red_pole,
@@ -61855,7 +62657,7 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior)
 "pTb" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "pTc" = (
 /obj/structure/sign/poster/random/directional/north,
@@ -61905,7 +62707,7 @@
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "pTM" = (
 /obj/machinery/light/small/directional/north,
@@ -61938,12 +62740,13 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/clinic)
 "pUg" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "pUh" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/hecata/nonni,
@@ -61963,7 +62766,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
 "pUu" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -62078,7 +62881,7 @@
 "pWf" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "pWl" = (
 /obj/machinery/light/small/directional/north,
@@ -62122,11 +62925,24 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "pXo" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 1;
+	pixel_y = 32
 	},
-/obj/structure/vampdoor/simple,
-/turf/open/floor/city/plating,
+/obj/structure/platform/lowwall/brick,
+/obj/structure/table/wood,
+/obj/item/instrument/eguitar/vamp{
+	name = "replica guitar";
+	desc = "A classic guitar, of some noteworthy rocker, seemingly signed by them - Likely a fake, to the point even the signature is far too smudged to make out the letters."
+	},
+/obj/item/melee/vamp/brick{
+	anchored = 1;
+	name = "Scorched brick";
+	desc = "A visibly burnt piece of rubble, once trash now on display - A memory of a supposed explosion, from where? Nobody can quite recall...";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/museum)
 "pXr" = (
 /obj/structure/table/wood/fancy,
@@ -62168,7 +62984,7 @@
 /turf/open/floor/plating/grate,
 /area/vtm/interior/endron_facility/plant)
 "pXA" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -62417,7 +63233,7 @@
 	dir = 9
 	},
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "qbQ" = (
 /obj/structure/urinal{
@@ -62556,7 +63372,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church)
 "qdy" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -62622,8 +63438,13 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"qer" = (
+/obj/structure/railing/darkpack/metal,
+/obj/machinery/light/directional/north,
+/turf/open/openspace,
+/area/vtm/interior/museum)
 "qes" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -62647,7 +63468,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "qeY" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
@@ -62761,13 +63582,6 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/city/plating,
 /area/vtm/outside/giovanni/courtyard)
-"qgk" = (
-/obj/machinery/photocopier/prebuilt,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/darkpack/redsilver,
-/area/vtm/interior/chantry)
 "qgm" = (
 /obj/effect/turf_decal/darkpack/grass{
 	dir = 1
@@ -62819,13 +63633,6 @@
 /obj/item/trash/can/food,
 /turf/open/misc/grass,
 /area/vtm/interior/library)
-"qgB" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet,
-/area/vtm/interior)
 "qgD" = (
 /obj/structure/table/wood,
 /obj/item/melee/vamp/tire,
@@ -62908,11 +63715,10 @@
 /turf/open/misc/grass,
 /area/vtm/outside/park)
 "qhA" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
-/obj/weapon_showcase,
-/turf/open/floor/plating/granite/black,
+/turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
 "qhO" = (
 /obj/structure/platform/lowwall/market/window,
@@ -62930,7 +63736,7 @@
 "qid" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "qij" = (
 /obj/item/kirbyplants/random,
@@ -63046,7 +63852,7 @@
 "qjr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "qjB" = (
 /obj/effect/decal/pallet,
@@ -63097,7 +63903,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "qko" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/antiques)
 "qkD" = (
@@ -63108,7 +63914,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "qkE" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/landmark/start/darkpack/pentex/sec,
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
@@ -63372,9 +64178,11 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/bubway)
 "qnV" = (
-/obj/structure/bookcase/random/fiction,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
 /turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "qoe" = (
 /obj/structure/rack/clothing_hanger/rand,
 /turf/open/floor/wood/herring,
@@ -63422,7 +64230,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "qoE" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/plating/rust,
 /area/vtm/interior/strip)
 "qoM" = (
@@ -63495,7 +64303,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "qqn" = (
 /obj/structure/rack,
@@ -63524,7 +64332,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "qqB" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/machinery/light/prince/directional/west,
@@ -63588,12 +64396,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer/nosferatu_town)
-"qrE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/carpet/black,
-/area/vtm/interior/hotel)
 "qrK" = (
 /obj/structure/curtain/cloth/fancy/mechanical/luxurious{
 	id = "sheriffcurtain"
@@ -63659,7 +64461,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/chantry)
 "qst" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -63732,7 +64534,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/music_store)
 "qtg" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
@@ -63763,7 +64565,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "qtp" = (
 /obj/structure/table/wood,
@@ -63831,7 +64633,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "qud" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -63875,7 +64677,7 @@
 /area/vtm/outside/ghetto)
 "quz" = (
 /obj/machinery/light/prince/directional/west,
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/millennium_tower/ventrue)
 "quA" = (
@@ -63991,6 +64793,13 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"qvC" = (
+/obj/effect/decal/carpet{
+	pixel_y = -12
+	},
+/obj/machinery/sprinkler,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "qvF" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -64016,10 +64825,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
-"qvM" = (
-/obj/structure/ladder/manhole/down,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "qvV" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/iron/grimy,
@@ -64047,9 +64852,8 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
 "qwp" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/triad/blue_lanterns,
 /turf/open/floor/wood/smooth/old,
@@ -64116,10 +64920,10 @@
 "qwL" = (
 /obj/structure/table/wood,
 /obj/item/plate,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "qwM" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/landmark/start/darkpack/citizen/club_worker,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/strip)
@@ -64140,7 +64944,7 @@
 /obj/structure/railing{
 	pixel_y = -2
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -64180,7 +64984,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "qxv" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
@@ -64339,7 +65143,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "qza" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "qzc" = (
 /obj/effect/turf_decal/siding/dark_blue/end{
@@ -64357,7 +65161,7 @@
 "qzi" = (
 /obj/structure/rack/clothing_hanger,
 /obj/machinery/light/prince/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "qzk" = (
 /obj/effect/spawner/random/occult/artifact,
@@ -64447,6 +65251,15 @@
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
+"qAB" = (
+/obj/effect/turf_decal/bordur/corner{
+	dir = 1
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "qAH" = (
 /obj/effect/decal/pallet{
 	pixel_x = -3;
@@ -64472,10 +65285,10 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
 "qAN" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/ghetto)
 "qAU" = (
 /obj/darkpack_car/taxi,
@@ -64558,11 +65371,6 @@
 /obj/structure/flora/darkpack_flower/primrose,
 /turf/open/misc/grass,
 /area/vtm/outside/fishermanswharf)
-"qCo" = (
-/obj/structure/chair,
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "qCI" = (
 /obj/structure/rack/food{
 	dir = 8
@@ -64654,16 +65462,6 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"qEd" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/item/flashlight,
-/obj/structure/coclock,
-/obj/effect/spawner/random/occult/artifact,
-/turf/open/floor/carpet/green,
-/area/vtm/interior/hotel)
 "qEg" = (
 /obj/effect/decal/wallpaper,
 /turf/closed/wall/vampwall/old,
@@ -64715,6 +65513,19 @@
 "qFg" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/directional/north,
+/obj/structure/closet/cabinet,
+/obj/item/paint_palette,
+/obj/item/paint_palette,
+/obj/item/paint_palette,
+/obj/item/paint_palette,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/fortyfive_twentyseven,
+/obj/item/canvas/fortyfive_twentyseven,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "qFh" = (
@@ -64847,8 +65658,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "qGY" = (
-/obj/effect/turf_decal/siding/white,
-/obj/structure/closet/cardboard,
+/obj/machinery/light/directional/north,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "qHd" = (
@@ -64900,7 +65710,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
 "qHC" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth,
@@ -64978,10 +65788,10 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "qIp" = (
 /obj/effect/turf_decal/siding/wood{
@@ -65105,7 +65915,7 @@
 /obj/structure/mirror{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/church/haven)
 "qJZ" = (
 /obj/structure/vampfence/corner{
@@ -65216,7 +66026,7 @@
 /area/vtm/interior/millennium_tower)
 "qKQ" = (
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/ghetto)
 "qKZ" = (
 /obj/structure/chair/sofa/corner{
@@ -65268,7 +66078,7 @@
 "qLv" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "qLA" = (
 /obj/structure/chair/sofa/middle/brown{
@@ -65278,7 +66088,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "qLB" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "qLF" = (
 /obj/structure/vampdoor/old{
@@ -65304,18 +66114,18 @@
 /obj/item/paper{
 	pixel_y = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "qLR" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic/haven)
 "qLS" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "qLU" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/white{
@@ -65350,7 +66160,7 @@
 "qMA" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/filingcabinet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "qMB" = (
 /obj/effect/decal/cleanable/trash,
@@ -65390,7 +66200,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
 "qNj" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -65488,7 +66298,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/outside/northbeach)
 "qOR" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/paper/stack{
 	dir = 5
@@ -65520,10 +66330,10 @@
 /area/vtm/outside/fishermanswharf/ghetto)
 "qPn" = (
 /obj/structure/fluff/tv,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "qPq" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/landmark/start/darkpack/citizen/priest,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
@@ -65539,7 +66349,7 @@
 /area/vtm/outside/financialdistrict)
 "qPA" = (
 /obj/structure/dresser,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "qPB" = (
 /obj/machinery/light/small/directional/east,
@@ -65615,7 +66425,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights)
 "qQX" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/structure/sign/city/strip_club/directional/north,
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
@@ -65730,7 +66540,7 @@
 "qRY" = (
 /obj/machinery/light/prince/directional/south,
 /obj/structure/bookcase/random,
-/turf/open/floor/wood/smooth/old,
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "qSb" = (
 /obj/machinery/light/small/directional/west,
@@ -65761,7 +66571,7 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/oldchurch)
 "qSk" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /obj/effect/landmark/start/darkpack/forest_wolves/keeper,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
@@ -65802,7 +66612,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
 "qSE" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/pentex/sec,
@@ -65836,10 +66646,6 @@
 "qSR" = (
 /turf/open/floor/light,
 /area/vtm/interior/strip)
-"qSV" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "qSW" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcbeacon/directed{
@@ -65884,7 +66690,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "qTl" = (
 /obj/effect/landmark/navigate_destination,
@@ -65901,7 +66707,7 @@
 	dir = 4;
 	pixel_y = -2
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "qTo" = (
 /obj/structure/table/wood/fancy/black,
@@ -65931,7 +66737,7 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower)
 "qTK" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/strip)
 "qTN" = (
@@ -65991,6 +66797,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/clinic/haven)
+"qUp" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "qUv" = (
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/city/church,
@@ -66062,8 +66874,8 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
 "qVc" = (
-/obj/machinery/shower/directional/west,
-/obj/structure/curtain,
+/obj/machinery/light/directional/east,
+/obj/structure/table/wood,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/chantry)
 "qVg" = (
@@ -66129,7 +66941,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/church)
 "qWr" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk/old,
@@ -66279,7 +67091,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
 "qYC" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /mob/living/carbon/human/npc/shop,
@@ -66336,7 +67148,7 @@
 /area/vtm/interior/jazzclub)
 "qZd" = (
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "qZe" = (
 /obj/structure/vampdoor,
@@ -66345,7 +67157,7 @@
 /area/vtm/interior/sewer)
 "qZi" = (
 /obj/structure/table/wood,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "qZo" = (
@@ -66402,7 +67214,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "qZP" = (
 /obj/machinery/light/floor/lamppost/one{
@@ -66456,21 +67268,17 @@
 /area/vtm/interior/supply)
 "raz" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/fishermanswharf)
 "raM" = (
-/obj/structure/table/modern,
-/obj/item/instrument/eguitar/vamp{
-	name = "Replica Guitar";
-	anchored = 1;
-	desc = "A classic guitar, of some noteworthy rocker, seemingly signed by them - Likely a fake, to the point even the signature is far too smudged to make out the letters."
-	},
 /obj/machinery/light/directional/west,
+/obj/structure/hedge,
 /turf/open/floor/city/plating,
 /area/vtm/interior/museum)
 "raO" = (
 /obj/machinery/light/directional/west,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/city/plating,
 /area/vtm/interior/museum)
 "rba" = (
@@ -66639,7 +67447,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
 "rcP" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -66712,7 +67520,7 @@
 /area/vtm/interior/clinic)
 "rdK" = (
 /obj/structure/chair/sofa/corp/left,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "rdO" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -66791,6 +67599,14 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
+"rej" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/ammo_box/magazine/darkpack556,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/museum)
 "rek" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/roadsign/warningdeer,
@@ -66815,7 +67631,7 @@
 /area/vtm/interior/police)
 "reR" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "reZ" = (
 /obj/structure/stairs/north,
@@ -66936,7 +67752,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "rhf" = (
 /turf/open/floor/plating/rough,
@@ -66980,7 +67796,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "rhF" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/ornate,
@@ -67003,14 +67819,6 @@
 /obj/structure/platform/lowwall/painted/window/reinforced,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/bianchiBank)
-"rhO" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/strip)
 "rhR" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/misc/dirt,
@@ -67042,7 +67850,18 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
 "rhY" = (
-/turf/open/floor/wood/old,
+/obj/effect/decal/pallet{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/effect/decal/pallet{
+	pixel_x = -12;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/trash{
+	icon_state = "trash30"
+	},
+/turf/open/floor/plating/concrete,
 /area/vtm/interior/police/fed)
 "ria" = (
 /obj/effect/turf_decal/bordur/corner{
@@ -67139,7 +67958,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "riT" = (
 /obj/structure/sink/directional/west,
@@ -67210,6 +68029,23 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
+"rjz" = (
+/obj/machinery/light/prince/directional/west,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/hedge,
+/obj/structure/flora/bush/flowers_yw/style_random{
+	pixel_y = 2
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/chantry)
 "rjB" = (
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -67273,10 +68109,13 @@
 /turf/open/openspace,
 /area/vtm/interior/hotel)
 "rjX" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/turf/open/floor/wood/smooth/old,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "rkf" = (
 /obj/structure/pole{
@@ -67286,7 +68125,7 @@
 /area/vtm/interior)
 "rkh" = (
 /obj/structure/coclock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "rkm" = (
 /obj/structure/chair/sofa/left/brown{
@@ -67321,14 +68160,14 @@
 /turf/open/floor/wood,
 /area/vtm/interior/church/haven)
 "rkB" = (
-/obj/structure/chair/comfy/brown{
-	color = "#50C878";
-	dir = 4
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/grey/corner{
+	dir = 1
 	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "rkQ" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "rkR" = (
@@ -67376,7 +68215,7 @@
 "rlX" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "rlZ" = (
 /obj/structure/table/wood,
@@ -67416,7 +68255,7 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/police/upstairs)
 "rmt" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/carpet/green,
 /area/vtm/interior)
 "rmB" = (
@@ -67428,7 +68267,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf/ghetto)
 "rmI" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -67454,7 +68293,7 @@
 /turf/open/misc/dirt,
 /area/vtm)
 "rnz" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -67519,7 +68358,7 @@
 /area/vtm/interior/hotel)
 "roo" = (
 /mob/living/carbon/human/npc/bouncer/elysium/theatre_backdoor,
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -67538,7 +68377,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/theatre)
 "rot" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/rough,
@@ -67559,7 +68398,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "roO" = (
 /obj/structure/railing{
@@ -67611,8 +68450,8 @@
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
 "rpF" = (
-/obj/structure/stairs/south,
-/turf/open/floor/plating/canalplating,
+/obj/structure/stairs/west,
+/turf/open/space/basic,
 /area/vtm/interior/police/fed)
 "rpI" = (
 /obj/machinery/light/small/directional/south,
@@ -67648,7 +68487,7 @@
 "rpU" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/fax/camarilla,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "rpW" = (
 /obj/structure/hedge{
@@ -67727,7 +68566,7 @@
 /obj/structure/table/wood,
 /obj/machinery/light/prince/directional/west,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "rqu" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -67762,7 +68601,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
 "rqE" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -67794,7 +68633,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/bubway)
 "rrh" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -67840,12 +68679,33 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/shop/otolleys)
+"rrN" = (
+/obj/structure/table/wood,
+/obj/item/storage/briefcase/secure{
+	pixel_y = 18
+	},
+/obj/item/folder/blue,
+/obj/item/folder/blue{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "rrW" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
+"rsb" = (
+/obj/effect/turf_decal/bordur/corner{
+	dir = 4
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "rsc" = (
 /obj/structure/railing/darkpack/metal/industrial{
 	dir = 9
@@ -68091,7 +68951,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
 "rux" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "ruz" = (
@@ -68144,7 +69004,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "ruR" = (
 /obj/effect/turf_decal/darkpack/grass,
@@ -68218,17 +69078,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
-"rvF" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/water,
-/area/vtm/interior/chantry)
 "rvG" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/toilet{
@@ -68328,7 +69177,7 @@
 /area/vtm/interior/clinic)
 "rwv" = (
 /obj/structure/stairs/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/giovanni)
 "rwz" = (
 /obj/structure/vampfence/corner,
@@ -68415,6 +69264,13 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/church)
+"rxD" = (
+/obj/machinery/sprinkler/area_managed,
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/chantry)
 "rxJ" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sink/directional/south,
@@ -68423,12 +69279,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/hotel)
-"rxS" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/city/toilet,
-/area/vtm/interior/police/fed)
 "rxW" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -68457,6 +69307,10 @@
 "rym" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
+"ryA" = (
+/obj/structure/bookcase/random,
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "ryE" = (
@@ -68498,6 +69352,11 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights/old)
+"ryT" = (
+/obj/machinery/light/directional/north,
+/obj/structure/hedge,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "ryZ" = (
 /obj/structure/vampipe{
 	icon_state = "piping32"
@@ -68551,7 +69410,7 @@
 /area/vtm/interior/tzimisce_manor)
 "rzY" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -68584,10 +69443,17 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"rAs" = (
+/obj/structure/table/wood,
+/obj/item/storage/briefcase/secure{
+	pixel_y = 3
+	},
+/obj/structure/detectiveboard/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "rAt" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/smooth/old,
@@ -68632,7 +69498,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower)
 "rBg" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
 "rBk" = (
@@ -68745,6 +69611,12 @@
 "rCX" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/techshop)
+"rCY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/hotel)
 "rDp" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/smooth/old,
@@ -68782,7 +69654,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "rDL" = (
 /obj/item/kirbyplants/darkpack/random,
@@ -68883,6 +69755,15 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/tzimisce_manor)
+"rFA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/sprinkler/area_managed,
+/obj/structure/closet/crate/large{
+	anchored = 1
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "rFE" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 1
@@ -68974,7 +69855,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "rGA" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/shop,
@@ -69000,23 +69881,6 @@
 /obj/structure/roadsign/speedlimit40,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"rGQ" = (
-/obj/structure/hedge,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "rGZ" = (
 /obj/structure/sign/city/hotel{
 	dir = 4
@@ -69135,7 +69999,7 @@
 /area/vtm/interior/shop/camping_store)
 "rIZ" = (
 /obj/machinery/light/directional/west,
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "rJc" = (
@@ -69226,11 +70090,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
-"rKp" = (
-/obj/structure/table/optable,
-/obj/machinery/light/small/red/directional/south,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/police/fed)
 "rKr" = (
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/carpet/royalblack,
@@ -69352,7 +70211,7 @@
 /turf/open/floor/city/clinic,
 /area/vtm/interior/clinic)
 "rLy" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -69387,10 +70246,6 @@
 /mob/living/carbon/human/npc/guard,
 /turf/open/misc/grass,
 /area/vtm/outside/fishermanswharf)
-"rLV" = (
-/obj/structure/filingcabinet/security,
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "rLY" = (
 /obj/structure/flora/tree/vamp,
 /obj/effect/landmark/npcwall,
@@ -69405,19 +70260,14 @@
 "rMf" = (
 /turf/open/floor/carpet/lone,
 /area/vtm/interior)
-"rMn" = (
-/obj/structure/bed,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/item/vampire_stake,
-/obj/item/vampire_stake,
-/turf/open/floor/carpet,
-/area/vtm/interior/hotel)
 "rMo" = (
 /obj/structure/vampdoor/old{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/door/access/malkavian,
+/obj/effect/mapping_helpers/door/lock_difficulty/seven,
+/obj/effect/mapping_helpers/door/bash_difficulty/seven,
+/obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/clinic/haven)
 "rMq" = (
@@ -69436,13 +70286,13 @@
 "rMI" = (
 /obj/structure/table/wood,
 /obj/machinery/radio_tranceiver/anarch,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "rMK" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -69473,13 +70323,13 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "rNe" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "rNf" = (
 /obj/structure/rack/food/rand,
@@ -69588,10 +70438,6 @@
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
-"rOB" = (
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/police/fed)
 "rOI" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/wood/smooth,
@@ -69651,7 +70497,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
 "rPx" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/pentex/sec,
@@ -69675,7 +70521,7 @@
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/techshop)
 "rQx" = (
 /obj/structure/table/wood,
@@ -69751,11 +70597,11 @@
 /area/vtm/interior/bianchiBank)
 "rRc" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /turf/open/floor/wood,
 /area/vtm/interior/church/haven)
 "rRd" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -69812,14 +70658,6 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer/nosferatu_town)
-"rSf" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/light,
-/area/vtm/interior/strip)
 "rSp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/sofa/corp/right{
@@ -69880,7 +70718,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
 "rSZ" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /mob/living/carbon/human/npc/illegal{
 	resistant_to_disciplines = 1
 	},
@@ -70180,9 +71018,15 @@
 /area/vtm/interior/millennium_tower/f4)
 "rXL" = (
 /obj/structure/table/wood,
-/obj/item/vampirebook/noddist,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/item/flashlight/lamp/green{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/siding/grey/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "rXP" = (
 /obj/effect/turf_decal/siding/wood/dark,
 /obj/effect/turf_decal/siding/wood/dark{
@@ -70262,12 +71106,6 @@
 /obj/item/clothing/shoes/vampire/brown,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch)
-"rYD" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
-/turf/open/floor/city/toilet,
-/area/vtm/interior/museum)
 "rYF" = (
 /obj/structure/table/wood,
 /obj/item/vampire_stake,
@@ -70287,7 +71125,7 @@
 /area/vtm/interior/millennium_tower/f4)
 "rYR" = (
 /obj/machinery/hydroponics/simple/plastic,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "rYV" = (
 /obj/structure/vampipe{
@@ -70490,7 +71328,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
-/obj/item/kirbyplants/random,
+/obj/structure/sign/painting/large{
+	pixel_y = 32
+	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "saD" = (
@@ -70502,6 +71342,10 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
+"saP" = (
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "saQ" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -70514,7 +71358,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "saU" = (
 /obj/structure/closet,
@@ -70532,14 +71376,6 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
-"saY" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/blood/b_plus,
-/obj/item/reagent_containers/blood/b_plus,
-/obj/item/reagent_containers/blood/a_plus,
-/obj/item/reagent_containers/blood/a_plus,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "sba" = (
 /obj/structure/flora/tree/vamp/pine,
 /turf/open/misc/grass,
@@ -70603,7 +71439,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
 "sbN" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -70639,6 +71475,12 @@
 	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
+"sbV" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "scd" = (
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/poor,
@@ -70661,7 +71503,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
 "scs" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/baali)
 "scv" = (
@@ -70742,7 +71584,7 @@
 /turf/open/floor/iron/small,
 /area/vtm/interior/endron_facility/restricted)
 "sdz" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/tzimisce_manor)
 "sdF" = (
@@ -70850,20 +71692,22 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
-"seZ" = (
-/obj/effect/landmark/start/darkpack/citizen/citizen,
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/green,
-/area/vtm/interior/hotel)
 "sfb" = (
 /obj/structure/chair/sofa/city_bench/metal/right/black,
 /obj/effect/turf_decal/siding/grey,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "sfd" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
+"sfp" = (
+/obj/structure/vampfence/rich{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "sft" = (
 /obj/machinery/camera/directional/north{
 	network = list("Endron");
@@ -71044,12 +71888,6 @@
 /obj/item/gun/ballistic/revolver/darkpack/magnum,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/graveyard)
-"shO" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/museum)
 "shV" = (
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/vtm/interior)
@@ -71172,7 +72010,7 @@
 /turf/open/water,
 /area/vtm/interior/jazzclub)
 "sjN" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /mob/living/carbon/human/npc/bandit,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
@@ -71184,21 +72022,12 @@
 /area/vtm)
 "sjY" = (
 /obj/effect/landmark/start/darkpack/citizen/citizen,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "sjZ" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf)
-"skd" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/item/wirecutters,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/light,
-/area/vtm/interior/strip)
 "skg" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/garbage{
@@ -71232,7 +72061,7 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/ventrue)
 "sky" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
 "skC" = (
@@ -71418,7 +72247,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 1
 	},
 /turf/open/floor/carpet/lone,
@@ -71458,23 +72287,16 @@
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/smoke_shop)
 "snp" = (
-/obj/structure/hedge,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/railing/darkpack/metal{
+	dir = 6
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 2
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/turf/open/openspace,
+/area/vtm/interior/museum)
 "snq" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/triad/blue_lanterns,
@@ -71498,7 +72320,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
 "snv" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalkalt,
@@ -71533,7 +72355,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "sod" = (
 /obj/structure/table/wood,
@@ -71648,7 +72470,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/anarch/baron,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "spy" = (
 /obj/effect/turf_decal/stripes/line,
@@ -71744,7 +72566,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "sre" = (
 /obj/structure/vampfence/rich{
@@ -71842,17 +72664,31 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
+/obj/structure/closet/cabinet,
+/obj/item/chisel,
+/obj/item/chisel,
+/obj/item/chisel,
+/obj/item/chisel,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "ssv" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/effect/turf_decal/siding/grey{
+	dir = 10
 	},
-/obj/structure/closet/crate,
-/obj/item/gun/ballistic/automatic/darkpack/ar15,
-/obj/machinery/light/directional/north,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "ssx" = (
 /obj/machinery/griddle,
 /obj/structure/table,
@@ -71886,12 +72722,12 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
 "ssN" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /obj/structure/railing{
 	dir = 1;
 	pixel_y = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/theatre)
 "ssW" = (
 /obj/structure/transport/linear/public,
@@ -71909,20 +72745,6 @@
 "stf" = (
 /turf/closed/wall/vampwall/metal,
 /area/vtm/interior/endron_facility/plant)
-"stj" = (
-/obj/item/paper_bin/carbon{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/radio/headset/darkpack/police,
-/obj/machinery/light/small/red/directional/north,
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "sto" = (
 /obj/structure/railing{
 	dir = 1;
@@ -71950,6 +72772,15 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/giovanni/basement)
+"suc" = (
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "sue" = (
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/painted,
@@ -71960,7 +72791,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/pink/directional/east,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "suj" = (
 /obj/effect/turf_decal/bordur{
@@ -71990,12 +72821,12 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood/fancy/black,
 /obj/item/clothing/suit/armor/riot/knight/yellow,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "sut" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "suw" = (
 /obj/effect/turf_decal/darkpack/grass{
@@ -72011,6 +72842,10 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"suC" = (
+/obj/effect/decal/wallpaper/paper/fancy/stripe,
+/turf/closed/wall/vampwall/brick_old,
+/area/vtm/interior/hotel)
 "suD" = (
 /obj/structure/vampdoor/glass,
 /obj/effect/mapping_helpers/door/autoname,
@@ -72306,7 +73141,7 @@
 "sxD" = (
 /obj/structure/table,
 /obj/item/stack/medical/suture,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "sxH" = (
 /obj/effect/landmark/navigate_destination,
@@ -72427,7 +73262,7 @@
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "syK" = (
 /obj/structure/werewolf_totem/bone_gnawer,
@@ -72460,7 +73295,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/clinic)
 "szf" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "szg" = (
@@ -72678,7 +73513,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "sCr" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/roofwalk,
@@ -72792,14 +73627,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "sDX" = (
 /obj/structure/ladder/manhole/down,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/financialdistrict)
 "sDY" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -72831,9 +73666,18 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/salubri)
+"sEf" = (
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/grey{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "sEt" = (
 /obj/effect/decal/pallet,
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "sEu" = (
@@ -72895,7 +73739,7 @@
 /obj/item/clothing/under/vampire/primogen_toreador/female,
 /obj/item/clothing/under/vampire/punk,
 /obj/item/vamp/keys/hack,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "sFp" = (
 /obj/structure/closet,
@@ -72903,7 +73747,7 @@
 /area/vtm/interior/sewer/nosferatu_town)
 "sFr" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -73013,7 +73857,7 @@
 "sHo" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "sHv" = (
 /obj/structure/bed/dogbed,
@@ -73041,16 +73885,18 @@
 /area/vtm/interior/tzimisce_manor)
 "sHP" = (
 /obj/structure/stairs/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "sHV" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/item/clothing/head/vampire/noddist_mask,
+/obj/item/clothing/head/vampire/noddist_mask,
+/obj/item/clothing/head/vampire/noddist_mask,
+/obj/effect/turf_decal/siding/grey{
+	dir = 6
 	},
-/obj/structure/closet/crate,
-/obj/item/ammo_box/magazine/darkpack556,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/obj/structure/table/wood/fancy/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "sIk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -73076,7 +73922,7 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/nine,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "sIr" = (
 /obj/effect/turf_decal/asphaltline/arrow/right{
@@ -73100,7 +73946,7 @@
 /area/vtm/interior)
 "sID" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -73193,10 +74039,10 @@
 /turf/open/floor/iron/textured_half,
 /area/vtm/interior/endron_facility/restricted)
 "sJE" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/turf/closed/wall/vampwall/brick_old{
+	density = 0;
+	color = "#BBBBBB"
 	},
-/turf/open/floor/wood/old,
 /area/vtm/interior/police/fed)
 "sJH" = (
 /obj/structure/reagent_dispensers/cleaningfluid,
@@ -73229,7 +74075,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/tzimisce_manor)
 "sKk" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/machinery/light/small/directional/east,
@@ -73387,11 +74233,18 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/clinic/haven)
 "sMQ" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic/haven)
+"sMW" = (
+/obj/structure/chair/office/darkpack/green{
+	dir = 1
+	},
+/obj/effect/landmark/start/darkpack/law_enforcement/fbi,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "sNh" = (
 /obj/structure/table,
 /turf/open/floor/plating/rough/cave,
@@ -73459,19 +74312,19 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "sOv" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "sOy" = (
 /obj/effect/turf_decal/asphaltline/yellow{
@@ -73501,6 +74354,17 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
+"sOJ" = (
+/obj/structure/sign/flag/soviet{
+	pixel_y = 29;
+	pixel_x = 17
+	},
+/obj/structure/mannequin/plastic/soviet,
+/obj/structure/railing/darkpack/metal{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "sOK" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
@@ -73556,7 +74420,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry/basement)
 "sPU" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/shop,
@@ -73617,8 +74481,13 @@
 /obj/structure/roadsign/warningtrafficlight,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"sRD" = (
+/obj/structure/table/wood,
+/obj/structure/platform/lowwall/rich/old,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "sRF" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /turf/open/floor/iron/textured_half{
@@ -73630,7 +74499,7 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer/nosferatu_town)
 "sRI" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/northbeach)
 "sRK" = (
@@ -73705,7 +74574,7 @@
 	},
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "sSE" = (
 /obj/effect/landmark/start/darkpack/camarilla/hound,
@@ -73727,14 +74596,8 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
-"sSX" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/banu/haven)
 "sTa" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/rough,
@@ -73783,7 +74646,7 @@
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
 /obj/effect/mapping_helpers/door/lock_difficulty/five,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/techshop)
 "sTI" = (
 /obj/structure/bed,
@@ -73815,8 +74678,12 @@
 	pixel_y = 8
 	},
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
+"sTR" = (
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "sTS" = (
 /obj/structure/vampdoor/simple,
 /turf/open/floor/city/toilet,
@@ -73909,17 +74776,10 @@
 /turf/closed/wall/vampwall/brick,
 /area/vtm/interior)
 "sVp" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
-"sVv" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/clothing/head/vampire/noddist_mask,
-/obj/item/clothing/head/vampire/noddist_mask,
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "sVw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
@@ -73993,6 +74853,12 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/five,
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/techshop)
+"sWj" = (
+/obj/structure/pole{
+	pixel_w = -16
+	},
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/strip)
 "sWk" = (
 /obj/structure/vampdoor/simple{
 	lock_id = "lasombra";
@@ -74087,7 +74953,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/church)
 "sXo" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /obj/machinery/light/red/directional/south,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
@@ -74100,6 +74966,16 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/ten,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
+"sXv" = (
+/obj/machinery/light/directional/north,
+/obj/structure/statue/bronze/marx{
+	desc = "A bust depicting a certain 19th century economist. What a trash...";
+	pixel_y = 10;
+	anchored = 1
+	},
+/obj/structure/table/countertop,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "sXJ" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/wood/smooth,
@@ -74124,14 +75000,14 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "sXT" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
 "sXU" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "sXX" = (
 /obj/structure/table,
@@ -74163,7 +75039,7 @@
 /area/vtm/outside/financialdistrict)
 "sYi" = (
 /obj/structure/table/no_smooth/wood/square,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
@@ -74199,10 +75075,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
-"sZe" = (
-/obj/structure/mannequin/plastic/conquistador,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/museum)
 "sZg" = (
 /obj/effect/turf_decal/asphaltline/alt/white{
 	dir = 4
@@ -74276,7 +75148,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "sZQ" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/captain,
@@ -74290,7 +75162,7 @@
 /area/vtm/outside/ghetto)
 "sZY" = (
 /mob/living/carbon/human/npc/hobo,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/dirt,
@@ -74348,6 +75220,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/bubway)
+"taT" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "taU" = (
 /obj/structure/vampdoor/simple,
 /obj/effect/turf_decal/siding/white,
@@ -74360,7 +75238,7 @@
 "tbe" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/blacklight/directional/east,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "tbo" = (
 /turf/open/floor/city/plating_mono,
@@ -74377,7 +75255,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "tbs" = (
 /obj/machinery/door/poddoor/shutters{
@@ -74423,7 +75301,7 @@
 	pixel_y = 10
 	},
 /obj/item/food/pizzaslice/square,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "tbT" = (
 /obj/effect/decal/pallet,
@@ -74512,13 +75390,6 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/restricted)
-"tcX" = (
-/obj/effect/decal/wallpaper/stone,
-/turf/closed/wall/vampwall/rich/old{
-	density = 0;
-	name = "oddly shaped rich-looking wall"
-	},
-/area/vtm/interior/trujah)
 "tda" = (
 /obj/structure/sign/flag/usa{
 	pixel_y = 32
@@ -74527,16 +75398,16 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/gunshop)
 "tdb" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/grey{
 	dir = 6
+	},
+/obj/structure/chair/darkpack/blue{
+	dir = 8
 	},
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic)
 "tdf" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/effect/landmark/start/darkpack/hecata/capo,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
@@ -74601,7 +75472,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/bianchiBank)
 "tef" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior)
 "tei" = (
@@ -74614,10 +75485,27 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"ten" = (
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/museum)
 "tep" = (
 /obj/structure/hedge,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
+"ter" = (
+/obj/structure/vampipe{
+	icon_state = "piping4";
+	pixel_y = 32
+	},
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "tes" = (
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk/rich,
@@ -74680,7 +75568,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/ornate,
@@ -74732,7 +75620,7 @@
 /area/vtm/interior/anarch)
 "tfH" = (
 /obj/structure/bookcase/random/fiction,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "tfN" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -74740,6 +75628,10 @@
 	},
 /turf/open/floor/city/factory,
 /area/vtm/interior/endron_facility/restricted)
+"tgd" = (
+/obj/structure/railing/darkpack/metal,
+/turf/open/openspace,
+/area/vtm/interior/strip)
 "tge" = (
 /obj/effect/decal/rugs,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -74766,7 +75658,7 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
 "tgl" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -74887,7 +75779,7 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
 "thD" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -74900,7 +75792,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/old)
 "thW" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/city/plating_mono,
@@ -74925,6 +75817,10 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/northbeach)
+"tip" = (
+/obj/structure/chair/stool/bar/darkpack/red,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/strip)
 "tiq" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/vampire/balaclava,
@@ -75008,6 +75904,16 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/ventrue)
+"tjq" = (
+/obj/structure/table/wood,
+/obj/vampire_computer,
+/obj/item/kirbyplants/darkpack/plant2{
+	pixel_y = 16;
+	pixel_x = 7
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "tjB" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/vampire/biker,
@@ -75033,18 +75939,12 @@
 /area/vtm/interior/endron_facility/restricted)
 "tjZ" = (
 /obj/structure/stairs/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "tkb" = (
 /obj/structure/platform/lowwall/market/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/techshop)
-"tkf" = (
-/obj/structure/hedge,
-/obj/structure/ladder/manhole/down,
-/obj/machinery/light/small/pink/directional/east,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "tkh" = (
 /obj/effect/landmark/npcwall,
 /turf/open/floor/iron/dark,
@@ -75128,7 +76028,7 @@
 /obj/item/paper_bin{
 	pixel_y = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "tlC" = (
 /obj/structure/table,
@@ -75331,7 +76231,7 @@
 /obj/item/radio/headset/darkpack,
 /obj/item/radio/headset/darkpack,
 /obj/item/radio/headset/darkpack,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "toK" = (
 /obj/machinery/light/small/directional/north,
@@ -75407,7 +76307,7 @@
 /turf/open/floor/plating/grate,
 /area/vtm/interior/endron_facility/plant)
 "tpK" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/glass,
 /area/vtm/interior/tzimisce_manor)
 "tpO" = (
@@ -75666,7 +76566,7 @@
 /area/vtm/interior/shop/camping_store)
 "tsm" = (
 /obj/effect/landmark/start/darkpack/citizen/citizen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "tso" = (
 /obj/effect/turf_decal/siding/wood{
@@ -75674,7 +76574,7 @@
 	},
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "tsr" = (
 /obj/structure/vampfence/rich{
@@ -75707,7 +76607,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "tsI" = (
 /obj/structure/vampdoor/old{
@@ -75728,7 +76628,7 @@
 	},
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "tsW" = (
 /obj/effect/decal/cleanable/litter,
@@ -75753,7 +76653,7 @@
 	pixel_y = 8
 	},
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "ttx" = (
 /obj/machinery/light/floor/lamppost/one{
@@ -75872,7 +76772,7 @@
 "tvi" = (
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/automatic/darkpack/sniper,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "tvn" = (
 /obj/machinery/light/small/red/directional/west,
@@ -75894,7 +76794,7 @@
 "tvz" = (
 /obj/structure/table/wood,
 /obj/item/plate,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/ghetto)
 "tvC" = (
 /obj/effect/turf_decal/bordur{
@@ -75919,8 +76819,9 @@
 /turf/open/misc/dirt,
 /area/vtm/graveyard)
 "tvZ" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 4
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/city/toilet,
@@ -75945,6 +76846,10 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"twl" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "twt" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/smooth/old,
@@ -75973,13 +76878,13 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "twL" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "twS" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75991,7 +76896,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "twX" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/granite,
@@ -76010,13 +76915,13 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/ventrue)
 "txp" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "txx" = (
 /obj/effect/spawner/random/stray_animal,
@@ -76078,7 +76983,7 @@
 "tyt" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "tyx" = (
 /obj/effect/landmark/event_spawn/sarcophagus,
@@ -76140,10 +77045,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
 "tzL" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "tzN" = (
 /obj/structure/table,
@@ -76182,7 +77087,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "tAf" = (
 /obj/machinery/light/prince/directional/west,
@@ -76205,11 +77110,6 @@
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/techshop)
-"tAG" = (
-/obj/structure/hedge,
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "tAP" = (
 /obj/structure/vampdoor{
 	dir = 4
@@ -76221,7 +77121,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/baali)
 "tAV" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/pentex/sec,
@@ -76279,6 +77179,12 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
+"tBQ" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "tBW" = (
 /obj/effect/decal/cleanable/cardboard,
 /obj/effect/decal/cleanable/trash,
@@ -76324,7 +77230,7 @@
 /obj/structure/vampdoor/glass,
 /obj/effect/mapping_helpers/door/access/laundromat,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "tCC" = (
 /obj/item/reagent_containers/cup/glass/coffee/vampire,
@@ -76337,7 +77243,7 @@
 /turf/open/water/beach/vamp/deep,
 /area/vtm/interior/cog/caern)
 "tCE" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/jazzclub)
 "tCI" = (
@@ -76345,10 +77251,10 @@
 	dir = 1
 	},
 /obj/structure/jesuscross,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "tCS" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/old,
@@ -76357,7 +77263,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/caern)
 "tCU" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
@@ -76474,7 +77380,7 @@
 	},
 /obj/item/gun/ballistic/automatic/darkpack/thompson,
 /obj/item/ammo_box/darkpack/c45acp,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "tDX" = (
 /obj/structure/pole{
@@ -76588,7 +77494,7 @@
 /turf/open/water/bloodwave,
 /area/vtm/interior/chantry/basement)
 "tEQ" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "tET" = (
@@ -76608,6 +77514,9 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
+"tFt" = (
+/turf/closed/wall/vampwall/rustbad,
+/area/vtm/interior/police/fed)
 "tFB" = (
 /turf/open/umbra,
 /area/vtm)
@@ -76616,7 +77525,7 @@
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/sabbat_lair)
 "tFL" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -76640,9 +77549,8 @@
 /turf/open/floor/city/industrial,
 /area/vtm/interior/shop/hardware_store)
 "tGd" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/triad/red_pole,
 /turf/open/floor/plating/concrete,
@@ -76657,7 +77565,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/lower)
 "tGp" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
+/mob/living/carbon/human/npc/shop,
+/obj/effect/mapping_helpers/mob_buckler,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "tGq" = (
@@ -76709,11 +77620,17 @@
 /obj/structure/coclock,
 /obj/item/storage/fancy/donut_box,
 /obj/item/storage/box/donkpockets,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "tGL" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/city/plating_mono,
+/obj/structure/chair/wood/darkpack/red{
+	dir = 1
+	},
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "tGO" = (
 /obj/effect/turf_decal/bordur{
@@ -76793,7 +77710,7 @@
 "tIi" = (
 /obj/structure/table/wood,
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "tIt" = (
 /obj/structure/ladder/manhole/down,
@@ -77107,7 +78024,7 @@
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/salubri)
 "tMQ" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
 "tMT" = (
@@ -77181,14 +78098,14 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
 	pixel_x = -11
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "tNK" = (
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
 "tNQ" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/litter,
@@ -77288,11 +78205,11 @@
 	force = 55
 	},
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "tQl" = (
 /obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "tQm" = (
 /obj/effect/turf_decal/siding/wood,
@@ -77323,7 +78240,7 @@
 /area/vtm/interior/giovanni/basement)
 "tQB" = (
 /obj/structure/bookcase/random/reference,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "tQM" = (
 /obj/structure/closet/crate/large,
@@ -77474,7 +78391,7 @@
 /turf/open/floor/wood/herring,
 /area/vtm/interior/chantry/basement)
 "tSY" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/camarilla/towerwork,
@@ -77508,7 +78425,7 @@
 /area/vtm/outside/ghetto)
 "tTo" = (
 /obj/effect/landmark/navigate_destination,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "tTp" = (
 /obj/darkpack_car/track/volkswagen{
@@ -77688,7 +78605,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf/lower)
 "tWk" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /mob/living/carbon/human/npc/walkby/club,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
@@ -77764,8 +78681,10 @@
 /turf/open/misc/grass,
 /area/vtm/outside/fishermanswharf)
 "tXp" = (
-/obj/weapon_showcase,
-/turf/open/floor/city/plating,
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
 "tXu" = (
 /obj/effect/decal/cleanable/garbage,
@@ -77914,7 +78833,7 @@
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "tYS" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/trash,
@@ -77944,7 +78863,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "tZl" = (
 /obj/structure/rack/clothing_hanger,
@@ -77965,7 +78884,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "tZN" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/rough/cave,
@@ -78156,7 +79075,7 @@
 	},
 /obj/item/pen,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "udf" = (
 /obj/machinery/light/prince/directional/west,
@@ -78244,7 +79163,7 @@
 /turf/open/water,
 /area/vtm/outside/forest)
 "ues" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/city/gummaguts,
@@ -78269,14 +79188,18 @@
 /obj/machinery/light/small/blacklight/directional/south,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
-"ueO" = (
-/turf/open/floor/carpet,
-/area/vtm/interior)
 "ueV" = (
 /obj/weapon_showcase,
 /obj/machinery/light/prince/directional/west,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/bianchiBank)
+"ufc" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/sign/painting/large{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "ufB" = (
 /obj/item/pizzabox/mushroom{
 	pixel_y = 10
@@ -78298,16 +79221,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f2)
-"ufG" = (
-/obj/structure/vampdoor/glass{
-	dir = 8;
-	name = "Museum";
-	locked = 1;
-	lockpick_difficulty = 15;
-	lock_id = "tmr"
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "ufI" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
@@ -78336,6 +79249,9 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
+"ufX" = (
+/turf/closed/wall/vampwall/redbrick,
+/area/vtm/interior/museum)
 "ugp" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/rough/cave,
@@ -78389,12 +79305,6 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/unionsquare)
-"uha" = (
-/obj/structure/chair/comfy/brown{
-	color = "#50C878"
-	},
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "uhe" = (
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
@@ -78432,15 +79342,6 @@
 /obj/effect/turf_decal/crosswalk,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
-"uhU" = (
-/obj/structure/table/wood,
-/obj/item/clothing/gloves/vampire/latex,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/storage/box/swab,
-/obj/machinery/light/small/red/directional/north,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/police/fed)
 "uhV" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth,
@@ -78449,7 +79350,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "uib" = (
 /obj/effect/decal/cleanable/garbage,
@@ -78465,6 +79366,10 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
+"uiz" = (
+/obj/effect/decal/cleanable/cardboard,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "uiE" = (
 /obj/machinery/hydroponics/simple/plastic,
 /obj/effect/decal/graffiti,
@@ -78551,6 +79456,21 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/interior/tzimisce_manor)
+"ujz" = (
+/obj/structure/table/wood/fancy/red,
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/obj/item/gun/ballistic/automatic/darkpack/huntrifle{
+	name = "antique rifle";
+	pin = null
+	},
+/obj/item/clothing/head/vampire/ushanka{
+	pixel_y = 10;
+	pixel_x = 6
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "ujA" = (
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/park)
@@ -78587,7 +79507,7 @@
 /area/vtm/interior/giovanni)
 "ujU" = (
 /obj/machinery/light/prince/directional/north,
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth,
@@ -78608,7 +79528,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "uke" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/dispatcher,
@@ -78637,11 +79557,11 @@
 /area/vtm/interior)
 "ukB" = (
 /obj/machinery/light/prince/directional/north,
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/millennium_tower/ventrue)
 "ukG" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/grey{
@@ -78709,7 +79629,7 @@
 /obj/item/flashlight/lamp/green,
 /obj/item/vampirebook/lilith,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "ulT" = (
 /obj/effect/turf_decal/bordur{
@@ -78754,6 +79674,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/vtm/interior/millennium_tower/f4)
+"umh" = (
+/obj/structure/platform/lowwall/wood/window/reinforced,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "umi" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -78805,7 +79729,7 @@
 /area/vtm/interior)
 "umR" = (
 /obj/structure/bookcase/random/adult,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "umT" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
@@ -78913,7 +79837,7 @@
 /area/vtm/interior/techshop)
 "uok" = (
 /obj/structure/filingcabinet/white,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "uon" = (
 /obj/effect/turf_decal/bordur/corner,
@@ -78943,7 +79867,7 @@
 "uou" = (
 /obj/structure/bed,
 /obj/machinery/light/warm/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uoy" = (
 /obj/machinery/light/small/directional/north,
@@ -78976,7 +79900,7 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/oldchurch)
 "uoI" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -79022,7 +79946,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/shop/arts)
 "upr" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/white{
@@ -79055,7 +79979,7 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "upU" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -79102,7 +80026,7 @@
 /area/vtm/outside/unionsquare)
 "uqc" = (
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uqk" = (
 /obj/structure/railing{
@@ -79151,6 +80075,16 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/fishermanswharf/lower)
+"uqH" = (
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/obj/machinery/washing_machine{
+	pixel_y = 17;
+	density = 0
+	},
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "uqL" = (
 /obj/effect/decal/pallet{
 	pixel_y = -7
@@ -79181,7 +80115,7 @@
 "uqT" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "uqU" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
@@ -79198,10 +80132,6 @@
 /obj/cargocrate,
 /turf/open/misc/dirt/rails,
 /area/vtm/interior/supply)
-"urm" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/chantry)
 "urn" = (
 /obj/effect/landmark/npcbeacon/directed{
 	dir = 4
@@ -79223,7 +80153,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "urO" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /mob/living/carbon/human/npc/shop,
 /obj/effect/mapping_helpers/mob_buckler,
 /turf/open/floor/wood/smooth/old,
@@ -79263,11 +80193,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "usi" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "usj" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /mob/living/carbon/human/npc/endronsecurity{
@@ -79343,7 +80273,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "utc" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/rough,
@@ -79418,10 +80348,10 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/techshop)
 "uub" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uuj" = (
 /obj/structure/rack,
@@ -79463,7 +80393,7 @@
 /area/vtm/interior/clinic/haven)
 "uuI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/bacotell,
@@ -79534,10 +80464,10 @@
 /area/vtm)
 "uvQ" = (
 /obj/structure/fluff/tv,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "uvU" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -79557,14 +80487,14 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
 "uwl" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
 "uwo" = (
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
@@ -79614,6 +80544,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/door/access/malkavian,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "uwV" = (
@@ -79673,7 +80604,7 @@
 "uxi" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "uxj" = (
 /obj/effect/turf_decal/siding/wood/dark{
@@ -79682,7 +80613,7 @@
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/salubri)
 "uxo" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/structure/curtain/bounty{
@@ -79728,12 +80659,20 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/wood/old,
 /area/vtm/interior/sewer/nosferatu_town)
+"uyg" = (
+/obj/machinery/vending/cola/black{
+	pixel_y = 20;
+	density = 0
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/museum)
 "uyj" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/blood/o_plus,
 /obj/item/reagent_containers/blood/ab_minus,
 /obj/item/reagent_containers/blood/a_minus,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uyr" = (
 /turf/closed/wall/vampwall/rich,
@@ -79836,6 +80775,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
+"uzq" = (
+/obj/effect/turf_decal/siding/grey/inner_corner{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/strip)
 "uzv" = (
 /obj/structure/loom,
 /turf/open/misc/dirt,
@@ -79895,7 +80843,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
 "uAf" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /obj/effect/decal/pallet,
@@ -79950,19 +80898,16 @@
 /area/vtm/outside/northbeach)
 "uAt" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "uAx" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/siding/grey{
+	dir = 1
 	},
 /obj/structure/railing{
-	pixel_y = -2
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/turf/open/floor/city/plating_mono,
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/strip)
 "uAD" = (
 /obj/structure/table/wood/poker,
@@ -80126,6 +81071,12 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"uCw" = (
+/obj/effect/decal/cleanable/trash{
+	icon_state = "trash8"
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "uCT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80141,11 +81092,17 @@
 	},
 /obj/structure/table/wood/fancy/black,
 /obj/vampire_computer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "uCX" = (
 /turf/open/floor/plating/grate,
 /area/vtm/interior/endron_facility/plant)
+"uDa" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/light,
+/area/vtm/interior/strip)
 "uDb" = (
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/smoke_shop)
@@ -80218,7 +81175,7 @@
 /obj/item/radio,
 /obj/item/vamp/keys/camarilla,
 /obj/item/vamp/keys/camarilla,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "uDL" = (
 /obj/structure/closet,
@@ -80244,7 +81201,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "uEh" = (
 /obj/structure/table/wood,
@@ -80295,7 +81252,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
 "uEL" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/plating/granite,
@@ -80355,7 +81312,7 @@
 	dir = 1
 	},
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "uFZ" = (
 /obj/effect/turf_decal/siding/white,
@@ -80383,7 +81340,7 @@
 /turf/open/floor/wood,
 /area/vtm/interior/church/haven)
 "uGh" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "uGj" = (
 /obj/effect/turf_decal/bordur{
@@ -80411,7 +81368,7 @@
 /area/vtm/interior/tzimisce_manor)
 "uGv" = (
 /obj/item/seeds/cannabis,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uGC" = (
 /obj/structure/closet/crate/large,
@@ -80556,6 +81513,15 @@
 	},
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/sabbat_lair)
+"uIb" = (
+/obj/structure/table/wood,
+/obj/item/kirbyplants/darkpack/plant4{
+	pixel_y = 7;
+	pixel_x = -20
+	},
+/obj/machinery/recharger,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "uIh" = (
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm)
@@ -80574,13 +81540,6 @@
 "uIl" = (
 /turf/open/openspace,
 /area/vtm/interior/bianchiBank)
-"uIt" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/mob/living/carbon/human/npc/incel,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "uIz" = (
 /obj/effect/turf_decal/darkpack/grass{
 	dir = 1
@@ -80608,13 +81567,13 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
 "uIL" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
 "uIM" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /mob/living/carbon/human/npc/bandit,
@@ -80705,7 +81664,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/strip)
 "uJT" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/pentex/employee,
@@ -80750,21 +81709,11 @@
 /turf/open/floor/light,
 /area/vtm/interior)
 "uKE" = (
-/obj/structure/hedge,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/vampstatue{
+	name = "statue to the Del'Roh"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "uKG" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/concrete,
@@ -80781,10 +81730,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
-"uLt" = (
-/obj/structure/table,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "uLu" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/white{
@@ -80793,7 +81738,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
 "uLD" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -80879,7 +81824,7 @@
 	dir = 8
 	},
 /mob/living/carbon/human/npc/incel,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uME" = (
 /obj/effect/turf_decal/stock{
@@ -80911,7 +81856,7 @@
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/shop/otolleys)
 "uNq" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /mob/living/carbon/human/npc/shop,
 /obj/effect/mapping_helpers/mob_buckler,
 /turf/open/floor/plating/concrete,
@@ -80936,7 +81881,7 @@
 /turf/open/openspace,
 /area/vtm)
 "uNR" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth,
@@ -80987,7 +81932,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "uOH" = (
 /obj/effect/turf_decal/bordur{
@@ -81005,7 +81950,7 @@
 /obj/item/stack/dollar/hundred,
 /obj/item/stack/dollar/hundred,
 /obj/item/stack/dollar/hundred,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
 "uPa" = (
 /obj/machinery/griddle,
@@ -81186,12 +82131,6 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/clinic/haven)
-"uRR" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/outside/forest)
 "uRT" = (
 /obj/structure/rack/food/rand,
 /turf/open/floor/city/circled,
@@ -81249,6 +82188,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/strip)
+"uSm" = (
+/obj/structure/table/wood,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/museum)
 "uSn" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/directional/north{
@@ -81260,7 +82203,7 @@
 /turf/open/floor/iron/small,
 /area/vtm/interior/endron_facility/restricted)
 "uSo" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating_mono,
@@ -81381,7 +82324,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "uTE" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /obj/item/fireaxe/vamp{
@@ -81398,7 +82341,7 @@
 	pixel_y = -6
 	},
 /obj/structure/table,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "uTQ" = (
 /obj/structure/hedge,
@@ -81452,9 +82395,16 @@
 /obj/structure/vampdoor/old,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/bianchiBank)
+"uUt" = (
+/obj/structure/table,
+/obj/machinery/vending/boozeomat,
+/obj/structure/platform/lowwall/old,
+/obj/structure/table,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/strip)
 "uUA" = (
 /obj/structure/dresser,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uUK" = (
 /obj/machinery/light/directional/north,
@@ -81570,13 +82520,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/ventrue)
-"uVQ" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/card/noddist,
-/obj/item/card/noddist,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
 "uWj" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -81585,11 +82528,11 @@
 	pixel_y = -32
 	},
 /obj/structure/table/wood,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "uWk" = (
 /obj/effect/decal/rugs,
@@ -81741,7 +82684,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/shop/clothing_store)
 "uXF" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "uXP" = (
 /obj/structure/closet/crate/coffin,
@@ -81762,18 +82705,19 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "uXV" = (
-/obj/structure/table/wood,
 /obj/item/rag,
-/turf/open/floor/carpet,
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
-"uXX" = (
-/obj/structure/mannequin/plastic/cowboy,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/museum)
 "uYa" = (
-/obj/effect/decal/wallpaper/paper/stripe,
-/turf/closed/wall/vampwall/rich/old,
-/area/vtm/interior/trujah)
+/obj/structure/chair/darkpack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "uYe" = (
 /obj/structure/table,
 /obj/effect/decal/graffiti/large{
@@ -81791,10 +82735,10 @@
 /area/vtm/outside/chinatown)
 "uYn" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "uYp" = (
 /obj/structure/toilet{
@@ -81813,7 +82757,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
 "uYu" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/white{
@@ -81890,7 +82834,7 @@
 	dir = 9
 	},
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "uZu" = (
 /obj/effect/landmark/npcactivity,
@@ -82059,7 +83003,7 @@
 /area/vtm/interior/millennium_tower)
 "vbD" = (
 /obj/item/fishing_rod,
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/misc/beach/vamp,
@@ -82081,7 +83025,7 @@
 	},
 /obj/item/flashlight,
 /obj/structure/coclock,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/hotel)
 "vbP" = (
 /obj/effect/decal/pallet,
@@ -82195,7 +83139,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/church/staff)
 "vdm" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -82274,7 +83218,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
 "vei" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "vek" = (
@@ -82300,6 +83244,11 @@
 /obj/structure/flora/rock/pile/darkpack,
 /turf/open/misc/dirt,
 /area/vtm/outside/pacificheights/forest)
+"ver" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light/small/pink/directional/south,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/strip)
 "vew" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
@@ -82308,12 +83257,18 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
+"vey" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "vez" = (
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "veG" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough/cave,
@@ -82390,6 +83345,15 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
+"vfR" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/chantry)
 "vfS" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/smooth/old,
@@ -82512,7 +83476,7 @@
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm)
 "vhw" = (
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
 "vhx" = (
@@ -82527,6 +83491,16 @@
 /obj/vampire_computer,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
+"vhA" = (
+/obj/effect/turf_decal/darkpack/grass{
+	dir = 4
+	},
+/obj/effect/turf_decal/darkpack/grass{
+	dir = 8
+	},
+/obj/item/seeds/poppy/geranium/fraxinella,
+/turf/open/misc/dirt,
+/area/vtm)
 "vhD" = (
 /turf/open/floor/city/factory,
 /area/vtm/interior/shop/smoke_shop)
@@ -82539,7 +83513,7 @@
 /area/vtm/interior/clinic/haven)
 "vhN" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "vhU" = (
 /obj/machinery/light/directional/west,
@@ -82622,16 +83596,15 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "vjc" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/baali)
 "vjp" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
@@ -82725,6 +83698,23 @@
 /obj/machinery/light/prince/directional/east,
 /turf/open/floor/wood/old,
 /area/vtm/interior/tzimisce_manor)
+"vkz" = (
+/obj/effect/mapping_helpers/door/access/kiasyd,
+/obj/structure/vampdoor/woodglass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/autoname,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/bash_difficulty/six,
+/obj/effect/turf_decal/siding/grey{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/grey{
+	dir = 8
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "vkA" = (
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/sewer)
@@ -82741,6 +83731,16 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"vkW" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/hotel)
+"vli" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/museum)
 "vlj" = (
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
@@ -82818,10 +83818,6 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/grass,
 /area/vtm/outside/fishermanswharf/lower)
-"vlR" = (
-/obj/structure/filingcabinet/medical,
-/turf/open/floor/wood/old,
-/area/vtm/interior/police/fed)
 "vmg" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/outside/forest)
@@ -82835,12 +83831,6 @@
 /obj/machinery/shower/directional/north,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
-"vml" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "vmr" = (
 /mob/living/basic/pet/cat/darkpack,
 /obj/effect/decal/graffiti/large{
@@ -82864,10 +83854,6 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/seven,
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
-"vmN" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/anarch)
 "vmO" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -82884,10 +83870,12 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
 "vmR" = (
-/obj/structure/curtain/cloth/fancy,
-/obj/structure/platform/lowwall/market/window/reinforced,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/trujah)
+/obj/structure/table/wood/fancy/cyan,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/museum)
 "vmT" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 8
@@ -82897,7 +83885,7 @@
 /area/vtm/interior/shop/antiques)
 "vmU" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -82959,8 +83947,8 @@
 /turf/open/misc/grass,
 /area/vtm/outside/financialdistrict)
 "vop" = (
-/obj/structure/chair/wood/wings,
-/turf/open/floor/carpet,
+/obj/structure/chair/wood/darkpack/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/theatre)
 "vot" = (
 /obj/structure/urinal{
@@ -83051,9 +84039,13 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
 "vpr" = (
-/obj/structure/mannequin/plastic/cowboy,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
+/obj/structure/sign/flag/france{
+	pixel_y = 29
+	},
+/obj/structure/mannequin/plastic/napoleon,
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "vps" = (
 /obj/item/smartphone/payphone,
 /turf/open/floor/plating/sidewalk,
@@ -83079,7 +84071,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf)
 "vpD" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
 "vpJ" = (
@@ -83095,7 +84087,7 @@
 /obj/structure/vampdoor/wood{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "vpZ" = (
 /obj/machinery/light/small/directional/east,
@@ -83129,7 +84121,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "vqy" = (
 /obj/structure/bed,
@@ -83143,6 +84135,13 @@
 "vqC" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/glasswalker)
+"vqE" = (
+/obj/structure/vampdoor/prison,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/lock_difficulty/nine,
+/obj/effect/mapping_helpers/door/access/federal,
+/turf/open/floor/wood/rough,
+/area/vtm/interior/police/fed)
 "vqG" = (
 /obj/structure/vampstatue,
 /turf/open/floor/wood/smooth/old,
@@ -83172,8 +84171,8 @@
 	},
 /area/vtm/interior/tzimisce_manor)
 "vqY" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/black,
+/obj/structure/chair/stool/bar/darkpack/red,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "vrc" = (
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -83337,9 +84336,6 @@
 /obj/structure/roadsign,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"vtK" = (
-/turf/open/floor/iron/stairs/medium,
-/area/vtm/interior/strip)
 "vtM" = (
 /obj/effect/turf_decal/bordur{
 	dir = 5
@@ -83431,7 +84427,7 @@
 "vuH" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "vuW" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -83508,7 +84504,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "vvL" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -83576,6 +84572,13 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/outside/giovanni/courtyard)
+"vwF" = (
+/obj/structure/chair/stool/bar/darkpack/black,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "vwJ" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/dark_green/corner{
@@ -83635,6 +84638,10 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/clothing_store)
+"vxO" = (
+/obj/effect/decal/wallpaper/paper/stripe,
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/museum)
 "vxT" = (
 /obj/structure/vampdoor/reinf,
 /obj/effect/mapping_helpers/door/access/setite,
@@ -83725,7 +84732,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/bianchiBank)
 "vzt" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/forest)
 "vzD" = (
@@ -83739,7 +84746,7 @@
 /obj/effect/turf_decal/bordur{
 	dir = 8
 	},
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/roofwalk,
@@ -83753,6 +84760,9 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/shop/gunshop)
+"vAv" = (
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/strip)
 "vAA" = (
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw{
 	dir = 8
@@ -83777,20 +84787,20 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/pawnshop)
 "vBa" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/wood/smooth,
 /area/vtm)
 "vBh" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "vBn" = (
-/obj/structure/chair/office,
 /mob/living/carbon/human/npc/guard,
-/turf/open/floor/carpet,
+/obj/structure/chair/office/darkpack/black,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "vBs" = (
 /obj/structure/table,
@@ -83904,10 +84914,10 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/library)
 "vCE" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "vCQ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -83968,11 +84978,18 @@
 /area/vtm/interior/police)
 "vDN" = (
 /obj/machinery/light/directional/north,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"vDP" = (
+/obj/weapon_showcase,
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "vDQ" = (
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior)
@@ -84011,7 +85028,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/cog/caern)
 "vEp" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
@@ -84031,7 +85048,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
 "vEx" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/landmark/start/darkpack/camarilla/clerk,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower)
@@ -84040,9 +85057,10 @@
 /area/vtm/interior/cog/pantry)
 "vEH" = (
 /obj/structure/chair/sofa/corp/corner{
-	dir = 8
+	dir = 8;
+	color = "#CD5C5C"
 	},
-/turf/open/floor/plating/granite/black,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/strip)
 "vEJ" = (
 /obj/effect/turf_decal/asphaltline/alt,
@@ -84066,7 +85084,7 @@
 /area/vtm/interior/shop/clothing_store)
 "vFd" = (
 /obj/machinery/light/directional/north,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -84231,7 +85249,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "vGW" = (
 /obj/structure/dresser,
@@ -84302,13 +85320,13 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "vHP" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "vHR" = (
 /obj/structure/table/wood,
@@ -84362,14 +85380,6 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
-"vIV" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/open/floor/light,
-/area/vtm/interior/strip)
 "vIX" = (
 /obj/structure/vampfence{
 	dir = 4
@@ -84393,7 +85403,7 @@
 /area/vtm/interior/supply)
 "vJe" = (
 /obj/structure/bookcase/random/religion,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "vJn" = (
 /obj/structure/closet/crate/bin,
@@ -84440,13 +85450,6 @@
 	color = "#8a8a8a"
 	},
 /area/vtm)
-"vJY" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/landmark/start/darkpack/citizen/club_worker,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/strip)
 "vKb" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/smooth/old,
@@ -84488,7 +85491,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "vKN" = (
 /obj/effect/turf_decal/siding/white{
@@ -84510,7 +85513,7 @@
 /obj/structure/bed,
 /obj/effect/decal/cleanable/trash,
 /obj/machinery/light/warm/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "vLo" = (
 /obj/effect/decal/wallpaper/paper/rich/low,
@@ -84578,8 +85581,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "vMt" = (
-/obj/structure/table/glass,
 /obj/machinery/light/directional/north,
+/mob/living/carbon/human/npc/shop,
+/obj/structure/chair/office/darkpack/black,
+/obj/effect/mapping_helpers/mob_buckler,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "vMw" = (
@@ -84624,6 +85629,7 @@
 "vMU" = (
 /obj/structure/vampdoor/old,
 /obj/effect/turf_decal/siding/white,
+/obj/effect/mapping_helpers/door/access/malkavian,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/clinic/haven)
 "vNb" = (
@@ -84668,7 +85674,7 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/giovanni/basement)
 "vNX" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -84707,7 +85713,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/fbi,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "vOZ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -84727,7 +85733,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "vPj" = (
 /obj/structure/bed,
@@ -84819,7 +85825,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "vQo" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/forest_wolves/keeper,
@@ -84831,6 +85837,10 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"vQy" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/anarch)
 "vQB" = (
 /obj/effect/decal/gut_floor,
 /obj/structure/statue/bone/rib,
@@ -84980,7 +85990,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "vSD" = (
 /obj/effect/turf_decal/bordur{
@@ -85001,7 +86011,7 @@
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
 /obj/structure/coclock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "vSZ" = (
 /obj/structure/vampipe{
@@ -85067,7 +86077,7 @@
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "vUf" = (
 /obj/transfer_point_vamp/stairs{
@@ -85098,7 +86108,7 @@
 /turf/open/floor/plating/rust,
 /area/vtm/outside/pacificheights/forest)
 "vUp" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -85138,14 +86148,8 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/jazzclub)
-"vUz" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/trujah)
 "vUA" = (
-/obj/structure/chair/comfy,
+/obj/structure/chair/comfy/darkpack,
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/jazzclub)
@@ -85186,6 +86190,17 @@
 	dir = 8
 	},
 /area/vtm/interior)
+"vUK" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_y = 7
+	},
+/obj/item/hand_labeler,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "vUM" = (
 /obj/structure/platform/lowwall/old/window,
 /turf/open/floor/plating/rough,
@@ -85352,7 +86367,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/clothing_store)
 "vWY" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -85399,6 +86414,19 @@
 /obj/machinery/telecomms/hub,
 /turf/open/floor/circuit,
 /area/vtm/interior/techshop)
+"vXI" = (
+/obj/structure/roadblock{
+	dir = 1;
+	pixel_y = 17;
+	density = 0
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "vXL" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -85415,10 +86443,10 @@
 "vXP" = (
 /obj/machinery/light/prince/directional/north,
 /obj/structure/bookcase/random,
-/turf/open/floor/wood/smooth/old,
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
 "vXR" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/strip)
 "vXU" = (
@@ -85472,7 +86500,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "vYx" = (
 /obj/structure/curtain/bounty,
@@ -85533,11 +86561,18 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "vZa" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 8
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"vZg" = (
+/obj/structure/chair/sofa/corp/right{
+	color = "#CD5C5C"
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/strip)
 "vZj" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/city/toilet,
@@ -85680,6 +86715,11 @@
 /obj/item/detective_scanner,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/techshop)
+"waT" = (
+/turf/open/floor/iron/stairs/black{
+	dir = 1
+	},
+/area/vtm/interior/strip)
 "waX" = (
 /obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/city/plating_mono,
@@ -85792,7 +86832,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/tzimisce_manor)
 "wcn" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "wcp" = (
@@ -85802,10 +86842,10 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
 "wcr" = (
 /obj/structure/railing/corner{
@@ -85858,7 +86898,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/baali)
 "wdz" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -85898,7 +86938,7 @@
 /turf/open/water,
 /area/vtm/interior/bianchiBank)
 "wed" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/carpet/purple,
@@ -85922,7 +86962,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
 "wel" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -86108,12 +87148,12 @@
 /area/vtm/interior/millennium_tower/ventrue)
 "wgU" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
 "whf" = (
 /obj/structure/bed/maint,
 /mob/living/carbon/human/npc/hobo,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "whj" = (
 /obj/structure/closet/crate/bin,
@@ -86155,7 +87195,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "whL" = (
 /obj/effect/turf_decal/bordur{
@@ -86200,7 +87240,7 @@
 /area/vtm/interior/shop/gasstation)
 "wih" = (
 /obj/structure/tank_holder/extinguisher,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "wii" = (
 /obj/machinery/light/prince/directional/east,
@@ -86244,7 +87284,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/church/haven)
 "wjb" = (
 /turf/open/floor/wood/smooth,
@@ -86289,7 +87329,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "wjM" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -86465,6 +87505,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 6
 	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
 "wmm" = (
@@ -86583,9 +87626,6 @@
 	},
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/salubri)
-"wod" = (
-/turf/open/floor/city/toilet,
-/area/vtm/interior/trujah)
 "wol" = (
 /obj/structure/railing{
 	dir = 4
@@ -86641,7 +87681,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/giovanni)
 "woS" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/forest_wolves/keeper,
@@ -86683,13 +87723,16 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
 "wpM" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/vampdoor/woodglass{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/structure/vampdoor/simple{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth/old,
+/turf/open/floor/plating/rough,
 /area/vtm/interior/museum)
 "wpP" = (
 /obj/structure/filingcabinet,
@@ -86741,7 +87784,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "wqL" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -86876,6 +87919,21 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"wsB" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/water,
+/area/vtm/interior/chantry)
 "wsO" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -86983,7 +88041,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "wum" = (
 /obj/effect/decal/cleanable/litter,
@@ -87046,6 +88104,11 @@
 /mob/living/carbon/human/npc/walkby,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
+"wvG" = (
+/obj/effect/turf_decal/siding/grey,
+/obj/structure/railing,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/strip)
 "wvS" = (
 /obj/structure/vampfence/rich{
 	dir = 4
@@ -87061,7 +88124,7 @@
 "wvU" = (
 /obj/structure/table/wood,
 /obj/item/switchblade/vamp,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "wvW" = (
 /obj/fusebox/transformer{
@@ -87140,19 +88203,13 @@
 /obj/structure/hydrant,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"wwX" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/light,
-/area/vtm/interior/strip)
 "wwY" = (
 /obj/item/reagent_containers/cup/glass/trophy/silver_cup,
 /obj/structure/table/modern,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f3)
 "wxb" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth,
@@ -87264,10 +88321,9 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/fed)
 "wyg" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/structure/coclock,
 /obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/darkpack/redsilver,
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "wyr" = (
 /obj/effect/decal/rugs,
@@ -87289,7 +88345,7 @@
 	},
 /obj/item/ammo_box/magazine/m50,
 /obj/item/ammo_box/magazine/m50,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "wyC" = (
 /obj/effect/turf_decal/bordur/corner{
@@ -87315,11 +88371,6 @@
 "wyS" = (
 /turf/closed/wall/vampwall/metal/glass,
 /area/vtm/interior/endron_facility/restricted)
-"wyW" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/chantry)
 "wzm" = (
 /obj/effect/turf_decal/siding/wood/rough{
 	dir = 8
@@ -87331,7 +88382,7 @@
 	pixel_x = -5;
 	pixel_y = -4
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
@@ -87485,7 +88536,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "wAW" = (
 /obj/effect/decal/cleanable/cardboard,
@@ -87705,7 +88756,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
 "wDg" = (
 /obj/structure/railing{
@@ -87726,7 +88777,7 @@
 /area/vtm/outside/pacificheights/community)
 "wDk" = (
 /obj/machinery/light/directional/north,
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/landmark/start/darkpack/hospital/doctor,
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 1
@@ -87790,7 +88841,7 @@
 /area/vtm/interior)
 "wEg" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "wEh" = (
 /obj/effect/turf_decal/siding/white{
@@ -87827,9 +88878,20 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "wEO" = (
-/obj/structure/toilet,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/trujah)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/access/kiasyd,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/bash_difficulty/six,
+/obj/effect/turf_decal/siding/grey,
+/obj/effect/turf_decal/siding/grey{
+	dir = 1
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "wEP" = (
 /obj/structure/rack/clothing_hanger,
 /turf/open/floor/wood/smooth/old,
@@ -87869,10 +88931,6 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
-"wFr" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/strip)
 "wFu" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/white{
@@ -87963,7 +89021,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/theatre)
 "wGC" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth,
@@ -87979,13 +89037,13 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "wGN" = (
 /turf/open/floor/carpet/red,
 /area/vtm/interior/clinic/haven)
 "wGO" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/dispatcher,
@@ -87993,7 +89051,7 @@
 /area/vtm/interior/police)
 "wGQ" = (
 /obj/structure/fireplace,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/church/haven)
 "wGR" = (
 /obj/effect/turf_decal/siding/white,
@@ -88034,8 +89092,26 @@
 "wHu" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/light/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
+"wHB" = (
+/obj/structure/sign/flag/britain{
+	pixel_y = 29;
+	pixel_x = 19
+	},
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/clothing/head/costume/powdered_wig{
+	pixel_y = 9;
+	pixel_x = 6
+	},
+/obj/item/clothing/under/costume/redcoat{
+	pixel_x = -5
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/museum)
 "wHE" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood/smooth/old,
@@ -88084,7 +89160,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "wIm" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
@@ -88170,7 +89246,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/upstairs)
 "wJx" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
 "wJy" = (
@@ -88268,8 +89344,14 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
+"wKI" = (
+/obj/structure/railing/darkpack/metal{
+	dir = 9
+	},
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "wKJ" = (
-/obj/structure/chair/wood/wings,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
 "wKO" = (
@@ -88289,7 +89371,7 @@
 "wLg" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "wLh" = (
 /obj/effect/decal/cleanable/ash,
@@ -88565,6 +89647,14 @@
 	pixel_y = 2;
 	pixel_x = -5
 	},
+/obj/item/reagent_containers/cup/jerrycan/robustharvest{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/jerrycan/eznutriment{
+	pixel_y = 2;
+	pixel_x = 8
+	},
 /turf/open/misc/grass,
 /area/vtm)
 "wOD" = (
@@ -88604,19 +89694,29 @@
 /obj/structure/roadsign/speedlimit40,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
+"wOV" = (
+/obj/structure/railing/darkpack/metal{
+	dir = 5
+	},
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "wOX" = (
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 8
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"wOZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "wPb" = (
 /obj/structure/railing,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "wPf" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/city/plating,
@@ -88629,7 +89729,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "wPq" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating,
@@ -88677,7 +89777,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
 "wPT" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /mob/living/carbon/human/npc/police/static,
@@ -88686,7 +89786,7 @@
 "wPZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "wQc" = (
 /obj/machinery/light/small/directional/east,
@@ -88804,10 +89904,8 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "wRG" = (
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	pixel_y = -11;
-	pixel_x = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
@@ -88817,6 +89915,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"wRP" = (
+/obj/machinery/iv_drip,
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "wRT" = (
 /obj/effect/decal/rugs,
 /obj/structure/guncase,
@@ -88850,21 +89952,21 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
 "wSr" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/sewer/nosferatu_town)
 "wSx" = (
 /obj/structure/table/wood,
-/obj/item/chair/wood/wings,
+/obj/item/chair/wood/darkpack/red,
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "wSF" = (
 /obj/structure/chair/comfy/beige,
 /obj/effect/landmark/start/darkpack/primogen/nosferatu,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/sewer/nosferatu_town)
 "wSH" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/grey/end,
@@ -88970,13 +90072,13 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer/nosferatu_town)
 "wTB" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/bianchiBank)
 "wTE" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/strip)
 "wTO" = (
@@ -88999,7 +90101,7 @@
 "wUf" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "wUk" = (
 /obj/machinery/light/small/directional/west,
@@ -89023,6 +90125,16 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/dirt,
 /area/vtm/outside/northbeach)
+"wUW" = (
+/obj/structure/table,
+/obj/structure/reagent_dispensers/wall/peppertank{
+	pixel_y = 5
+	},
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
+/turf/open/misc/dirt,
+/area/vtm/interior/police/fed)
 "wUY" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating/sidewalk,
@@ -89143,6 +90255,10 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"wWr" = (
+/obj/effect/decal/cleanable/trash,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/police/fed)
 "wWx" = (
 /obj/structure/vampdoor/reinf,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -89192,7 +90308,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/fishermanswharf)
 "wXl" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
 "wXq" = (
@@ -89223,7 +90339,7 @@
 	dir = 1;
 	pixel_y = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "wXM" = (
 /obj/structure/hedge,
@@ -89236,14 +90352,6 @@
 	},
 /turf/open/floor/wood/herring,
 /area/vtm/interior/shop/clothing_store)
-"wXX" = (
-/obj/structure/bed,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/cyan,
-/area/vtm/interior/hotel)
 "wXZ" = (
 /obj/structure/table,
 /obj/structure/fluff/tv{
@@ -89271,12 +90379,6 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
-"wYm" = (
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/strip)
 "wYn" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -89348,13 +90450,13 @@
 	dir = 4;
 	pixel_y = 13
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/tzimisce_manor)
 "wZm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/wood/smooth/old,
@@ -89548,7 +90650,7 @@
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/sewer)
 "xaF" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
 "xaG" = (
@@ -89582,7 +90684,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
 "xaI" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
@@ -89682,7 +90784,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "xbH" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -89734,7 +90836,7 @@
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
 "xcs" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/wood/darkpack/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/caern)
 "xcu" = (
@@ -89750,7 +90852,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
 "xcJ" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -89813,7 +90915,7 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
 "xdF" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/plating/concrete,
@@ -89863,7 +90965,7 @@
 /area/vtm/interior/endron_facility/restricted)
 "xek" = (
 /obj/machinery/light/directional/south,
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/plating,
@@ -89896,7 +90998,7 @@
 "xeQ" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/spawner/random/occult/artifact,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "xeT" = (
 /obj/item/fishing_rod{
@@ -89910,9 +91012,9 @@
 /turf/open/misc/grass,
 /area/vtm/outside/northbeach)
 "xeZ" = (
-/obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/open/floor/carpet,
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "xfb" = (
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -89964,12 +91066,16 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/structure/bed/dogbed/mcgriff,
 /mob/living/basic/pet/dog/pug/mcgriff,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "xfv" = (
 /obj/machinery/light/small/pink/directional/north,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
+"xfC" = (
+/obj/effect/decal/wallpaper/light,
+/turf/closed/wall/vampwall/market,
+/area/vtm/interior/museum)
 "xfE" = (
 /obj/structure/closet/crate,
 /obj/item/food/vampire/icecream,
@@ -89999,7 +91105,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "xfJ" = (
-/obj/structure/chair/office,
+/obj/structure/chair/office/darkpack/black,
 /obj/effect/landmark/start/darkpack/camarilla/clerk,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower)
@@ -90114,7 +91220,7 @@
 /turf/open/floor/city/circled,
 /area/vtm/interior/clinic)
 "xhB" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/plating/concrete,
@@ -90146,6 +91252,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
+"xhT" = (
+/obj/item/newspaper,
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/anarch)
 "xib" = (
 /obj/machinery/door/poddoor/shutters/armory{
 	damage_deflection = 60;
@@ -90181,6 +91292,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
+"xiB" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/blue,
+/area/vtm/interior/museum)
 "xiD" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/bodybags,
@@ -90323,7 +91440,7 @@
 /area/vtm/interior)
 "xkF" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "xkN" = (
 /obj/structure/flora/tree/vamp/pine,
@@ -90349,12 +91466,8 @@
 /area/vtm/interior/endron_facility/restricted)
 "xle" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
-"xli" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/carpet,
-/area/vtm/interior/hotel)
 "xln" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/turf_decal/weather/dirt{
@@ -90442,7 +91555,7 @@
 /area/vtm/interior/millennium_tower/f3)
 "xmq" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "xms" = (
 /obj/structure/rack,
@@ -90509,10 +91622,10 @@
 /area/vtm/interior/banu/haven)
 "xmQ" = (
 /obj/structure/table,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "xmX" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -90618,7 +91731,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/financialdistrict)
 "xnZ" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -90753,7 +91866,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/red/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "xpQ" = (
 /obj/machinery/light/directional/north,
@@ -90952,7 +92065,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "xrG" = (
 /obj/structure/vampstatue,
@@ -91015,7 +92128,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
 "xso" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/supply)
 "xsx" = (
 /obj/effect/turf_decal/siding/white{
@@ -91030,7 +92143,7 @@
 /obj/structure/railing{
 	pixel_y = -2
 	},
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/city/plating_mono,
@@ -91063,7 +92176,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/gasstation)
 "xsP" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /turf/open/floor/plating/concrete,
@@ -91086,13 +92199,6 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/old,
 /area/vtm/interior/tzimisce_manor)
-"xtr" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/ghetto)
 "xtG" = (
 /obj/effect/decal/wallpaper/paper/rich,
 /turf/closed/wall/vampwall/rich/old,
@@ -91368,7 +92474,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm)
 "xyb" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /turf/open/floor/city/plating,
@@ -91436,7 +92542,7 @@
 /turf/open/floor/city/saint,
 /area/vtm/interior/church/haven)
 "xyS" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -91592,7 +92698,7 @@
 /obj/structure/closet/cardboard,
 /obj/item/instrument/guitar,
 /obj/item/instrument/piano_synth,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "xBt" = (
 /obj/structure/table/wood,
@@ -91644,7 +92750,7 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/nine,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "xBX" = (
 /obj/structure/rack,
@@ -91674,6 +92780,13 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/giovanni/courtyard)
+"xCp" = (
+/obj/effect/turf_decal/bordur,
+/obj/structure/railing/darkpack/metal{
+	dir = 9
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "xCr" = (
 /obj/effect/landmark/start/darkpack/hecata/famiglia,
 /obj/structure/railing{
@@ -91711,7 +92824,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
 "xCP" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -91850,7 +92963,7 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/ventrue)
 "xFe" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -91875,7 +92988,7 @@
 /obj/item/reagent_containers/blood/vitae,
 /obj/item/reagent_containers/blood/vitae,
 /obj/structure/closet/crate/freezer,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "xFt" = (
 /obj/effect/turf_decal/siding/white{
@@ -91908,7 +93021,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "xFH" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/theatre)
 "xFO" = (
@@ -91981,11 +93094,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
-"xGt" = (
-/obj/effect/landmark/start/darkpack/citizen/citizen,
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/hotel)
 "xGu" = (
 /obj/effect/decal/shadow,
 /obj/structure/railing{
@@ -92029,7 +93137,7 @@
 /turf/open/floor/wood/herring,
 /area/vtm/interior/clinic)
 "xGV" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 4
 	},
 /turf/open/floor/plating/concrete,
@@ -92046,10 +93154,10 @@
 /area/vtm/interior/graveyard)
 "xHw" = (
 /obj/structure/vampdoor/glass,
-/obj/effect/mapping_helpers/door/access/clinic,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
 /obj/effect/mapping_helpers/door/bash_difficulty/seven,
+/obj/effect/mapping_helpers/door/access/malkavian,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
 "xHI" = (
@@ -92073,11 +93181,6 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
-"xHV" = (
-/obj/item/kirbyplants/random,
-/obj/fusebox,
-/turf/open/floor/wood/old,
-/area/vtm/interior/trujah)
 "xHW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -92087,7 +93190,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
 "xHX" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/carpet/darkpack/redsilver,
@@ -92190,7 +93293,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
 "xIS" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -92242,7 +93345,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "xJF" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -92335,8 +93438,8 @@
 /area/vtm/outside/pacificheights/community)
 "xKr" = (
 /obj/structure/table/wood,
-/obj/item/chair/wood/wings,
-/turf/open/floor/carpet,
+/obj/item/chair/wood/darkpack/red,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "xKs" = (
 /obj/structure/table/wood,
@@ -92349,6 +93452,10 @@
 	},
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/graveyard)
+"xKy" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/museum)
 "xKz" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -92403,9 +93510,17 @@
 "xKS" = (
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/techshop)
+"xKV" = (
+/obj/structure/vampdoor/wood,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/access/federal,
+/obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/police/fed)
 "xKZ" = (
-/obj/structure/chair/office,
-/turf/open/floor/carpet,
+/obj/structure/chair/office/darkpack/black,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
 "xLe" = (
 /obj/structure/rack/clothing_hanger,
@@ -92415,7 +93530,7 @@
 /obj/structure/chair/sofa/middle/brown{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "xLh" = (
 /obj/machinery/light/directional/east,
@@ -92453,8 +93568,12 @@
 /area/vtm/interior/library)
 "xLD" = (
 /obj/structure/bed/maint,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
+"xLF" = (
+/obj/structure/chair/wood/darkpack/red,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior/library)
 "xLK" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/rich,
@@ -92485,7 +93604,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
 "xLQ" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/city/church,
@@ -92533,7 +93652,7 @@
 /area/vtm/outside/fishermanswharf/ghetto)
 "xMo" = (
 /obj/vampire_computer,
-/obj/vampire_computer,
+/obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
 "xMs" = (
@@ -92582,8 +93701,13 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "xNa" = (
-/turf/closed/wall/vampwall/rich/old,
-/area/vtm/interior/trujah)
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/blood/b_plus,
+/obj/item/reagent_containers/blood/b_plus,
+/obj/item/reagent_containers/blood/a_plus,
+/obj/item/reagent_containers/blood/a_plus,
+/turf/open/floor/plating/concrete,
+/area/vtm/interior/museum)
 "xNb" = (
 /obj/structure/railing{
 	dir = 4
@@ -92610,11 +93734,16 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/community)
 "xNo" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
+"xNq" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/bush/sunny/style_random,
+/turf/open/misc/grass,
+/area/vtm/interior/museum)
 "xNv" = (
 /obj/effect/decal/cleanable/litter,
 /obj/effect/turf_decal/weather/dirt,
@@ -92643,12 +93772,12 @@
 	pixel_y = 8
 	},
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "xNY" = (
-/obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
-/turf/open/floor/carpet,
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "xOn" = (
 /obj/effect/decal/pallet,
@@ -92665,7 +93794,7 @@
 /area/vtm/interior/banu/haven)
 "xOE" = (
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/tzimisce_manor)
 "xOG" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -92680,7 +93809,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer)
 "xOZ" = (
-/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "xPu" = (
@@ -92740,11 +93869,17 @@
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
 "xQu" = (
-/obj/structure/chair{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
+"xQM" = (
+/obj/structure/curtain/bounty{
+	pixel_y = 8
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/strip)
 "xQS" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 8
@@ -92756,7 +93891,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
 "xQU" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth,
@@ -92777,7 +93912,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
 "xRt" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/trash,
@@ -92810,6 +93945,10 @@
 /obj/structure/platform/lowwall/rich/old,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
+"xRO" = (
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/vtm/interior/strip)
 "xRX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -92916,10 +94055,6 @@
 /obj/item/toy/cattoy,
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/smoke_shop)
-"xTp" = (
-/obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/hotel)
 "xTr" = (
 /obj/machinery/photocopier/prebuilt,
 /obj/effect/decal/wallpaper/papers/random{
@@ -92962,7 +94097,7 @@
 	pixel_x = 2;
 	pixel_y = 7
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
 "xTH" = (
 /obj/effect/decal/cleanable/litter,
@@ -93090,6 +94225,12 @@
 /obj/effect/spawner/random/bedsheet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
+"xUQ" = (
+/turf/closed/wall/vampwall/rich/old{
+	density = 0;
+	color = "#BBBBBB"
+	},
+/area/vtm/interior/museum)
 "xUV" = (
 /obj/structure/railing{
 	dir = 1;
@@ -93112,7 +94253,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
 "xVc" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/city/church,
@@ -93166,7 +94307,7 @@
 /area/vtm/interior/cog/caern)
 "xWd" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/laundromat)
 "xWg" = (
 /obj/item/stack/dollar/rand,
@@ -93253,7 +94394,7 @@
 /obj/structure/table/wood/fancy/black,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "xXl" = (
 /obj/machinery/light/small/directional/east,
@@ -93263,7 +94404,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "xXm" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
@@ -93314,7 +94455,7 @@
 /area/vtm/interior/anarch/basement)
 "xXP" = (
 /obj/effect/decal/shadow,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior)
 "xXV" = (
@@ -93489,13 +94630,9 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
 "ybt" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/concrete,
-/area/vtm/interior/trujah)
+/area/vtm/interior/museum)
 "ybA" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/darkpack/old,
@@ -93616,6 +94753,15 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/clothing_store)
+"ydi" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/grey/corner{
+	dir = 8
+	},
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/strip)
 "ydo" = (
 /obj/structure/vampfence/corner/rich,
 /turf/open/misc/grass,
@@ -93641,7 +94787,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "ydC" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 4
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -93679,10 +94825,10 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower)
 "ydM" = (
-/obj/structure/chair/wood{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/techshop)
 "ydO" = (
 /obj/structure/chair/sofa/corp/left,
@@ -93796,7 +94942,7 @@
 /obj/structure/coclock,
 /obj/item/detective_scanner,
 /obj/item/detective_scanner,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
 "yfh" = (
 /obj/structure/table,
@@ -93956,12 +95102,6 @@
 "yhp" = (
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower)
-"yhq" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/strip)
 "yhs" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table,
@@ -93971,9 +95111,9 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
 "yhu" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/darkpack/red,
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "yhv" = (
 /obj/structure/chair/old/tzimisce,
@@ -93988,10 +95128,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
 "yhR" = (
-/obj/structure/chair/wood/wings{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "yic" = (
 /obj/machinery/washing_machine,
@@ -94081,7 +95221,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
 "yiR" = (
-/obj/structure/chair/office{
+/obj/structure/chair/office/darkpack/black{
 	dir = 1
 	},
 /mob/living/carbon/human/npc/shop,
@@ -94255,7 +95395,7 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
 "ylc" = (
-/obj/structure/chair,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
 "yle" = (
@@ -94321,7 +95461,7 @@
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/nine,
 /obj/effect/mapping_helpers/door/bash_difficulty/nine,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "yme" = (
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -106035,9 +107175,9 @@ xqR
 waf
 wTq
 dvN
-pQp
-biH
-heN
+lzL
+eUU
+dht
 pzf
 tBk
 tBk
@@ -106292,9 +107432,9 @@ xqR
 waf
 wTq
 dvN
-pQp
-wLm
-heN
+lzL
+jyr
+dht
 pzf
 hLn
 hLn
@@ -106549,10 +107689,10 @@ xqR
 waf
 wTq
 dvN
-pQp
-heN
-heN
-pJn
+lzL
+dht
+dht
+pYq
 dht
 prD
 lzL
@@ -106587,7 +107727,7 @@ dvN
 dvN
 eQD
 bMM
-ueO
+tYg
 eQD
 xJh
 iAm
@@ -106844,7 +107984,7 @@ dvN
 dvN
 iHg
 mGM
-ueO
+tYg
 cCG
 tsW
 xgh
@@ -107618,7 +108758,7 @@ eKl
 uQS
 eQD
 mzA
-ueO
+tYg
 tsW
 cCG
 gSZ
@@ -108091,9 +109231,9 @@ xqR
 waf
 wTq
 dvN
-pzf
-dht
-dht
+lzL
+lzL
+lzL
 lzL
 lzL
 lzL
@@ -108132,7 +109272,7 @@ eQD
 lZI
 jHa
 whf
-ueO
+tYg
 xgh
 eQD
 xRX
@@ -108348,10 +109488,10 @@ xqR
 waf
 wTq
 dvN
-pzf
-jyr
-dht
-lzL
+dvN
+dvN
+dvN
+dvN
 dvN
 dvN
 lzL
@@ -108386,7 +109526,7 @@ dvN
 dvN
 eQD
 bMM
-ueO
+tYg
 eQD
 mXD
 xUX
@@ -108605,10 +109745,10 @@ xqR
 waf
 wTq
 dvN
-pzf
-dht
-dht
-lzL
+dvN
+dvN
+dvN
+dvN
 dvN
 dvN
 lzL
@@ -108862,10 +110002,10 @@ xqR
 waf
 wTq
 dvN
-pzf
-jyW
-jyW
-lzL
+dvN
+dvN
+dvN
+dvN
 dvN
 dvN
 lzL
@@ -108900,7 +110040,7 @@ dvN
 dvN
 eQD
 vKW
-ueO
+tYg
 eQD
 sCy
 vft
@@ -109119,12 +110259,12 @@ xqR
 waf
 wTq
 dvN
-lzL
-lzL
-lzL
-lzL
-vhv
-vhv
+dvN
+dvN
+dvN
+dvN
+dvN
+dvN
 lzL
 lzL
 lzL
@@ -109541,7 +110681,7 @@ rrB
 icG
 jVA
 eir
-jqn
+gle
 eir
 wJn
 sLN
@@ -110310,7 +111450,7 @@ lEs
 dth
 rrB
 icG
-jqn
+gle
 eir
 eir
 bCv
@@ -145078,7 +146218,7 @@ dvN
 dvN
 dvN
 dvN
-qoU
+dvN
 qoU
 qoU
 qip
@@ -145335,10 +146475,10 @@ dvN
 dvN
 dvN
 dvN
+dvN
 qoU
-oKF
-rxS
-aOK
+hHn
+hHn
 imN
 qoU
 dvN
@@ -145592,10 +146732,10 @@ dvN
 dvN
 dvN
 dvN
+dvN
 qoU
-uhU
-aOK
-aOK
+saP
+hHn
 aOK
 qoU
 dvN
@@ -145849,11 +146989,11 @@ dvN
 dvN
 dvN
 dvN
+dvN
 qoU
-lWx
+lqu
+rFA
 aOK
-aOK
-rKp
 qoU
 dvN
 dvN
@@ -146106,10 +147246,10 @@ dvN
 dvN
 dvN
 dvN
+dvN
 qoU
-oKF
-rxS
-aOK
+imN
+hNQ
 hHn
 qoU
 dvN
@@ -146363,11 +147503,11 @@ dvN
 dvN
 dvN
 dvN
+dvN
 qoU
-qoU
-qoU
-cOj
-qoU
+hHn
+aOK
+uCw
 qoU
 dvN
 dvN
@@ -146616,15 +147756,15 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-wNo
-stj
-kpP
-rhY
-rLV
+qoU
+qoU
+qoU
+qoU
+qoU
+qoU
+aOK
+hNQ
+imN
 qoU
 dvN
 dvN
@@ -146872,16 +148012,16 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
 qoU
-wNo
-fVy
+qoU
+dTq
+geM
+dTq
+qoU
+qoU
 hyJ
-rhY
-vlR
+imN
+hHn
 qoU
 dvN
 dvN
@@ -147129,16 +148269,16 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-wNo
+qoU
+vUK
+cMn
+iqJ
+oic
 dTq
 sJE
-rhY
-rhY
-pvz
+hHn
+hHn
+hHn
 qoU
 dvN
 dvN
@@ -147386,16 +148526,16 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-wNo
-rOB
-sJE
+qoU
+emP
+iqJ
+gSc
+cMn
+dTq
+qoU
 rhY
-pDp
-dPn
+qoU
+qoU
 qoU
 dvN
 dvN
@@ -147643,15 +148783,15 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-wNo
-eCD
-dkE
-hFE
-pDp
+qoU
+cMn
+wOZ
+cMn
+oic
+dTq
+qoU
+qoU
+qoU
 rpF
 qoU
 dvN
@@ -147895,21 +149035,21 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+ont
+ont
+ont
+ont
+ont
+ont
+auT
+ont
 qoU
 qoU
 qoU
 qoU
-qoU
-qoU
+avA
+eHF
+uiz
 qoU
 dvN
 dvN
@@ -148150,25 +149290,25 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+ont
+ont
+ont
+wRP
+wRP
+tFt
+knf
+nYq
+cMn
+oic
+qoU
+ter
+eHF
+qoU
+tjq
+sMW
+eHF
+qoU
+qoU
 dvN
 dvN
 dvN
@@ -148407,25 +149547,25 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+tFt
+fOQ
+cMn
+cMn
+cMn
+nYq
+cMn
+cMn
+cMn
+jUz
+qoU
+vXI
+fzH
+qoU
+rAs
+eHF
+eHF
+dWc
+qoU
 dvN
 dvN
 dvN
@@ -148664,25 +149804,25 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+tFt
+hbM
+nYq
+cMn
+jPv
+cMn
+cMn
+fjS
+cMn
+oic
+oic
+iRu
+fzH
+xKV
+fzH
+qvC
+eHF
+jYX
+qoU
 dvN
 dvN
 dvN
@@ -148921,25 +150061,25 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+ont
+ont
+hYI
+cMn
+tFt
+gnU
+oic
+cMn
+nYq
+cMn
+qoU
+kMQ
+eHF
+qoU
+fyO
+eHF
+gba
+kki
+qoU
 dvN
 dvN
 dvN
@@ -149178,25 +150318,25 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+ont
+tFt
+uqH
+cMn
+tFt
+iRZ
+cMn
+nYq
+oic
+cMn
+qoU
+nNj
+kLF
+qoU
+aUf
+awq
+rrN
+uIb
+qoU
 dvN
 dvN
 dvN
@@ -149435,25 +150575,25 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+ont
+nYq
+cTM
+cMn
+cMn
+cMn
+cMn
+ebl
+tFt
+tFt
+qoU
+qoU
+irU
+qoU
+qoU
+qoU
+qoU
+qoU
+qoU
 dvN
 dvN
 dvN
@@ -149691,21 +150831,21 @@ dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+ont
+ont
+ont
+tFt
+oic
+oic
+dpo
+ont
+ont
+ont
+lUC
+wWr
+twl
+hHn
+qoU
 dvN
 dvN
 dvN
@@ -149948,21 +151088,21 @@ dvN
 dvN
 dvN
 dvN
+ont
+ofw
+oic
+vqE
+oic
+ktA
+ont
+ont
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+ont
+faw
+hHn
+oGC
+nYq
+qoU
 dvN
 dvN
 dvN
@@ -150205,21 +151345,21 @@ dvN
 dvN
 dvN
 dvN
+ont
+kIQ
+cMn
+sfp
+cTM
+ont
+ont
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+qoU
+qoU
+gJx
+wUW
+qoU
+qoU
 dvN
 dvN
 dvN
@@ -150462,20 +151602,20 @@ dvN
 dvN
 dvN
 dvN
+ont
+ont
+ont
+ont
+ont
+ont
 dvN
 dvN
 dvN
 dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
-dvN
+qoU
+qoU
+qoU
+qoU
 dvN
 dvN
 dvN
@@ -162293,9 +163433,9 @@ lVM
 lVM
 lVM
 lVM
-ueO
-ueO
-ueO
+tYg
+tYg
+tYg
 taU
 mEs
 vDv
@@ -162550,8 +163690,8 @@ lVM
 lVM
 lVM
 jUi
-ueO
-ueO
+tYg
+tYg
 cUX
 oOD
 oOD
@@ -162807,8 +163947,8 @@ ldd
 lVM
 lVM
 lVM
-ueO
-ueO
+tYg
+tYg
 kpE
 hRI
 lVM
@@ -163886,9 +165026,9 @@ vWl
 iHq
 iHq
 pEO
-ueO
-ueO
-ueO
+tYg
+tYg
+tYg
 nqT
 iHq
 iHq
@@ -164088,10 +165228,10 @@ uAr
 aUi
 gye
 vVw
-ueO
-ueO
-ueO
-ueO
+tYg
+tYg
+tYg
+tYg
 oOD
 efr
 yjQ
@@ -164143,8 +165283,8 @@ iHq
 iHq
 ihN
 cMC
-ueO
-ueO
+tYg
+tYg
 kpE
 mzA
 iHq
@@ -164156,7 +165296,7 @@ qwL
 mzA
 mzA
 tzL
-ueO
+tYg
 vui
 vYV
 uQS
@@ -164345,10 +165485,10 @@ aUi
 nNo
 xjt
 bsf
-ueO
-ueO
-ueO
-ueO
+tYg
+tYg
+tYg
+tYg
 oOD
 wmm
 dKk
@@ -164413,7 +165553,7 @@ mzA
 lnX
 qwL
 tzL
-ueO
+tYg
 vui
 uQS
 lFi
@@ -164602,7 +165742,7 @@ ixM
 aUi
 xjt
 hRI
-ueO
+tYg
 vCE
 vCE
 kyu
@@ -164666,11 +165806,11 @@ iHq
 xEP
 iHq
 vBh
-ueO
+tYg
 uub
 uub
 kCh
-ueO
+tYg
 vui
 uQS
 sTS
@@ -164859,7 +165999,7 @@ xeV
 aUi
 xjt
 lVM
-ueO
+tYg
 mzA
 qwL
 mzA
@@ -165116,7 +166256,7 @@ aUi
 aUi
 gye
 bgv
-ueO
+tYg
 mzA
 mzA
 pBU
@@ -165373,10 +166513,10 @@ aUi
 ixM
 gye
 lVM
-ueO
+tYg
 uub
 uub
-ueO
+tYg
 oOD
 wmm
 dKk
@@ -165630,10 +166770,10 @@ ixM
 xeV
 xjt
 lVM
-ueO
-ueO
-ueO
-ueO
+tYg
+tYg
+tYg
+tYg
 oOD
 wmm
 dKk
@@ -167658,20 +168798,20 @@ qIX
 qIX
 qIX
 qIX
-qIX
-qIX
-qIX
-qIX
-aUi
-iEV
-ixM
-qIX
-qIX
-qIX
-qIX
-gVA
-qIX
-nNo
+daK
+ozP
+daK
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
 ixM
 uAr
 nNo
@@ -167915,20 +169055,20 @@ gQo
 gQo
 gQo
 gQo
-daK
-ozP
-daK
-ozP
-daK
-ozP
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
+dar
+dar
+dar
+dar
+xNq
+ixr
+dar
+byX
+fFa
+fFa
+fFa
+fFa
+fFa
+dar
 obM
 oWV
 qDM
@@ -168172,20 +169312,20 @@ gQo
 gQo
 gQo
 daK
-daK
-ozP
-daK
-ozP
-ozP
-ozP
-aoa
-noj
-hOP
-ovR
+fsH
+sOJ
+fFa
+dar
+fFE
+fFE
+dar
+byX
+fFa
+fFa
 byX
 bzp
 bzp
-nGZ
+dar
 obM
 oWV
 ptA
@@ -168429,20 +169569,20 @@ gQo
 gQo
 daK
 daK
-daK
-daK
-daK
-ozP
-ozP
-daK
-aoa
+fsH
+ujz
+fFa
+fFa
+fFa
+fFa
+fFa
 wEO
-wod
-cQR
-bzp
-bpj
-bzp
-nGZ
+fFa
+fFa
+dar
+dar
+dar
+dar
 obM
 oWV
 ptA
@@ -168686,20 +169826,20 @@ gQo
 daY
 daY
 ozP
+bXn
+dbT
+fFa
+vxO
+dKg
+fFa
+fFa
+byX
 nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
-nGZ
+fFa
+fFa
+fFa
 iAk
-nGZ
+dar
 obM
 oWV
 ptA
@@ -168943,20 +170083,20 @@ daK
 daK
 daY
 daK
-nGZ
+mKT
 lHX
+fFa
+vxO
 bRd
-lHX
-bRd
-lHX
-ovR
-xHV
+fFa
+fFa
+dar
+byX
+ntE
+kdb
+cpu
 esa
-esa
-esa
-esa
-esa
-nGZ
+dar
 obM
 oWV
 ptA
@@ -169200,20 +170340,20 @@ daK
 daK
 ozP
 daK
-nGZ
+mKT
 vpr
-bzp
-bzp
-bzp
-bzp
+bsd
+fFa
+fFa
+fFa
 ovR
 nby
-esa
-mzr
-mzr
-esa
-esa
-nGZ
+byX
+sRD
+sRD
+sRD
+dar
+dar
 obM
 oWV
 ptA
@@ -169457,20 +170597,20 @@ daK
 ozP
 daK
 daK
-dvL
+mKT
 bmu
-bzp
-bzp
-bzp
-bzp
-nGZ
-ptM
+fFa
+xfC
+wHB
+fFa
+fFa
+fFa
 nGZ
 oVy
 aQs
+bzF
 nGZ
-nGZ
-nGZ
+dar
 obM
 oWV
 qDM
@@ -169714,20 +170854,20 @@ daK
 ozP
 daK
 ozP
-dvL
+bXn
 pze
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-iGL
-bzp
-bzp
-iGL
+fFa
+xfC
+vDP
+fFa
+fFa
+fFa
+fFa
+oVy
+aQs
+bzF
 kDz
-nGZ
+dar
 obM
 oWV
 ePK
@@ -169972,19 +171112,19 @@ ozP
 daK
 daK
 dvL
-pze
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-nGZ
+khg
+fFa
+fFa
+fFa
+fFa
+fFa
+fFa
+fFa
+oVy
+sTR
+bzF
+kDz
+dar
 obM
 oWV
 qhO
@@ -170228,20 +171368,20 @@ daK
 daK
 daK
 daK
-nGZ
+dvL
 kog
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
+fFa
+dar
+fFE
+fFE
+byX
+bAW
+tBQ
+xiB
+pDM
+ggx
 nGZ
+dar
 obM
 oWV
 qhO
@@ -170485,20 +171625,20 @@ pfQ
 pfQ
 eav
 pfQ
-nGZ
-lHX
-mFB
-lHX
+dar
+dar
+dar
+dar
 piZ
 bMn
-vpr
-jLV
-vpr
-frP
-bzp
-bzp
-kDz
-nGZ
+dar
+dar
+jDF
+vkz
+jDF
+vkz
+jDF
+dar
 obM
 oWV
 ePK
@@ -170742,21 +171882,21 @@ daK
 daK
 daK
 ozP
-nGZ
-nGZ
-nGZ
-dvL
-dvL
-nGZ
-nGZ
-nGZ
-nGZ
-ufG
-ufG
-dvL
-dvL
-nGZ
-obM
+daK
+daK
+daK
+dar
+fFE
+fFE
+dar
+kOn
+cNc
+cNc
+cNc
+cNc
+cNc
+cNc
+fnj
 oWV
 qhO
 vUE
@@ -171006,14 +172146,14 @@ cNc
 tol
 cNc
 cNc
-cNc
-cNc
-cNc
-cNc
-cNc
-cNc
-rPN
 fnj
+oWV
+oWV
+oWV
+oWV
+oWV
+gSI
+oWV
 oWV
 qhO
 bZK
@@ -171315,14 +172455,14 @@ eAi
 bbB
 ddd
 sPq
-xkR
-uIt
-kMU
-kPZ
-xkR
-aTm
-uLt
-aTm
+aKX
+aKX
+aKX
+aKX
+aKX
+aKX
+aKX
+aKX
 xkR
 lzL
 hBM
@@ -171572,13 +172712,13 @@ vXR
 heN
 heN
 sPq
-xkR
-wFr
+tgd
 aKX
 aKX
-aKX
-aKX
-aKX
+tip
+tip
+tip
+vAv
 aKX
 fJH
 lzL
@@ -171829,14 +172969,14 @@ qJf
 qJf
 qJf
 sPq
+jrK
 aKX
-aKX
-qSR
-aKX
-dgg
-dXl
-dgg
-dXl
+jNs
+qHV
+qHV
+dvC
+tip
+vAv
 aKX
 hQv
 lJh
@@ -172088,12 +173228,12 @@ iNm
 sum
 mVg
 aKX
-aKX
-aKX
-dXl
-dgg
-dXl
-dgg
+uDa
+qSR
+qSR
+lNy
+bga
+tip
 aKX
 hQv
 lJh
@@ -172345,12 +173485,12 @@ lzL
 lzL
 sPq
 uJI
-aKX
-fJH
-dgg
-dXl
-dgg
-dXl
+iAZ
+qSR
+gyp
+qSR
+bga
+tip
 aKX
 hQv
 lJh
@@ -172602,12 +173742,12 @@ ggu
 sPq
 ouY
 aKX
+uUt
 qSR
-aKX
-dXl
-dgg
-dXl
-dgg
+qSR
+qSR
+bga
+tip
 aKX
 hQv
 lJh
@@ -172859,12 +173999,12 @@ aZx
 lzL
 sPq
 uJI
-aKX
-aKX
-dgg
-dXl
-dgg
-dXl
+aIf
+qSR
+qSR
+lNy
+bga
+tip
 aKX
 hQv
 gMQ
@@ -173116,12 +174256,12 @@ aZx
 qDb
 qDb
 aKX
-aKX
-aKX
-aKX
-aKX
-aKX
-aKX
+tmt
+dFE
+dFE
+kFb
+tip
+vAv
 aKX
 lzL
 rky
@@ -173373,13 +174513,13 @@ iNm
 ven
 ibL
 aKX
-qSR
 aKX
-aKX
-aKX
-aKX
-aKX
-tAG
+tip
+tip
+tip
+vAv
+wpS
+fJH
 lzL
 gMQ
 gQE
@@ -173629,14 +174769,14 @@ iNm
 iNm
 uvw
 myl
+dXl
+dgg
 aKX
 aKX
 aKX
 aKX
-lzL
-hQv
-hQv
-hQv
+aKX
+xkR
 lzL
 fep
 gQE
@@ -173883,17 +175023,17 @@ iPt
 ent
 iNm
 iNm
-lLK
+uEQ
 uvw
-jAh
-mqR
+ibL
+dgg
+dXl
+xRO
 aKX
-fJH
-hQs
-sPq
-cYO
-cYO
-cYO
+aKX
+aKX
+xkR
+xkR
 lzL
 rzn
 gQE
@@ -174143,14 +175283,14 @@ iNm
 iNm
 bxO
 cRG
-icz
-aKX
-aKX
-aKX
-ofl
-cYO
-cYO
-mJw
+dXl
+dgg
+dXl
+hQs
+lzL
+hQv
+hQv
+hQv
 lzL
 lJh
 gQE
@@ -174398,16 +175538,16 @@ sPq
 teE
 iNm
 iNm
-bxO
-cRG
-icz
-aKX
-aKX
+uvw
+eQX
+dgg
+dXl
+dgg
 aKX
 sPq
+gpb
 cYO
-vJY
-rzB
+awv
 lzL
 lJh
 gQE
@@ -174658,13 +175798,13 @@ iNm
 uvw
 myl
 aKX
-wpS
+dgg
+dXl
 aKX
-aKX
-lzL
-rhO
-awv
-hpH
+ofl
+cYO
+cYO
+mJw
 lzL
 rYb
 gQE
@@ -174910,18 +176050,18 @@ lFX
 vdV
 sPq
 voR
+iNm
 qal
-aeI
 wma
 ibL
 aKX
 aKX
 aKX
 aKX
-xbz
-aKX
-aKX
-fLh
+sPq
+vAv
+hkZ
+rzB
 lzL
 lJh
 gQE
@@ -175167,6 +176307,7 @@ msq
 msq
 sPq
 wlT
+iNm
 aZx
 ajL
 ajL
@@ -175174,11 +176315,10 @@ aKX
 aKX
 aKX
 aKX
-aKX
+sPq
 aTm
-aTm
-aKX
-hQs
+fHM
+hpH
 lzL
 lJh
 gQE
@@ -175424,18 +176564,18 @@ msq
 msq
 sPq
 enU
+iNm
 aZx
-vtK
-vtK
+lzL
+lzL
+sPq
 aKX
 aKX
 aKX
-skd
-wwX
-qHV
-dvC
-aTm
-aKX
+xbz
+vAv
+vAv
+ver
 lzL
 sBG
 gQE
@@ -175681,17 +176821,17 @@ msq
 ckQ
 sPq
 wYe
+iNm
 aZx
-qDb
-qDb
+sPq
 mqR
+uzq
+ibL
 aKX
 aKX
-eiP
-qSR
-qSR
-bga
-aTm
+dXl
+dgg
+aKX
 aKX
 lzL
 lJh
@@ -175938,17 +177078,17 @@ agH
 cCP
 sPq
 teE
-wYm
-ayE
-yhq
+iNm
+aZx
+sPq
 mwz
+ydi
+uzq
 ibL
-aKX
-vIV
-qSR
-gyp
-bga
-aTm
+dXl
+dgg
+dXl
+dgg
 aKX
 gpa
 inY
@@ -176196,18 +177336,18 @@ cCP
 sPq
 reZ
 pUs
-iNm
-iPt
+aZx
+waT
 mSF
+sWj
+wvG
 myl
+dgg
+pei
+dgg
+dXl
 aKX
-rSf
-qSR
-qSR
-bga
-lKj
-aKX
-gpa
+lzL
 lJh
 gQE
 dJL
@@ -176454,17 +177594,17 @@ sPq
 eQE
 iNm
 iPi
-kkd
+sPq
 uAx
+hkF
+kIU
 ibL
+dXl
+dgg
+dXl
+dgg
 aKX
-tmt
-dFE
-dFE
-kFb
-aTm
-aKX
-lzL
+gpa
 lJh
 gQE
 dJL
@@ -176713,14 +177853,14 @@ iNm
 aZx
 sPq
 djg
+kIU
+ibL
 aKX
 aKX
-lKj
-aTm
-aTm
-aTm
-eOk
-vml
+dXl
+dgg
+aKX
+hQs
 lzL
 lJh
 tPi
@@ -176904,8 +178044,8 @@ oRi
 jAr
 wsX
 nEU
-bGN
-bGN
+vQy
+vQy
 mNA
 fkk
 nXI
@@ -176968,11 +178108,11 @@ ent
 iNm
 iNm
 aZx
+lzL
+lzL
 sPq
-ffb
+vZg
 cyA
-aKX
-aKX
 aKX
 aKX
 aKX
@@ -177161,7 +178301,7 @@ cTf
 fdj
 yhu
 jFZ
-bGN
+vQy
 qLB
 pKp
 fkk
@@ -177225,14 +178365,14 @@ sPq
 iaS
 oII
 aiL
+lzL
+lzL
 sPq
-lSe
-bpz
 prx
+dyq
 xkR
-tkf
+dlN
 xkR
-pMv
 bpz
 vEH
 lzL
@@ -177417,7 +178557,7 @@ rza
 nzB
 pMC
 nEU
-bGN
+vQy
 qLB
 qLB
 opP
@@ -177674,10 +178814,10 @@ wsX
 iZB
 pMC
 nEU
-bGN
+vQy
 qLB
 qLB
-bGN
+vQy
 fkk
 rXs
 msq
@@ -177919,7 +179059,7 @@ kGg
 xnx
 rvo
 bnD
-tKo
+pho
 kGg
 nts
 wsX
@@ -177931,7 +179071,7 @@ hRf
 iZB
 pMC
 iui
-bGN
+vQy
 ark
 qLB
 bcq
@@ -178176,7 +179316,7 @@ kGg
 dLq
 rvo
 tbF
-pho
+tKo
 kGg
 ofk
 wsX
@@ -178702,10 +179842,10 @@ wsX
 qjS
 pMC
 iui
-bGN
+vQy
 qLB
 qLB
-bGN
+vQy
 fkk
 fuT
 msq
@@ -178959,7 +180099,7 @@ vRT
 iFM
 pMC
 nEU
-pDs
+xhT
 qLB
 qLB
 jbv
@@ -179210,14 +180350,14 @@ jmc
 wsX
 iZB
 oeX
-vmN
+hvx
 pMC
 pMC
 pMC
 pMC
 yhu
 jFZ
-bGN
+vQy
 qLB
 pKp
 fkk
@@ -179472,10 +180612,10 @@ xCP
 pMC
 oTi
 tmK
-kfO
+wsX
 nEU
-bGN
-bGN
+vQy
+vQy
 mNA
 fkk
 vdV
@@ -179724,7 +180864,7 @@ pMC
 pMC
 pMC
 oeX
-vmN
+hvx
 pMC
 pMC
 pMC
@@ -180240,8 +181380,8 @@ bLe
 pMC
 pMC
 twK
-pek
-pek
+hvx
+hvx
 pMC
 fkk
 fkk
@@ -180493,7 +181633,7 @@ fkk
 kGg
 pMC
 kWp
-pek
+hvx
 pMC
 pMC
 pMC
@@ -189998,8 +191138,8 @@ mCP
 mCP
 mCP
 mCP
-jws
-obW
+kgk
+pre
 bUt
 oIb
 fQP
@@ -195932,7 +197072,7 @@ ewI
 ewI
 oVa
 hDq
-kyt
+fnX
 ajJ
 bCk
 bCk
@@ -202863,23 +204003,23 @@ lFi
 xna
 iog
 oKY
-dar
-dar
-dar
-dar
-dar
-dar
+ufX
+fFE
+fFE
+ufX
+ufX
+ufX
 wpM
-dar
-dar
+ufX
+ufX
 wpM
-dar
-dar
-dar
-dar
-dar
-dar
-dar
+ufX
+ufX
+ufX
+fFE
+fFE
+ufX
+ufX
 hiy
 hiy
 hiy
@@ -203119,24 +204259,24 @@ iHq
 lFi
 xna
 iog
-dar
-gKn
+ufX
+iSt
 jGR
 jGR
 raM
-qRf
-dar
+wOd
+ufX
 fFa
 fFa
 sxH
 fFa
-dar
+ufX
 raO
 qRf
 ncV
-ctx
 bUX
-dar
+bUX
+fFE
 tru
 hiy
 qxU
@@ -203376,9 +204516,9 @@ kGa
 lFi
 iog
 iog
-dar
-mhX
-sZe
+ufX
+sXv
+jGR
 jGR
 qRf
 qRf
@@ -203390,10 +204530,10 @@ fFa
 bbG
 qRf
 qRf
-qRf
-qRf
-xii
-dar
+mZy
+ijU
+xKy
+fFE
 hiy
 hiy
 jHi
@@ -203633,9 +204773,9 @@ lFi
 lFi
 iog
 iog
-dar
-jGR
-jGR
+ufX
+hoC
+ghZ
 jGR
 qRf
 qRf
@@ -203648,9 +204788,9 @@ bbG
 qRf
 qRf
 tXp
-qRf
 qhA
-dar
+qhA
+fFE
 hiy
 hiy
 xtG
@@ -203890,24 +205030,24 @@ iog
 lPc
 iog
 iog
-dar
-saw
+ufX
+vNU
+omk
+ten
 qRf
-qRf
-qRf
-wOd
-dar
+cnl
+ufX
 cWn
 cWn
 cWn
 ibo
-dar
+ufX
 dzV
+uSm
 qRf
 qRf
 qRf
-qhA
-dar
+ufX
 vCD
 hiy
 xtG
@@ -204147,24 +205287,24 @@ iog
 iog
 iog
 iog
-dar
+ufX
 qGY
+mJe
 qRf
-ieV
 qRf
-tXp
-dar
+ewD
+ufX
 uQz
 sID
 jGR
 qRf
-dar
+ufX
+ekv
+aOI
 qRf
-qRf
-tXp
-qRf
+vwF
 nSY
-dar
+ufX
 hiy
 hiy
 xtG
@@ -204193,9 +205333,9 @@ euk
 hoA
 hoA
 hoA
-spk
+dic
 hoA
-hoA
+oPO
 qRY
 jHi
 dBF
@@ -204404,24 +205544,24 @@ iog
 iog
 iog
 iog
-dar
-qGY
+ufX
+vNU
+fYX
+ten
 qRf
-qRf
-qRf
-tXp
-dar
+ewD
+ufX
 bvB
 jGR
 jGR
 qRf
-dar
+ufX
+qUp
+uSm
 qRf
-qRf
-qRf
-qRf
-qhA
-dar
+pse
+bUX
+fFE
 hiy
 hiy
 xtG
@@ -204447,13 +205587,13 @@ hoA
 hoA
 vRv
 xtG
-spk
+ryA
+oPO
 hoA
+cuA
 hoA
-spk
-hoA
-hoA
-spk
+nPg
+ryA
 jHi
 rsh
 tEw
@@ -204661,24 +205801,24 @@ qTP
 qTP
 qTP
 iog
-dar
-mJe
+ufX
+vNU
+fYX
+ten
 qRf
+cNK
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+mhX
+jGR
 qRf
-qRf
-wOd
-dar
-dar
-dar
-dar
-dar
-dar
-qRf
-qRf
-tXp
-qRf
-qhA
-dar
+pse
+bUX
+fFE
 hiy
 hiy
 xtG
@@ -204705,9 +205845,9 @@ hoA
 wVf
 xtG
 vXP
+nPg
 hoA
-hoA
-spk
+vfR
 hoA
 hoA
 bkw
@@ -204918,9 +206058,9 @@ eGv
 byP
 qTP
 iog
-dar
-jcs
-qRf
+ufX
+qGY
+mJe
 qRf
 qRf
 qRf
@@ -204933,9 +206073,9 @@ jGR
 qRf
 qRf
 qRf
-qRf
-nSY
-dar
+lxt
+hfK
+ufX
 hiy
 hiy
 xtG
@@ -204966,8 +206106,8 @@ hoA
 hoA
 hoA
 hoA
-hoA
-spk
+oPO
+ryA
 jHi
 kvF
 tEw
@@ -205175,10 +206315,10 @@ uke
 kUH
 qTP
 mHu
-dar
-lHu
-qRf
-qRf
+ufX
+vNU
+pJZ
+ten
 qRf
 qRf
 jGR
@@ -205189,10 +206329,10 @@ jGR
 jGR
 qRf
 qRf
-tXp
 qRf
-qhA
-dar
+qRf
+qRf
+ufX
 hiy
 hiy
 xtG
@@ -205218,12 +206358,12 @@ hoA
 hoA
 qVy
 xtG
-hoA
+sMy
 hoA
 rjX
+mAA
 hoA
-hoA
-hoA
+nPg
 qRY
 jHi
 tEw
@@ -205432,24 +206572,24 @@ uZV
 dRn
 qTP
 jhC
-dar
-jGR
-jGR
+ufX
+dNd
+mdN
 jGR
 qRf
 qRf
 cnl
-dar
+ufX
 liC
 liC
-dar
+ufX
 ssm
 qRf
 qRf
-qRf
-qRf
+aZZ
 knj
-dar
+knj
+fFE
 hiy
 hiy
 xtG
@@ -205477,7 +206617,7 @@ uEr
 xtG
 pxB
 abB
-lbB
+wzw
 wzw
 hoA
 hoA
@@ -205689,24 +206829,24 @@ uZV
 uZV
 qTP
 hFy
-dar
-mhX
-uXX
+ufX
+fLp
+jGR
 jGR
 qRf
 qRf
-xii
-dar
-dar
-dar
-dar
+ewD
+ufX
+ufX
+ufX
+ufX
 qFg
 qRf
 qRf
-tXp
-qRf
-xii
-dar
+oer
+jMG
+xKy
+fFE
 hiy
 wxn
 xtG
@@ -205732,13 +206872,13 @@ hoA
 maD
 juk
 xtG
-lOj
-lOj
+sMy
+agp
 chz
 jYn
-lJY
 hoA
-spk
+oPO
+ryA
 jHi
 tEw
 tEw
@@ -205946,24 +207086,24 @@ uZV
 jkY
 qTP
 lHG
-dar
-gKn
+ufX
+eYc
 jGR
 geN
-iFf
+wOd
 owv
-dAi
-dar
-qRf
-qRf
-dar
+ewD
+ufX
+ufX
+ufX
+ufX
 itp
 qRf
 qRf
-qRf
-qRf
+mZy
 bUX
-dar
+bUX
+fFE
 wxn
 kvw
 xtG
@@ -205989,12 +207129,12 @@ hoA
 hoA
 juk
 xtG
-qgk
-lOj
+sMy
+bdr
 tGp
 otl
 hoA
-hoA
+nPg
 qRY
 jHi
 jlC
@@ -206203,24 +207343,24 @@ wrw
 qTP
 qTP
 lHG
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
 hiy
 hiy
 jHi
@@ -206247,8 +207387,8 @@ mmE
 jHi
 xtG
 wyg
-lOj
-lOj
+kFU
+vey
 wzw
 hoA
 hoA
@@ -206481,10 +207621,10 @@ piU
 hiy
 hiy
 rAN
-jdP
-aAG
 gSx
-bCe
+rAN
+gSx
+jHi
 xtG
 nan
 wYK
@@ -206503,9 +207643,9 @@ epA
 hoA
 hoA
 xtG
-kHg
-lOj
-lOj
+nan
+jIc
+jHi
 jHi
 jHi
 jHi
@@ -206760,9 +207900,9 @@ hoA
 hoA
 hoA
 qgR
-lOj
-lOj
-lOj
+hoA
+nPg
+pvE
 jHi
 vNb
 sxJ
@@ -206994,11 +208134,11 @@ pAo
 pAo
 pAo
 pAo
-rAN
-ofV
+jHi
+jHi
+gZD
 bCe
-bCe
-bCe
+jHi
 xtG
 pxB
 wYK
@@ -207018,8 +208158,8 @@ lOj
 sxi
 xtG
 asA
-gNV
-jFH
+xYr
+hoA
 jHi
 sxJ
 vNb
@@ -207543,7 +208683,7 @@ wuj
 jWz
 wEg
 dwi
-kRy
+nsO
 kjv
 roM
 kVA
@@ -207766,10 +208906,10 @@ mwS
 vbd
 jlv
 rAN
-qVc
-urm
-qVc
+ohu
 bCe
+qVc
+mDI
 xtG
 vOh
 vOh
@@ -207800,7 +208940,7 @@ wuj
 tsm
 wEg
 dwi
-kRy
+nsO
 dsP
 roM
 dOl
@@ -208057,7 +209197,7 @@ pKL
 ewW
 kYb
 dwi
-kRy
+nsO
 gWj
 uEd
 cta
@@ -208314,7 +209454,7 @@ dwi
 dwi
 dwi
 dwi
-kRy
+nsO
 dWb
 dwi
 dwi
@@ -208571,7 +209711,7 @@ dwi
 dwi
 dwi
 ibv
-kRy
+nsO
 roj
 dwi
 dwi
@@ -209073,7 +210213,7 @@ eHs
 rsh
 tEw
 tEw
-mvo
+kRy
 dwi
 dwi
 wjp
@@ -209330,7 +210470,7 @@ rsh
 tEw
 kvF
 eHs
-mvo
+kRy
 tso
 riJ
 ruM
@@ -209587,7 +210727,7 @@ tEw
 eHs
 tEw
 rsh
-mvo
+kRy
 ibG
 ljt
 mux
@@ -209844,7 +210984,7 @@ xwu
 xwu
 xwu
 xwu
-mvo
+kRy
 dst
 npj
 kZm
@@ -210101,12 +211241,12 @@ fkd
 fkd
 fkd
 fkd
-mvo
+kRy
 roj
 xOG
 dwi
 dwi
-bRZ
+vkW
 cxT
 qlm
 pjf
@@ -210615,7 +211755,7 @@ bmV
 afe
 acR
 fkd
-kRy
+kex
 dwi
 dwi
 wjp
@@ -210872,7 +212012,7 @@ flA
 afe
 fkd
 fkd
-kRy
+kex
 fPt
 fVs
 kPd
@@ -211129,7 +212269,7 @@ flA
 afe
 fkd
 fkd
-kRy
+kex
 not
 sjY
 nvL
@@ -211386,7 +212526,7 @@ afe
 afe
 fkd
 fkd
-kRy
+kex
 vbN
 dZa
 tAe
@@ -211643,12 +212783,12 @@ gZe
 afe
 fkd
 fkd
-kRy
+kex
 roj
 xOG
 lcG
 dwi
-bRZ
+vkW
 cxT
 xRI
 taP
@@ -213187,7 +214327,7 @@ fRk
 fkd
 gEg
 gmZ
-uzk
+eHF
 cbn
 hJH
 miN
@@ -213445,7 +214585,7 @@ fkd
 qoU
 qoU
 qoU
-qoU
+uzk
 qoU
 qoU
 qoU
@@ -213701,18 +214841,18 @@ fkd
 fkd
 iBB
 tEw
-rsh
-tEw
-tEw
+qoU
+qoU
+qoU
 tEw
 mvo
-bOt
+kjv
 dwi
 dwi
 dwi
 ibv
-kRy
-bOt
+suC
+kjv
 dwi
 dwi
 dwi
@@ -213968,7 +215108,7 @@ dwi
 dwi
 dwi
 dwi
-kRy
+suC
 dsP
 dwi
 dwi
@@ -214225,7 +215365,7 @@ jTZ
 qqm
 vqv
 dwi
-kRy
+suC
 gWj
 fNa
 vPc
@@ -214482,7 +215622,7 @@ wGM
 kqJ
 reR
 dwi
-kRy
+suC
 dWb
 kOT
 nmC
@@ -214739,7 +215879,7 @@ wGM
 oaD
 abG
 dwi
-kRy
+suC
 roj
 kOT
 vGT
@@ -220283,8 +221423,8 @@ nXD
 hKB
 iFP
 iFP
-xtr
-xtr
+cIl
+cIl
 afe
 jlv
 qKe
@@ -222372,7 +223512,7 @@ vCf
 enC
 rjQ
 iFP
-xtr
+cIl
 rAt
 enC
 oNc
@@ -233197,17 +234337,17 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
+fjt
+jps
+jps
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
 ntq
 ntq
 ntq
@@ -233451,28 +234591,28 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-cEB
-xNa
-xNa
-xNa
-xNa
-jZi
-xNa
-jZi
-xNa
-xNa
-xNa
-xNa
-xNa
-xNa
-xNa
-xNa
+fjt
+jps
+jps
+jQN
+rTq
+lTQ
+byX
+nRp
+eDE
+dar
+byX
+dOU
+dOU
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
 ruG
 ruG
 gUW
@@ -233708,28 +234848,28 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-xNa
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+jFh
 uYa
-akx
-bzp
-cEB
-jBn
-pMc
-bzp
+fFa
+eDE
+byX
+dOU
+dOU
+byX
 uKE
 jaW
 mul
-lgP
-sVv
+fFa
+fFa
 mNb
-uVQ
-xNa
+fFa
+dar
 pEQ
 foR
 ntq
@@ -233965,28 +235105,28 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-uYa
+oXF
+lTQ
+gvi
+lTQ
+gvi
+lTQ
+jFh
 fcy
-afH
-bzp
-bRL
-bzp
-bzp
-bzp
-bzp
-mpf
+fFa
+eDE
+byX
+ePv
+fFa
+byX
+fFa
+gAH
 npg
+fFa
+fFa
+jDQ
 igG
-igG
-igG
-igG
-xNa
+dar
 kno
 foR
 ntq
@@ -234221,29 +235361,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-ruG
-ruG
-ruG
-ruG
-ruG
-ruG
-uYa
+ntq
+oXF
+lTQ
+pyd
+lTQ
+pyd
+lTQ
+jFh
 iSI
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-dnT
-npg
-igG
-rkB
+fFa
+eDE
+byX
+fFa
+fFa
+dtY
+fFa
+fFa
+fFa
+fFa
+iKX
 rkB
 njS
-xNa
+dar
 cyb
 foR
 ntq
@@ -234478,29 +235618,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-kno
-kno
-fuh
-kno
-fuh
-kno
-uYa
+ntq
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+byX
 qnV
-bzp
-bzp
-bzp
-bzp
-bzp
-bzp
-vUz
-jaW
+fFa
+fFa
+dar
+dar
+dar
+byX
+fFa
+iKX
 ssv
-uha
+fFa
 gAH
 rXL
-igG
-xNa
+njS
+dar
 kno
 foR
 ntq
@@ -234735,29 +235875,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-kno
-kno
-bgM
-kno
-bgM
-kno
-uYa
-qnV
-bzp
-bzp
-vUz
-bzp
-bzp
-qCo
-pUg
+ntq
+oXF
+lTQ
+gvi
+lTQ
+gvi
+lTQ
+byX
+qer
+fFa
+fFa
+fFa
+fFa
+nGZ
+byX
+uKE
 dnT
 sHV
-uha
-iKx
+fFa
+fFa
 juZ
-njS
-xNa
+sEf
+dar
 kno
 bvc
 bvc
@@ -234992,29 +236132,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-kno
-kno
-kno
-kno
-kno
-kno
-uYa
+ntq
+oXF
+lTQ
+pyd
+lTQ
+pyd
+lTQ
+byX
 snp
-bzp
+fFa
 buS
 pUg
-bzp
+fFa
 mFU
-xNa
-jZi
-jaW
-lXQ
-igG
-czj
-czj
-igG
-xNa
+dar
+dar
+dar
+byX
+fFa
+fFa
+fFa
+fFa
+dar
 kno
 bgX
 pyM
@@ -235249,29 +236389,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-kno
-kno
-fuh
-kno
-fuh
-kno
-uYa
-fcy
-bzp
-bzp
-lOV
-bzp
-mFU
-xNa
 ntq
-jaW
-jtL
-igG
-nlC
-igG
-njS
-xNa
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+jFh
+uYa
+fFa
+kbr
+lOV
+fFa
+jzw
+dar
+ojm
+vli
+dar
+dar
+dar
+xUQ
+dar
+dar
 kno
 bgX
 iTZ
@@ -235506,29 +236646,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-kno
-kno
-bgM
-kno
-bgM
-kno
-xNa
-xNa
-fRV
-xNa
-vmR
-vmR
-xNa
-xNa
 ntq
+oXF
+lTQ
+gvi
+lTQ
+gvi
+lTQ
+jFh
+fcy
+fFa
+bhz
+vmR
+fFa
+mFU
+dar
+rej
+jmO
 xNa
-xNa
-xNa
-xNa
+dar
 jmO
 jmO
-xNa
+jmO
+dar
 kno
 bWw
 iTZ
@@ -235763,29 +236903,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-foR
 ntq
-jaW
-igG
-jaW
-saY
-igG
+oXF
+lTQ
+pyd
+lTQ
+pyd
+lTQ
+jFh
+iSI
+fFa
+fFa
+fFa
+fFa
+nGZ
+dar
+dxv
+jmO
+jmO
+xUQ
+jmO
+jmO
 exB
-xNa
+dar
 kno
 bgX
 had
@@ -236020,29 +237160,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-kno
-kno
-kno
-kno
-kno
-kno
-cyb
-kno
-cyb
-kno
-cyb
-kno
-kno
-foR
 ntq
-gua
-igG
-tcX
-igG
-igG
+vMH
+rTq
+lTQ
+lTQ
+lTQ
+lTQ
+byX
+nGZ
+mFU
+dbm
+mFU
+nGZ
+dar
+dar
+aKn
+ybt
+jmO
+dar
 exB
-xNa
+jmO
+exB
+dar
 kno
 bgX
 wKD
@@ -236277,29 +237417,29 @@ ntq
 ntq
 ntq
 ntq
-jeA
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-cEq
-wVk
 ntq
-gua
-igG
-jaW
-gAH
-ybt
-exB
+aOT
+lbr
+lbr
+lbr
+lbr
+lbr
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
+dar
 xNa
+dar
+exB
+ybt
+jmO
+dar
 kno
 bvc
 bvc
@@ -236550,13 +237690,13 @@ ntq
 ntq
 ntq
 ntq
-xNa
-xNa
-xNa
-xNa
-xNa
-xNa
-xNa
+dar
+dar
+dar
+dar
+dar
+dar
+dar
 foR
 ntq
 ntq
@@ -238642,9 +239782,9 @@ xCH
 ntq
 ntq
 sPq
-haa
-fkj
-leR
+iNm
+ePk
+xQM
 iNm
 iNm
 haa
@@ -238901,7 +240041,7 @@ ntq
 sPq
 vMt
 dha
-leR
+xQM
 iNm
 uEQ
 tQO
@@ -239156,9 +240296,9 @@ xCH
 ntq
 ntq
 sPq
-dME
-veb
-leR
+iNm
+ePk
+xQM
 iNm
 iNm
 dME
@@ -261186,7 +262326,7 @@ dQb
 kFv
 uIz
 civ
-iwL
+vhA
 iwL
 iwL
 gvW
@@ -261702,7 +262842,7 @@ isk
 evU
 tCd
 aWS
-kFv
+bdU
 kFv
 tkX
 ntq
@@ -266888,7 +268028,7 @@ spk
 hoA
 hoA
 xvH
-oMk
+wRG
 hoA
 hoA
 spk
@@ -268398,24 +269538,24 @@ lTQ
 ctC
 ntq
 ntq
-dar
-dar
+ufX
+ufX
 fFE
 fFE
 fFE
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
 fFE
 fFE
 fFE
-dar
-dar
+ufX
+ufX
 ntq
 ntq
 ntq
@@ -268655,24 +269795,24 @@ lTQ
 ctC
 ntq
 ntq
-dar
+ufX
 jGR
 jGR
 jGR
 qRf
 qRf
-dar
-dzd
-dar
+ufX
 tvZ
-pvR
-dar
+ufX
+tvZ
+ufX
+ktg
+umh
+qRf
+qRf
 jGR
-aEq
-aEq
 jGR
-jGR
-dar
+ufX
 ntq
 ntq
 jHi
@@ -268912,24 +270052,24 @@ iQG
 ctC
 ntq
 ntq
-dar
-mhX
-eaY
-nFW
+ufX
+ryT
+ufX
+ezY
+gBK
 qRf
-qRf
-dar
+ufX
 gfH
-dar
-rYD
-pvR
-dar
-jGR
-jGR
-jGR
-jGR
+ufX
+gfH
+ufX
+iyV
+umh
+qRf
+qRf
+laC
 tGL
-dar
+ufX
 ntq
 ntq
 gou
@@ -268942,9 +270082,9 @@ qBm
 hoA
 hoA
 hoA
-oMk
+wRG
 hoA
-oMk
+wRG
 rDp
 hoA
 hoA
@@ -269169,24 +270309,24 @@ lbr
 poJ
 ntq
 ntq
-dar
+ufX
+gKn
+ufX
 jGR
-jGR
-jGR
-qRf
-qRf
-dar
+ufX
+kxV
+ufX
+nZS
 pvR
 pvR
-pvR
-pvR
+ufX
 pXo
-qRf
+umh
 qRf
 gBK
 aUZ
 iCd
-dar
+ufX
 ntq
 ntq
 xtG
@@ -269218,9 +270358,9 @@ jHi
 jHi
 jHi
 jHi
-utG
+eoG
+nhp
 pgR
-ntq
 ntq
 ntq
 ntq
@@ -269426,24 +270566,24 @@ ntq
 ntq
 ntq
 ntq
-dar
+ufX
 saw
 qRf
 qRf
 qRf
-qRf
-dar
+uqq
+ufX
+nZS
+eLl
 pvR
-pvR
-pvR
-pvR
-dar
-qRf
+ufX
+ktg
+umh
 qRf
 qRf
 xii
 vNU
-dar
+ufX
 ntq
 ntq
 xtG
@@ -269470,14 +270610,14 @@ hoA
 qrR
 hoA
 hoA
-xvH
+nWU
+rjz
+wsB
 hoA
-hoA
-jHi
+eoG
 mXe
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -269683,24 +270823,24 @@ ntq
 ntq
 ntq
 ntq
-dar
+ufX
 mJe
 qRf
+ufX
+kxV
 qRf
+ufX
+ufX
+ufX
+brI
+ufX
+ufX
+ufX
+eCl
 qRf
-uqq
-dar
-dar
-dzK
-dar
-dar
-dar
-dzV
-qRf
-qRf
-xii
+jCh
 cek
-dar
+ufX
 ntq
 ntq
 phB
@@ -269725,16 +270865,16 @@ xtG
 wCZ
 hoA
 xtG
-kDc
+pxB
 hoA
 rDp
 hoA
 hoA
-kDM
+hoA
+eoG
 kFo
 kFo
-jdy
-ntq
+pBf
 ntq
 ntq
 ntq
@@ -269940,8 +271080,8 @@ ntq
 ntq
 ntq
 ntq
-dar
-mJe
+ufX
+ufc
 qRf
 qRf
 qRf
@@ -269955,9 +271095,9 @@ jGR
 qRf
 qRf
 qRf
-xii
+ocV
 cOq
-dar
+ufX
 ntq
 ntq
 phB
@@ -269986,12 +271126,12 @@ oJp
 hoA
 hoA
 hoA
-qSV
-jHi
+hoA
+hoA
+cRF
 kFo
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -270197,7 +271337,7 @@ ruG
 ruG
 pnE
 ntq
-dar
+ufX
 mJe
 qRf
 qRf
@@ -270212,9 +271352,9 @@ jGR
 qRf
 qRf
 qRf
-xii
+ocV
 cOq
-dar
+ufX
 ntq
 ntq
 phB
@@ -270241,14 +271381,14 @@ rDp
 hmH
 wWe
 hoA
-mNa
+agp
+iRj
+chz
 hoA
-cNw
-jHi
-mAW
+eoG
+xLF
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -270454,24 +271594,24 @@ kno
 kno
 foR
 ntq
-dar
-mJe
+ufX
+ufc
 qRf
+ufX
+kxV
+uqq
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+uyg
 qRf
-qRf
-qRf
-muI
-dar
-dar
-dar
-dar
-dar
-dzV
-qRf
-qRf
-xii
-cOq
-dar
+aUZ
+sbV
+ufX
 ntq
 ntq
 xtG
@@ -270497,15 +271637,15 @@ ekL
 hoA
 xtG
 pti
-aTn
+hoA
 fda
-ekL
+hdM
 fBJ
-mmE
+hoA
 mAW
+xLF
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -270711,24 +271851,24 @@ kno
 kno
 foR
 ntq
-dar
+ufX
 lHu
 qRf
 qRf
 qRf
 qRf
-dAi
-dar
+ufX
+ufX
 dOU
 dOU
-dar
-jGR
-jGR
-jGR
+ufX
+dsf
+umh
+qRf
 qRf
 xii
-cOq
-dar
+vNU
+ufX
 ntq
 ntq
 gou
@@ -270754,15 +271894,15 @@ ekL
 hoA
 xtG
 wWe
-aTn
+hoA
 fda
-ekL
-fHr
-mmE
+hdM
+fBJ
+hoA
+mAW
 iYh
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -270968,24 +272108,24 @@ kno
 kno
 foR
 ntq
-dar
-jGR
-jGR
-jGR
-qRf
-qRf
-shO
-dar
+ufX
+gKn
+ufX
+ezY
+ufX
+kxV
+ufX
+ufX
 dOU
 dOU
-dar
-jGR
-aEq
-jGR
+ufX
+dsf
+umh
+qRf
 gBK
-xii
-cek
-dar
+jCh
+iCd
+ufX
 ntq
 ntq
 phB
@@ -271011,15 +272151,15 @@ ekL
 hoA
 xtG
 rOZ
-aTn
+hoA
 fda
-ekL
-rvF
-mmE
+hdM
+fBJ
+hoA
+mAW
 jKZ
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -271225,24 +272365,24 @@ kno
 kno
 foR
 ntq
-dar
-mhX
-sZe
-nFW
+ufX
+ryT
+ufX
+jGR
+gBK
 qRf
 qRf
+taT
+nFF
+nFF
+ufX
+dsf
+umh
 qRf
-jGR
-jGR
-jGR
-dar
-jGR
-aEq
-jGR
 qRf
-xii
+nNN
 jzn
-dar
+ufX
 ntq
 ntq
 phB
@@ -271268,15 +272408,15 @@ wCZ
 hoA
 xtG
 wWe
-aTn
+hoA
 fda
-ekL
-ocu
-mmE
+hdM
+fBJ
+hoA
+mAW
 qUl
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -271482,7 +272622,7 @@ kno
 kno
 foR
 ntq
-dar
+ufX
 jGR
 jGR
 jGR
@@ -271492,14 +272632,14 @@ qRf
 jGR
 jGR
 jGR
-dar
-jGR
-jGR
-jGR
+ufX
+dsf
+umh
 qRf
-dAi
-vNU
-dar
+qRf
+jGR
+fjm
+ufX
 ntq
 ntq
 phB
@@ -271527,13 +272667,13 @@ hmH
 hiS
 hoA
 nNu
+suc
+vey
 hoA
-rGQ
-mmE
+mAW
 tKs
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -271739,24 +272879,24 @@ jps
 jps
 iex
 ntq
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
-dar
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
+ufX
 ntq
 ntq
 xtG
@@ -271785,12 +272925,12 @@ bhb
 hoA
 hoA
 hoA
-qSV
-jHi
+hoA
+hoA
+eoG
 mXe
 kFo
 jdy
-ntq
 ntq
 ntq
 ntq
@@ -272038,16 +273178,16 @@ xtG
 hoA
 hoA
 xtG
-wyW
+pxB
 hoA
 hoA
-lYs
+hoA
 jHi
 jHi
 jHi
+eoG
 rEb
 mZV
-ntq
 ntq
 ntq
 ntq
@@ -272297,8 +273437,8 @@ hoA
 nmd
 hoA
 hoA
-rDp
-hoA
+rxD
+gMB
 jHi
 ntq
 ntq
@@ -272554,8 +273694,8 @@ hoA
 xtG
 hoA
 hoA
-xYr
-qvM
+mdy
+gMB
 jHi
 ntq
 ntq
@@ -273074,12 +274214,12 @@ ntq
 ntq
 ntq
 ijC
-mKY
+kjv
 wuj
-xli
+jWz
 wEg
-ibv
-kRy
+dwi
+nsO
 kjv
 roM
 kVA
@@ -273087,15 +274227,15 @@ fEr
 dwi
 ijC
 kjv
-wGM
+rCY
 eSU
-reR
+gcs
 dwi
 kRy
 kjv
-kOT
+kGG
 blP
-dmg
+mux
 dwi
 eFA
 ntq
@@ -273331,12 +274471,12 @@ ntq
 ntq
 ntq
 ijC
-mbl
+xMo
 wuj
-mVc
+tsm
 wEg
 dwi
-kRy
+nsO
 dsP
 roM
 dOl
@@ -273344,15 +274484,15 @@ fEr
 dwi
 ijC
 dsP
-wGM
-kqJ
-reR
+rCY
+kJo
+gcs
 dwi
 kRy
 dsP
-kOT
-nmC
-dmg
+kGG
+ljt
+mux
 dwi
 eFA
 ntq
@@ -273589,13 +274729,13 @@ ntq
 ntq
 ijC
 gWj
-nhh
-rMn
+pKL
+ewW
 kYb
 dwi
-kRy
+nsO
 gWj
-kMx
+uEd
 cta
 pyg
 dwi
@@ -273608,8 +274748,8 @@ dwi
 kRy
 gWj
 jAm
-wXX
-hUb
+npj
+kZm
 dwi
 eFA
 ntq
@@ -273845,12 +274985,12 @@ ntq
 ntq
 ntq
 ijC
-loD
-bfe
+dWb
 dwi
-pAT
-xTp
-kRy
+dwi
+dwi
+dwi
+nsO
 dWb
 dwi
 dwi
@@ -274103,11 +275243,11 @@ ntq
 ntq
 ijC
 roj
-dqK
-bRZ
-dqK
-dqK
-kRy
+dwi
+dwi
+dwi
+ibv
+nsO
 roj
 dwi
 dwi
@@ -274609,11 +275749,11 @@ ntq
 ntq
 ntq
 ntq
-mvo
-dwi
+kRy
 dwi
 dwi
 wjp
+dwi
 ibv
 cxT
 taP
@@ -274866,7 +276006,7 @@ ntq
 ntq
 ntq
 ntq
-mvo
+kRy
 tso
 riJ
 ruM
@@ -275123,9 +276263,9 @@ ntq
 ntq
 ntq
 ntq
-mvo
+kRy
 ibG
-seZ
+ljt
 mux
 dwi
 dwi
@@ -275380,8 +276520,8 @@ ntq
 ntq
 ntq
 ntq
-mvo
-qEd
+kRy
+dst
 npj
 kZm
 dwi
@@ -275637,12 +276777,12 @@ ntq
 ntq
 ntq
 ntq
-mvo
+kRy
 roj
 xOG
 dwi
 dwi
-bRZ
+vkW
 cxT
 xRI
 taP
@@ -276151,7 +277291,7 @@ lTQ
 ctC
 ntq
 ntq
-kRy
+kex
 dwi
 dwi
 wjp
@@ -276408,7 +277548,7 @@ lTQ
 ctC
 ntq
 ntq
-kRy
+kex
 fPt
 fVs
 kPd
@@ -276665,9 +277805,9 @@ lTQ
 ctC
 ntq
 ntq
-kRy
+kex
 not
-xGt
+sjY
 nvL
 dwi
 dwi
@@ -276922,7 +278062,7 @@ lTQ
 ctC
 ntq
 ntq
-kRy
+kex
 vbN
 dZa
 tAe
@@ -277179,12 +278319,12 @@ lTQ
 ctC
 ntq
 ntq
-kRy
+kex
 roj
 xOG
 lcG
 dwi
-bRZ
+vkW
 cxT
 aGO
 taP
@@ -279242,25 +280382,25 @@ ntq
 ntq
 ntq
 mvo
-bOt
+kjv
+dwi
+dwi
+dwi
+ibv
+suC
+kjv
+dwi
+dwi
+dwi
+ibv
+kGi
+kjv
 dwi
 dwi
 dwi
 ibv
 kRy
-bOt
-dwi
-dwi
-dwi
-ibv
-mvo
-bOt
-dwi
-dwi
-dwi
-ibv
-kRy
-bOt
+kjv
 dwi
 dwi
 dwi
@@ -279504,13 +280644,13 @@ dwi
 dwi
 dwi
 dwi
-kRy
+suC
 dsP
 dwi
 dwi
 dwi
 dwi
-mvo
+kGi
 dsP
 dwi
 dwi
@@ -279757,17 +280897,17 @@ ntq
 ntq
 mvo
 gWj
-klF
+jTZ
 qqm
 vqv
 dwi
-kRy
+suC
 gWj
-knr
+fNa
 vPc
 whJ
 dwi
-mvo
+kGi
 gWj
 uZc
 oAC
@@ -279776,8 +280916,8 @@ dwi
 kRy
 gWj
 qbM
-iJc
-qrE
+riJ
+ruM
 dwi
 eFA
 ntq
@@ -280018,13 +281158,13 @@ wGM
 kqJ
 reR
 dwi
-kRy
+suC
 dWb
 kOT
 nmC
 dmg
 dwi
-mvo
+kGi
 dWb
 wuj
 tsm
@@ -280032,9 +281172,9 @@ wEg
 dwi
 kRy
 dWb
-roM
-dOl
-fEr
+kGG
+ljt
+mux
 dwi
 eFA
 ntq
@@ -280275,13 +281415,13 @@ wGM
 oaD
 abG
 dwi
-kRy
+suC
 roj
 kOT
 vGT
 hGi
 dwi
-mvo
+kGi
 roj
 wuj
 kkj
@@ -280289,7 +281429,7 @@ wPZ
 dwi
 kRy
 roj
-roM
+kGG
 cMr
 uqT
 dwi
@@ -282999,7 +284139,7 @@ ntq
 pwN
 hEr
 nfs
-sSX
+dCa
 mov
 jiF
 mov
@@ -287110,8 +288250,8 @@ ctC
 ntq
 ntq
 esX
-sSX
-sSX
+dCa
+dCa
 mov
 mov
 mov
@@ -298736,14 +299876,14 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
+fjt
+jps
+jps
+jps
+jps
+jps
+jps
+iex
 ntq
 ntq
 ntq
@@ -298993,22 +300133,22 @@ ntq
 ntq
 ntq
 ntq
-lvw
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-wpx
+vMH
+mHK
+aMo
+bHr
+lTQ
+lTQ
+lTQ
+xtH
+jps
+jps
+jps
+jps
+jps
+jps
+jps
+iex
 ntq
 ntq
 ntq
@@ -299250,22 +300390,22 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+jqz
+aRs
+bHr
+lTQ
+rTq
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -299507,22 +300647,22 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -299764,22 +300904,22 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+wKI
+mWJ
+jcU
+jcU
+jcU
+jcU
+jcU
+otS
+bHr
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -300021,22 +301161,22 @@ ntq
 ntq
 ntq
 ntq
+vMH
+lTQ
+lTQ
+lTQ
+bzo
 kTh
+fuh
+kno
+fuh
 kno
 kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+eUL
+bHr
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -300278,22 +301418,22 @@ ntq
 ntq
 ntq
 ntq
+vMH
+lTQ
+lTQ
+lTQ
+bzo
 kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
+iha
+iha
+iha
+iha
+iha
 sqA
+bHr
+lTQ
+lTQ
+ctC
 ntq
 lvw
 jPj
@@ -300535,22 +301675,22 @@ ntq
 ntq
 ntq
 ntq
+vMH
+lTQ
+lTQ
+lTQ
+bzo
 kTh
+iha
 kno
+iha
 kno
-kno
-kno
-kno
-kno
-tUd
-cvt
-gpR
-kno
-kno
-kno
-kno
-kno
+bgM
 sqA
+bHr
+lTQ
+lTQ
+ctC
 ntq
 kTh
 kno
@@ -300792,22 +301932,22 @@ ntq
 ntq
 ntq
 ntq
+vMH
+lTQ
+lTQ
+lTQ
+bzo
 kTh
+bgM
+kno
+bgM
 kno
 kno
-kno
-kno
-kno
-kno
-sqA
-ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-sqA
+xCp
+bHr
+lTQ
+lTQ
+ctC
 ntq
 kTh
 kno
@@ -301049,22 +302189,22 @@ ntq
 ntq
 ntq
 ntq
-gjN
-cvt
-cvt
-cvt
-cvt
-cvt
-cvt
-lmH
-ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+wOV
+qAB
+kuq
+kuq
+kuq
+kuq
+kuq
+rsb
+bHr
+lTQ
+rTq
+ctC
 ntq
 kTh
 kno
@@ -301306,22 +302446,22 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 kTh
 kno
@@ -301563,22 +302703,22 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+mHK
+aMo
+bHr
+ctC
 ntq
 kTh
 kno
@@ -301820,22 +302960,22 @@ ntq
 ntq
 ntq
 ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-sqA
+aOT
+lbr
+lbr
+lbr
+lbr
+lbr
+lbr
+lbr
+lbr
+rbp
+lTQ
+lTQ
+jqz
+aRs
+bHr
+ctC
 ntq
 gjN
 cvt
@@ -302086,13 +303226,13 @@ ntq
 ntq
 ntq
 ntq
-gjN
-cvt
-cvt
-cvt
-cvt
-cvt
-lmH
+aOT
+lbr
+lbr
+lbr
+lbr
+lbr
+bSw
 ntq
 ntq
 ntq
@@ -302381,7 +303521,7 @@ ntq
 sab
 nZL
 ilC
-ueO
+tYg
 sab
 kPv
 eRZ
@@ -302638,10 +303778,10 @@ ntq
 sab
 kxr
 uGv
-ueO
+tYg
 fzL
-ueO
-ueO
+tYg
+tYg
 cCD
 lIL
 yix
@@ -302898,7 +304038,7 @@ rYR
 uUA
 sab
 jva
-ueO
+tYg
 iHq
 lIL
 iHq
@@ -303155,7 +304295,7 @@ eQD
 eQD
 sab
 ezt
-ueO
+tYg
 iHq
 bBX
 iHq
@@ -303189,7 +304329,7 @@ uzI
 xyQ
 fYY
 gUw
-kTa
+bIE
 pOL
 uzI
 vzM
@@ -303411,8 +304551,8 @@ wmA
 uQS
 sab
 uyj
-jMP
-ueO
+uub
+tYg
 iHq
 lIL
 iHq
@@ -303446,7 +304586,7 @@ hlS
 pOL
 mhU
 rEu
-kTa
+bIE
 pOL
 uzI
 vzM
@@ -303667,9 +304807,9 @@ ser
 aOh
 uQS
 uWJ
-ueO
-ueO
-ueO
+tYg
+tYg
+tYg
 iHq
 lIL
 iHq
@@ -371024,9 +372164,9 @@ qLv
 uqc
 mzA
 iHq
-ueO
-qgB
-qgB
+tYg
+vCE
+vCE
 krG
 cAr
 cAr
@@ -371277,9 +372417,9 @@ lVM
 lVM
 krG
 aHn
-ueO
-ueO
-ueO
+tYg
+tYg
+tYg
 iHq
 dpT
 vuH
@@ -371538,7 +372678,7 @@ sHo
 mzA
 mzA
 iHq
-ueO
+tYg
 uub
 dxQ
 cCQ
@@ -417935,7 +419075,7 @@ cDh
 eyO
 eyO
 cDh
-uRR
+kmb
 qZv
 qEF
 ycH

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -356,6 +356,10 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/wyrm_corrupted)
+"aeW" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "aeX" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -6329,6 +6333,7 @@
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/museum)
 "bAY" = (
@@ -169314,13 +169319,13 @@ gQo
 daK
 fsH
 sOJ
-fFa
+mNb
 dar
 fFE
 fFE
 dar
 byX
-fFa
+ePv
 fFa
 byX
 bzp
@@ -171370,7 +171375,7 @@ daK
 daK
 dvL
 kog
-fFa
+aeW
 dar
 fFE
 fFE

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -333,6 +333,12 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
+"aeB" = (
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "aeE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/grey{
@@ -360,15 +366,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/museum)
-"aeX" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "afe" = (
 /turf/closed/wall/vampwall/junk,
 /area/vtm/interior/ghetto)
@@ -574,11 +571,18 @@
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
 "ahy" = (
-/obj/structure/chair/wood/darkpack/red{
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "ahE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -699,6 +703,10 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/park)
+"aiU" = (
+/obj/machinery/light/prince/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "aiW" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -863,6 +871,17 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/hotel)
+"akV" = (
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/unlock,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plating/roofwalk/cobblestones,
+/area/vtm/interior/jazzclub)
 "akZ" = (
 /obj/structure/vampdoor/reinf{
 	dir = 8
@@ -882,8 +901,11 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop/clothing_store)
 "all" = (
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/carpet/purple,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "alm" = (
 /obj/effect/turf_decal/siding/white,
@@ -902,12 +924,17 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
 "alq" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/machinery/computer/stockexchange{
-	name = "Luxurious stock exchange computer"
+/obj/structure/table/no_smooth/wood/low,
+/obj/item/clothing/glasses/regular/thin{
+	pixel_x = -4;
+	pixel_y = 6
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/kirbyplants/darkpack/random{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "alt" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/carpet/darkpack/hotel,
@@ -1131,6 +1158,25 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"aop" = (
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
+"aot" = (
+/obj/machinery/light/prince/directional/north,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "aoA" = (
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
@@ -1236,6 +1282,18 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/shop/bacotell)
+"apX" = (
+/obj/structure/table/countertop/black,
+/obj/item/storage/box/coffeepack{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "apZ" = (
 /obj/machinery/light/floor/lamppost/three,
 /obj/structure/trafficlight,
@@ -1548,10 +1606,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
-"atA" = (
-/obj/structure/mirror,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
 "atE" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/blood/ab_plus,
@@ -1642,9 +1696,11 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
 "auB" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/carpet/green,
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "auM" = (
 /obj/effect/turf_decal/siding/white{
@@ -1663,6 +1719,15 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/baali)
+"auQ" = (
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "auT" = (
 /obj/structure/vampdoor/wood{
 	dir = 4
@@ -1726,12 +1791,6 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
-"avo" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
 "avt" = (
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
@@ -1754,14 +1813,6 @@
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/ghetto)
-"avM" = (
-/obj/effect/decal/shadow,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/water,
-/area/vtm/interior/jazzclub)
 "avQ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -2304,6 +2355,25 @@
 /obj/effect/decal/wallpaper/gold,
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/interior/sewer/nosferatu_town)
+"aDd" = (
+/obj/structure/platform/lowwall/rich,
+/obj/structure/vampstatue/angel{
+	pixel_y = 26
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = 9;
+	pixel_y = 19
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "aDf" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -2571,10 +2641,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
 "aGu" = (
-/obj/structure/chair/comfy/darkpack{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "aGw" = (
 /obj/effect/decal/graffiti,
@@ -2624,25 +2694,11 @@
 /obj/structure/sink/directional/west,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
-"aHj" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/obj/fusebox,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
 "aHn" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
-"aHp" = (
-/obj/structure/coclock,
-/obj/structure/chair/sofa/corp/corner,
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "aHq" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -2791,6 +2847,22 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
+"aIV" = (
+/obj/structure/platform/lowwall/rich,
+/obj/structure/vampstatue/angel{
+	pixel_y = 26
+	},
+/obj/item/food/grown/flower/poppy/lily,
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = 10;
+	pixel_y = 11
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "aJb" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 8
@@ -2842,6 +2914,10 @@
 /obj/effect/turf_decal/siding/grey,
 /turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/clinic)
+"aKb" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "aKj" = (
 /obj/structure/bookcase/random/kindred,
 /obj/machinery/light/directional/south,
@@ -3085,8 +3161,8 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f3)
 "aNn" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/platform/lowwall/rich/window,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/jazzclub)
 "aNs" = (
@@ -3271,7 +3347,7 @@
 "aPN" = (
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "aPP" = (
 /obj/fusebox,
 /obj/structure/closet/secure_closet/freezer/meat/open,
@@ -3287,10 +3363,6 @@
 /obj/machinery/light/prince/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
-"aQe" = (
-/obj/structure/table/glass,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "aQg" = (
 /obj/structure/fluff/tv/order/one{
 	pixel_x = -16
@@ -3353,10 +3425,6 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
-"aRe" = (
-/obj/machinery/light/floor/lamppost/sidewalk,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "aRq" = (
 /obj/machinery/light/directional/south,
 /obj/structure/hedge,
@@ -3437,9 +3505,9 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
 "aRT" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/chair/comfy/darkpack/dark,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "aRW" = (
 /obj/effect/turf_decal/crosswalk{
 	dir = 8
@@ -3469,6 +3537,22 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm)
+"aSm" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "aSn" = (
 /mob/living/carbon/human/npc/guard,
 /obj/effect/turf_decal/weather/dirt{
@@ -3587,10 +3671,14 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower)
 "aTd" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
 	},
-/turf/open/floor/carpet/purple,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	color = "#36454F"
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "aTe" = (
 /obj/effect/turf_decal/asphaltline{
@@ -4132,20 +4220,13 @@
 /turf/open/floor/cult,
 /area/vtm/interior/chantry/basement)
 "aZW" = (
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "primVentrue";
-	lockpick_difficulty = 16;
-	name = "board chair's office";
-	locked = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/mapping_helpers/door/access/primogen_ventrue,
-/obj/effect/mapping_helpers/door/lock_difficulty/ten,
-/obj/effect/mapping_helpers/door/bash_difficulty/ten,
+/obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/mapping_helpers/door/access/primogen_ventrue,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "aZZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -4214,6 +4295,12 @@
 /obj/machinery/light/floor/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"bbi" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "bbo" = (
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/old,
@@ -4365,6 +4452,11 @@
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/smoke_shop)
+"bdk" = (
+/obj/structure/platform/lowwall/rich/window,
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "bdr" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4445,11 +4537,11 @@
 /area/vtm/interior/tzimisce_manor)
 "bex" = (
 /obj/effect/decal/wallpaper/red/low,
-/obj/structure/window/reinforced/tinted/spawner/directional/south{
-	max_integrity = 1000000
-	},
 /obj/effect/decal/wallpaper/red/low,
 /obj/structure/platform/lowwall/rich/window,
+/obj/structure/window/reinforced/tinted/spawner/directional/south{
+	opacity = 1
+	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/jazzclub)
 "bez" = (
@@ -4529,16 +4621,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
-"bfs" = (
-/obj/structure/table/wood,
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/item/rag{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/jazzclub)
 "bfu" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/lone,
@@ -4632,10 +4714,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
-"bgy" = (
-/obj/effect/landmark/npcability,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "bgB" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/rough,
@@ -4902,7 +4980,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "bjV" = (
 /obj/structure/railing/darkpack/metal/industrial/solo{
 	dir = 1
@@ -5000,6 +5078,12 @@
 /obj/item/vamp/keys/daughters,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior)
+"bkR" = (
+/obj/structure/aquarium/prefilled,
+/obj/structure/platform/lowwall/rich,
+/obj/effect/decal/wallpaper/blue/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "bkT" = (
 /obj/structure/platform/lowwall/painted/window/reinforced,
 /turf/open/floor/plating/rough,
@@ -5254,12 +5338,6 @@
 /obj/structure/bed/maint,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
-"boe" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
 "bof" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -5296,13 +5374,6 @@
 	},
 /turf/open/openspace,
 /area/vtm/interior/giovanni)
-"bow" = (
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "boD" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/vampfence/corner{
@@ -5498,6 +5569,10 @@
 "bqB" = (
 /turf/open/openspace,
 /area/vtm/interior/giovanni)
+"bqC" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "bqG" = (
 /obj/structure/vampipe{
 	pixel_y = 32
@@ -5808,6 +5883,88 @@
 /obj/fusebox,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/theatre)
+"buZ" = (
+/obj/structure/table/countertop/black,
+/obj/item/reagent_containers/cup/glass/drinkingglass/collins_glass,
+/obj/item/reagent_containers/cup/glass/drinkingglass/collins_glass,
+/obj/item/reagent_containers/cup/glass/drinkingglass/collins_glass,
+/obj/item/reagent_containers/cup/glass/drinkingglass/collins_glass,
+/obj/item/reagent_containers/cup/glass/drinkingglass/collins_glass,
+/obj/item/reagent_containers/cup/glass/drinkingglass/pint{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/pint{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/pint{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/pint{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/pint{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/pint{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/pint{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/whiskey_shot{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/whiskey_shot{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/whiskey_shot{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/whiskey_shot{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/whiskey_shot{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/whiskey_shot{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/whiskey_shot{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/vodka_shot{
+	pixel_y = -6;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/vodka_shot{
+	pixel_y = -6;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/vodka_shot{
+	pixel_y = -6;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/vodka_shot{
+	pixel_y = -6;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/vodka_shot{
+	pixel_y = -6;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/vodka_shot{
+	pixel_y = -6;
+	pixel_x = 11
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "bva" = (
 /obj/structure/ladder/manhole/down,
 /obj/machinery/light/small/directional/east,
@@ -5832,10 +5989,10 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/giovanni)
 "bvA" = (
-/obj/structure/chair/comfy{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "bvB" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -5955,12 +6112,6 @@
 "bwN" = (
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
-"bwR" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "bxa" = (
 /obj/structure/railing{
 	dir = 4;
@@ -6109,6 +6260,15 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/iron/dark,
 /area/vtm/interior/millennium_tower/f4)
+"byA" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/cup/glass/bottle/wine{
+	pixel_x = 14;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "byD" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth,
@@ -6275,7 +6435,7 @@
 /obj/machinery/light/floor/lamppost/sidewalk,
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "bAq" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/toilet{
@@ -6308,10 +6468,6 @@
 /obj/structure/closet/secure_closet/freezer,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
-"bAI" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "bAK" = (
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f3)
@@ -6730,6 +6886,13 @@
 	},
 /turf/open/floor/city/circled,
 /area/vtm/interior/salubri)
+"bGL" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/effect/decal/wallpaper/paper/fancy/red,
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior/jazzclub)
 "bGM" = (
 /obj/structure/vampdoor{
 	name = "Bathroom"
@@ -6809,11 +6972,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
-"bHE" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/jazzclub)
 "bHG" = (
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
@@ -6893,15 +7051,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/banu)
-"bIz" = (
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_x = 2;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/jazzclub)
 "bIE" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 1
@@ -6909,10 +7058,8 @@
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "bIJ" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
-	},
-/turf/open/floor/carpet/royalblue,
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "bIM" = (
 /obj/structure/table,
@@ -7021,6 +7168,15 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/misc/dirt,
 /area/vtm/interior)
+"bKi" = (
+/obj/structure/chair/office/darkpack/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/jazzclub)
 "bKo" = (
 /obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/city/toilet,
@@ -7172,8 +7328,8 @@
 /turf/open/floor/plating/rough,
 /area/vtm)
 "bLX" = (
-/obj/structure/chair/plastic/darkpack{
-	dir = 8
+/obj/structure/railing/wooden_fence{
+	dir = 4
 	},
 /turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/interior/jazzclub)
@@ -7320,6 +7476,15 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"bNB" = (
+/obj/structure/rack/tall/store_shelf_metal,
+/obj/item/mop,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/pushbroom,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "bNE" = (
 /obj/structure/coclock,
 /obj/structure/closet/crate/bin,
@@ -7521,11 +7686,19 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
+"bRi" = (
+/obj/structure/table/wood,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "bRs" = (
-/obj/item/binoculars,
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/autoname,
+/obj/effect/mapping_helpers/door/unlock,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "bRu" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
@@ -7539,15 +7712,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic)
-"bRF" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "bRG" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/item/ammo_box/darkpack/c50,
@@ -7907,13 +8071,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/caern)
-"bVs" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "bVt" = (
 /obj/structure/vampdoor/wood{
 	dir = 4
@@ -8194,10 +8351,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
-"bYm" = (
-/obj/structure/flora/bush/style_random,
-/turf/open/misc/grass,
-/area/vtm/interior/library)
 "bYr" = (
 /obj/structure/hedge,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -8251,7 +8404,7 @@
 	},
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "bZm" = (
 /obj/item/flashlight/flare/candle/infinite{
 	pixel_x = -8;
@@ -8432,9 +8585,10 @@
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "cbJ" = (
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/mop_bucket,
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "cbK" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 1
@@ -8450,6 +8604,15 @@
 /obj/machinery/griddle,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop/otolleys)
+"cbS" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/obj/machinery/light/prince/directional/west{
+	pixel_y = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "ccj" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /turf/open/floor/plating/sidewalk/old,
@@ -8557,10 +8720,160 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
 "cdG" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 10
+/obj/structure/table/countertop/black,
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/fork{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "cdW" = (
 /obj/machinery/light/directional/north,
@@ -8606,9 +8919,11 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "cen" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "ceo" = (
 /obj/structure/chair/darkpack{
 	dir = 4
@@ -8647,10 +8962,17 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights)
 "ceM" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 6
+/obj/structure/table/countertop/black,
+/obj/machinery/coffeemaker/impressa,
+/obj/item/storage/box/coffeepack/robusta{
+	pixel_x = 15;
+	pixel_y = 6
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/item/storage/box/coffeepack/robusta{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "ceQ" = (
 /obj/effect/decal/cleanable/ash/large,
@@ -8916,15 +9238,6 @@
 /obj/structure/roadsign/street,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"ciA" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "ciB" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 1
@@ -8976,33 +9289,16 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
 "cjp" = (
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/stack/dollar/hundred,
-/obj/item/smartphone/clean,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table/wood/fancy/red,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = 0;
+	pixel_y = 12
 	},
-/obj/structure/table/wood/fancy/royalblue,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/lighter/empty,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "cjy" = (
 /obj/effect/landmark/npcwall,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -9046,6 +9342,40 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"ckh" = (
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 3;
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 3;
+	pixel_x = 8
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "cki" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -9071,14 +9401,19 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f2)
 "ckF" = (
-/obj/item/flashlight/lamp/green{
-	pixel_x = -5;
-	pixel_y = 15
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/button/curtain{
+	id = "venOfficeCurtain";
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/paper_bin,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "ckO" = (
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/dirt,
@@ -9195,15 +9530,6 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/bianchiBank)
-"cmk" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_x = 2;
-	pixel_y = 12
-	},
-/obj/item/lighter,
-/turf/open/floor/carpet/green,
-/area/vtm/interior/jazzclub)
 "cmp" = (
 /obj/structure/weightmachine,
 /obj/effect/turf_decal/stripes/white/line{
@@ -9384,11 +9710,9 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
 "cot" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wideplating/end,
+/turf/open/floor/plating/sidewalk/rich,
+/area/vtm/interior/jazzclub)
 "cox" = (
 /obj/structure/vampdoor/old{
 	dir = 8
@@ -9416,6 +9740,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"coP" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/chair/comfy/darkpack/dark,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "coQ" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -9432,22 +9763,12 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop/pharmacy)
 "coW" = (
-/obj/structure/vampdoor/wood{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/door/access/jazz_club,
-/obj/effect/mapping_helpers/door/lock,
-/obj/effect/mapping_helpers/door/lock_difficulty/five,
-/obj/effect/mapping_helpers/door/bash_difficulty/five,
-/turf/open/floor/mineral/plastitanium,
-/area/vtm/interior/jazzclub)
-"coY" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/south{
-	max_integrity = 1000000
-	},
 /obj/structure/platform/lowwall/rich/window,
+/obj/structure/window/reinforced/tinted/spawner/directional/west{
+	opacity = 1
+	},
 /turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "cpe" = (
 /obj/structure/bed/double{
 	dir = 1
@@ -9696,6 +10017,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/setite)
+"csI" = (
+/obj/machinery/light/prince/directional/north,
+/obj/machinery/jukebox{
+	pixel_y = 15;
+	density = 0
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "csJ" = (
 /obj/structure/coclock,
 /obj/structure/ladder/manhole/up,
@@ -9887,13 +10216,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"cuS" = (
-/obj/structure/chair/comfy/brown{
-	color = "#50C878";
-	dir = 1
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "cuW" = (
 /obj/structure/chair/sofa/corner/brown,
 /turf/open/floor/wood/smooth/old,
@@ -9951,10 +10273,6 @@
 /obj/fusebox,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church)
-"cwd" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/jazzclub)
 "cwn" = (
 /obj/structure/vampdoor/old,
 /obj/effect/mapping_helpers/door/access/malkavian,
@@ -10023,14 +10341,14 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
 "cwW" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "#36454F"
 	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "cwX" = (
 /obj/structure/rack/clothing/rand,
@@ -10079,10 +10397,6 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
-"cxJ" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "cxK" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -10250,13 +10564,11 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "cAi" = (
-/obj/machinery/light/prince/directional/east,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/obj/machinery/light/prince/directional/west{
+	pixel_y = 8
 	},
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "cAm" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/wood/smooth/old,
@@ -10430,6 +10742,10 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/city/industrial/large,
 /area/vtm/interior/shop/hardware_store)
+"cCB" = (
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "cCD" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/smooth/old,
@@ -10462,7 +10778,18 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior)
 "cCY" = (
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/structure/chair/stool/bar/darkpack/blue,
+/obj/effect/turf_decal/siding/wideplating/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "cDb" = (
 /obj/effect/mapping_helpers/door/access/clinic,
@@ -10739,12 +11066,12 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights)
 "cGJ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/vampdoor/wood,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/unlock,
+/obj/effect/mapping_helpers/door/lock_difficulty/two,
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "cGL" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -10932,10 +11259,10 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/mapping_helpers/door/access/primogen_ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/five,
-/obj/effect/mapping_helpers/door/lock_difficulty/ten,
+/obj/effect/mapping_helpers/door/lock_difficulty/two,
+/obj/effect/mapping_helpers/door/unlock,
 /turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "cIC" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/bordur{
@@ -10946,6 +11273,12 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"cIE" = (
+/obj/structure/railing/wooden_fence{
+	dir = 8
+	},
+/turf/open/floor/plating/roofwalk/cobblestones,
+/area/vtm/interior/jazzclub)
 "cIK" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcability,
@@ -11590,14 +11923,8 @@
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic/haven)
 "cSr" = (
-/obj/structure/table/wood,
-/obj/item/rag{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/cup/glass/shaker,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "cSu" = (
 /obj/structure/chair/wood/darkpack/red,
@@ -11748,20 +12075,6 @@
 /obj/effect/landmark/start/darkpack/hecata/capo,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/bianchiBank)
-"cUv" = (
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/vtm/interior/millennium_tower/ventrue)
 "cUw" = (
 /obj/structure/table,
 /obj/machinery/light/warm/directional/north,
@@ -11776,11 +12089,23 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
 "cUC" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
+/obj/structure/closet/secure_closet/freezer{
+	locked = 0
 	},
+/obj/item/storage/box/ingredients/seafood,
+/obj/item/storage/box/ingredients/seafood,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/sweets,
+/obj/item/storage/box/ingredients/sweets,
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "cUF" = (
 /obj/effect/decal/wallpaper/blue/low,
@@ -11997,16 +12322,14 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
 "cXT" = (
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "cXU" = (
 /obj/structure/vampdoor{
@@ -12092,15 +12415,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"daa" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_x = 2;
-	pixel_y = 12
-	},
-/obj/item/lighter,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "dak" = (
 /obj/effect/turf_decal/siding/dark_blue/corner{
 	dir = 8
@@ -12110,14 +12424,6 @@
 "dar" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/museum)
-"dax" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "daA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -12503,16 +12809,11 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
 "dfu" = (
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/turf/open/floor/wood/old,
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "dfy" = (
 /obj/effect/decal/pallet,
@@ -12923,15 +13224,8 @@
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/strip)
-"dkX" = (
-/obj/structure/table,
-/obj/item/newspaper,
-/obj/item/rag{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clothing/suit/apron/chef,
-/turf/open/floor/city/toilet,
+"dkZ" = (
+/turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/jazzclub)
 "dld" = (
 /obj/effect/turf_decal/siding/white{
@@ -13268,20 +13562,18 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "dpu" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/white{
-	dir = 10
+	dir = 8
 	},
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/railing{
-	pixel_y = -2
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	color = "#36454F"
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "dpw" = (
 /obj/effect/turf_decal/bordur{
 	dir = 5
@@ -13542,8 +13834,19 @@
 /turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "dsw" = (
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/light/corner,
+/obj/structure/table/wood,
+/turf/open/floor/wood/ornate,
+/area/vtm)
+"dsB" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "dsG" = (
 /obj/transfer_point_vamp{
 	id = "Graveyard2"
@@ -13648,6 +13951,41 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/concrete,
 /area/vtm)
+"dup" = (
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -11
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "dur" = (
 /obj/machinery/light/floor/lamppost/one{
 	dir = 8
@@ -13785,6 +14123,13 @@
 "dvN" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm)
+"dvO" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
+	},
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "dvW" = (
 /obj/structure/railing{
 	dir = 1;
@@ -13862,12 +14207,6 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/police)
-"dwS" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "dxd" = (
 /obj/effect/decal/cleanable/cardboard,
 /obj/machinery/atm{
@@ -14193,9 +14532,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/shop/gasstation)
-"dBF" = (
-/turf/open/misc/grass,
-/area/vtm/interior/library)
 "dBU" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -14210,30 +14546,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
-"dCg" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/item/statuebust/hippocratic{
-	anchored = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "dCi" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -14491,10 +14803,6 @@
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
-"dGb" = (
-/obj/structure/stairs/west,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/jazzclub)
 "dGm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -14789,12 +15097,6 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
-"dJy" = (
-/obj/machinery/light/floor/lamppost/one{
-	dir = 8
-	},
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "dJC" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/prince/directional/west,
@@ -14870,24 +15172,13 @@
 /obj/item/newspaper,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
-"dKu" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/vampdoor/wood,
-/turf/open/floor/mineral/plastitanium,
-/area/vtm/interior/jazzclub)
 "dKv" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
 	},
 /obj/structure/roadsign/speedlimit40,
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "dKC" = (
 /obj/structure/vampdoor/old{
 	lock_id = "triad";
@@ -14972,7 +15263,7 @@
 	},
 /obj/effect/decal/support,
 /turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm)
 "dLJ" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior/endron_facility/restricted)
@@ -14985,6 +15276,12 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
+"dLQ" = (
+/obj/effect/decal/painting/third{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "dLR" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -15004,6 +15301,15 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
+"dMl" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 10
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "dMu" = (
 /obj/structure/lattice/catwalk{
 	pixel_x = 1
@@ -15169,6 +15475,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/vtm/interior)
+"dOi" = (
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/turf/open/floor/plating/roofwalk/cobblestones,
+/area/vtm/interior/jazzclub)
 "dOk" = (
 /obj/structure/rack/tall/store_shelf_metal{
 	dir = 8
@@ -15217,14 +15532,9 @@
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "dPp" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/griddle,
+/obj/machinery/light/prince/directional/north,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "dPv" = (
 /obj/structure/bed,
@@ -15332,6 +15642,12 @@
 /obj/structure/platform/lowwall/painted/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/banu)
+"dQi" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "dQm" = (
 /obj/structure/table,
 /obj/item/food/grown/cannabis,
@@ -15454,6 +15770,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"dSi" = (
+/obj/effect/turf_decal/siding/wood/light/corner,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "dSo" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -15505,6 +15825,12 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"dSS" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "dSY" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/peppermill{
@@ -15645,12 +15971,13 @@
 /area/vtm/interior)
 "dUS" = (
 /obj/structure/curtain/cloth/fancy/mechanical/luxurious{
-	id = 2004
+	id = 2004;
+	pixel_y = 8
 	},
-/obj/effect/decal/wallpaper/gold/low,
 /obj/structure/platform/lowwall/rich/window,
+/obj/effect/decal/wallpaper/paper/fancy/red/low,
 /turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "dVk" = (
 /obj/structure/vampdoor/reinf{
 	dir = 4
@@ -15667,10 +15994,9 @@
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/shop/gasstation)
 "dVo" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "dVp" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/outside/pacificheights/forest)
@@ -15713,6 +16039,13 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/cog/caern)
+"dVE" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "dVI" = (
 /obj/structure/vampipe{
 	icon_state = "piping35"
@@ -15876,11 +16209,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
-"dXK" = (
-/obj/machinery/jukebox,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/jazzclub)
 "dXM" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/chair/sofa/corp/right{
@@ -16016,17 +16344,6 @@
 	},
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/sabbat_lair)
-"dZm" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/jazzclub)
 "dZo" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/asphalt,
@@ -16155,12 +16472,6 @@
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"ebg" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "ebh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -16212,10 +16523,6 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
-"ebT" = (
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "ebX" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -16266,11 +16573,6 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/clothing_store)
-"ecs" = (
-/obj/structure/table/glass,
-/obj/vampire_computer,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "ecu" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/sidewalk/poor,
@@ -16335,11 +16637,10 @@
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/sewer)
 "edF" = (
-/obj/structure/chair/sofa/corp/left{
-	alpha = 225;
-	dir = 4
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "edM" = (
 /obj/structure/vampdoor/old{
@@ -16350,6 +16651,12 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/five,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/graveyard)
+"edR" = (
+/obj/structure/railing/wooden_fence{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "edW" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -16357,6 +16664,12 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
+"edY" = (
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/turf/open/floor/iron/stairs/medium,
+/area/vtm/interior/jazzclub)
 "eea" = (
 /obj/structure/railing{
 	pixel_y = -1
@@ -16412,6 +16725,13 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
+"eez" = (
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/lock,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "eeC" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/secure_closet/freezer/meat/open,
@@ -16666,12 +16986,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"ehi" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
 "ehk" = (
 /obj/structure/table/wood,
 /obj/structure/platform/lowwall/city,
@@ -16827,11 +17141,20 @@
 	},
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
+"ejL" = (
+/obj/structure/rack/tall/wood_shelf,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/jazzclub)
 "ejP" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/effect/decal/carpet{
+	icon_state = "rug_blue";
+	pixel_x = -15;
+	pixel_y = 9
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "ejT" = (
 /mob/living/carbon/human/npc/guard,
@@ -17014,16 +17337,6 @@
 	},
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
-"emm" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/iron/stairs,
-/area/vtm/interior/millennium_tower/ventrue)
 "emn" = (
 /obj/structure/coclock/grandpa,
 /turf/open/floor/carpet/green,
@@ -17147,6 +17460,13 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
+"eny" = (
+/obj/machinery/sprinkler/area_managed,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "enA" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -17206,12 +17526,6 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/park)
-"eoc" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/jazzclub)
 "eof" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
@@ -17254,16 +17568,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
-"eoS" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/misc/grass,
-/area/vtm/interior/jazzclub)
 "epb" = (
 /obj/effect/turf_decal/siding/dark_blue/end{
 	dir = 8
@@ -17379,12 +17683,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/restricted)
-"eqz" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "eqN" = (
 /obj/structure/rack/food/rand{
 	dir = 4;
@@ -17482,6 +17780,14 @@
 /obj/structure/chair/office/darkpack/black,
 /turf/open/floor/city/circled,
 /area/vtm/interior/salubri)
+"esk" = (
+/obj/fusebox,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mop_bucket,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/mop,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/jazzclub)
 "esp" = (
 /obj/structure/table/countertop/bubway,
 /obj/item/ammo_box/darkpack/c556{
@@ -17534,6 +17840,12 @@
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"ett" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "etv" = (
 /turf/closed/wall/vampwall/brick,
 /area/vtm/interior/shop/bubway)
@@ -17713,11 +18025,6 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/oldchurch)
-"evP" = (
-/obj/effect/decal/wallpaper/red/low,
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/jazzclub)
 "evS" = (
 /obj/structure/railing{
 	dir = 4
@@ -17729,9 +18036,10 @@
 /turf/open/misc/grass,
 /area/vtm)
 "ewc" = (
+/obj/effect/turf_decal/siding/dark,
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "ewg" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/techshop)
@@ -17869,19 +18177,13 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/ghetto)
 "eye" = (
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 14;
-	name = "board room"
+/obj/structure/toilet{
+	dir = 8;
+	pixel_y = 11
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/machinery/light/prince/directional/north,
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "eyh" = (
 /obj/structure/railing{
 	dir = 8;
@@ -17971,9 +18273,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
 "ezL" = (
+/obj/effect/turf_decal/siding/dark,
 /obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "ezX" = (
 /obj/machinery/light/prince/directional/north,
 /turf/open/misc/dirt,
@@ -18105,6 +18408,10 @@
 /obj/machinery/light/small/red/directional/north,
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/wyrm_corrupted)
+"eBX" = (
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/plating/roofwalk/cobblestones,
+/area/vtm/interior/jazzclub)
 "eCe" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -18207,15 +18514,6 @@
 "eDf" = (
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/clinic/haven)
-"eDk" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/vampdoor/glass,
-/obj/effect/mapping_helpers/door/access/jazz_club,
-/obj/effect/mapping_helpers/door/lock,
-/obj/effect/mapping_helpers/door/bash_difficulty/five,
-/obj/effect/mapping_helpers/door/lock_difficulty/five,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/jazzclub)
 "eDn" = (
 /obj/machinery/light/prince/directional/north,
 /obj/structure/table/wood/fancy/black,
@@ -18223,6 +18521,9 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
+"eDq" = (
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/unionsquare)
 "eDr" = (
 /obj/structure/table,
 /obj/structure/vampfence/rich{
@@ -18240,7 +18541,7 @@
 "eDt" = (
 /obj/structure/hedge,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "eDE" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood/smooth/old,
@@ -18467,21 +18768,6 @@
 /obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic/haven)
-"eGa" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 10
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/jazzclub)
-"eGg" = (
-/obj/structure/fluff/tv{
-	pixel_y = 13
-	},
-/obj/structure/table/wood{
-	density = 0
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/jazzclub)
 "eGm" = (
 /obj/structure/vampdoor/old{
 	lock_id = "triad";
@@ -18627,6 +18913,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
+"eIo" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/support,
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "eIq" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -18658,6 +18951,12 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
+"eIB" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "eIE" = (
 /obj/effect/turf_decal/asphaltline/alt/white{
 	dir = 4;
@@ -18864,15 +19163,6 @@
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/giovanni)
-"eKZ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "eLg" = (
 /obj/structure/rack/clothing/rand,
 /obj/machinery/light/directional/east,
@@ -18992,13 +19282,6 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
-"eMz" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "eMA" = (
 /obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/access/npc,
@@ -19057,12 +19340,13 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf)
 "eNE" = (
-/obj/structure/curtain/cloth/fancy/mechanical/luxurious{
-	id = "ventrueprim"
-	},
 /obj/structure/platform/lowwall/rich/window,
+/obj/structure/curtain/cloth/fancy/mechanical/luxurious{
+	pixel_y = 8;
+	id = "venOfficeCurtain"
+	},
 /turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "eNN" = (
 /obj/structure/vampfence/rich{
 	dir = 4;
@@ -19182,10 +19466,11 @@
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
 "eOW" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
+/obj/structure/table/countertop/black,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "eOZ" = (
 /obj/structure/closet/cabinet,
@@ -19286,12 +19571,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior)
-"eQk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "eQn" = (
 /obj/structure/vampdoor/simple{
 	dir = 4
@@ -19477,6 +19756,24 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/park)
+"eSI" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "eSN" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/effect/turf_decal/siding/wood{
@@ -19525,6 +19822,9 @@
 	},
 /turf/open/floor/carpet/darkpack,
 /area/vtm/outside/pacificheights/forest)
+"eTI" = (
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "eTM" = (
 /obj/structure/roadblock/alt{
 	dir = 4
@@ -19710,6 +20010,19 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/clothing_store)
+"eWx" = (
+/obj/machinery/light/prince/directional/north,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/shoes/vampire/jackboots,
+/obj/item/clothing/shoes/vampire/jackboots,
+/obj/item/clothing/shoes/vampire/heels,
+/obj/item/clothing/shoes/vampire/heels,
+/obj/item/clothing/under/vampire/gown_black,
+/obj/item/clothing/suit/vampire/shawl_black,
+/obj/item/clothing/under/vampire/suit,
+/obj/item/clothing/under/vampire/suit/female,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "eWA" = (
 /obj/structure/chair/plastic{
 	dir = 8;
@@ -19778,6 +20091,15 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"eXs" = (
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/old,
+/area/vtm)
 "eXy" = (
 /obj/effect/decal/painting{
 	pixel_y = 32
@@ -19973,13 +20295,19 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer)
-"fah" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+"fam" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/support,
+/obj/structure/hedge,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
 	},
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "fas" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -20312,10 +20640,8 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
 "fdE" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 6
-	},
-/turf/open/floor/carpet/green,
+/obj/structure/chair/stool/bar/darkpack/blue,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "fdF" = (
 /obj/structure/railing{
@@ -20379,21 +20705,6 @@
 /obj/item/dice/d6,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
-"fez" = (
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "Storage Closet"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior/millennium_tower/ventrue)
 "feV" = (
 /obj/effect/decal/graffiti/large,
 /turf/open/floor/plating/rough/cave,
@@ -20523,6 +20834,17 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/clothing_store)
+"fgw" = (
+/obj/machinery/sprinkler/area_managed,
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
+"fgx" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "fgA" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/carpet/red,
@@ -20711,6 +21033,13 @@
 /obj/darkpack_car/track/volkswagen,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf)
+"fiB" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/obj/structure/chair/wood/darkpack,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "fiX" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/necropolis/air,
@@ -20830,23 +21159,14 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/endron_facility/restricted)
 "fkR" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/structure/vampdoor/wood{
-	dir = 8;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "Ventrue Office"
-	},
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/old,
+/area/vtm)
 "fkY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -20924,6 +21244,20 @@
 /obj/structure/chair/darkpack,
 /turf/open/floor/city/plating,
 /area/vtm/interior/techshop)
+"flW" = (
+/obj/structure/rack/tall/store_shelf_metal,
+/obj/item/chair/wood/darkpack{
+	pixel_x = -6
+	},
+/obj/item/chair/wood/darkpack{
+	pixel_y = 6
+	},
+/obj/item/chair/wood/darkpack{
+	pixel_y = 12;
+	pixel_x = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "flY" = (
 /obj/structure/table/wood,
 /obj/machinery/light/prince/directional/north,
@@ -21049,10 +21383,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"fno" = (
-/obj/structure/chair/darkpack,
-/turf/open/floor/wood/old,
-/area/vtm/interior/jazzclub)
 "fns" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/turf_decal/bordur{
@@ -21093,12 +21423,24 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "foo" = (
-/obj/structure/curtain/cloth/fancy/mechanical/luxurious{
-	id = 2004
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
 	},
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/reagent_containers/cup/glass/bottle/champagne{
+	pixel_x = 0;
+	pixel_y = 20
+	},
+/obj/item/reagent_containers/cup/glass/bottle/champagne{
+	pixel_x = -5;
+	pixel_y = 17
+	},
+/obj/item/reagent_containers/cup/glass/bottle/champagne{
+	pixel_x = 6;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "fop" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -21122,10 +21464,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
 "foG" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "foI" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -21323,6 +21665,9 @@
 /obj/machinery/light/floor/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
+"frP" = (
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "frR" = (
 /obj/effect/decal/carpet,
 /turf/open/floor/wood/smooth/old,
@@ -21363,16 +21708,6 @@
 /obj/structure/vampdoor/simple,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior)
-"fsB" = (
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 14;
-	name = "board room"
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/jazzclub)
 "fsC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -21430,12 +21765,10 @@
 /turf/open/openspace,
 /area/vtm/interior/cog/pantry)
 "ftr" = (
-/obj/effect/decal/support,
 /obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
+	dir = 8
 	},
-/turf/open/water,
+/turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/jazzclub)
 "ftO" = (
 /obj/effect/turf_decal/bordur,
@@ -21519,10 +21852,8 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
 "fuP" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/stairs/north,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "fuQ" = (
 /obj/structure/rack,
@@ -21743,15 +22074,6 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
-"fxs" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/newspaper,
-/obj/item/food/baguette,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/jazzclub)
 "fxt" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 4
@@ -21891,10 +22213,14 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights/community)
 "fyW" = (
-/obj/structure/table/wood,
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "fyY" = (
 /obj/structure/table,
@@ -21933,9 +22259,9 @@
 /turf/open/misc/grass,
 /area/vtm/outside/forest)
 "fzA" = (
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/stairs/west,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "fzC" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/wood/smooth/old,
@@ -22025,10 +22351,6 @@
 "fAu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 1
 	},
 /obj/structure/curtain/cloth/fancy/mechanical{
 	id = 2005
@@ -22196,6 +22518,19 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/forest)
+"fCn" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/obj/structure/chair/sofa/corp/corner{
+	color = "#36454F";
+	dir = 8
+	},
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "fCo" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/pallet,
@@ -22777,12 +23112,18 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop/flower_shop)
 "fJy" = (
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/table/wood/fancy/red,
+/obj/structure/bedsheetbin/basket,
+/obj/item/rag{
+	pixel_y = 7;
+	pixel_x = 10
+	},
+/obj/item/rag{
+	pixel_y = 7;
+	pixel_x = 10
+	},
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "fJG" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -23351,10 +23692,13 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "fQI" = (
-/obj/structure/chair/darkpack{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
 	},
-/turf/open/floor/wood/old,
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "fQP" = (
 /turf/open/floor/plating/asphalt,
@@ -23405,8 +23749,11 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f3)
 "fRj" = (
-/turf/open/openspace,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "fRk" = (
 /obj/effect/decal/graffiti/large,
 /turf/open/floor/plating/sidewalk,
@@ -23812,6 +24159,12 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/park)
+"fXe" = (
+/obj/effect/turf_decal/bordur{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/unionsquare)
 "fXf" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -23837,12 +24190,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
-"fXp" = (
-/obj/structure/table,
-/obj/item/newspaper,
-/obj/item/food/baguette,
-/turf/open/floor/plating/roofwalk/cobblestones,
-/area/vtm/interior/jazzclub)
 "fXv" = (
 /obj/structure/vampdoor/reinf{
 	dir = 4;
@@ -23907,6 +24254,10 @@
 	},
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/shop/otolleys)
+"fYo" = (
+/obj/structure/hedge,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "fYz" = (
 /obj/structure/table,
 /obj/machinery/light/prince/directional/west,
@@ -24067,27 +24418,6 @@
 /obj/structure/platform/lowwall/rich/old/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/hotel)
-"gaV" = (
-/obj/structure/vampdoor/wood{
-	dir = 8;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "Ventrue Office"
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "gaZ" = (
 /obj/structure/bed,
 /obj/machinery/camera/directional/north{
@@ -24105,14 +24435,6 @@
 /obj/effect/landmark/start/darkpack/law_enforcement/fbi,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/fed)
-"gbb" = (
-/obj/effect/decal/wallpaper/red/low,
-/obj/structure/window/reinforced/tinted/spawner/directional/south{
-	max_integrity = 1000000
-	},
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/jazzclub)
 "gbe" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/directional/north,
@@ -24350,8 +24672,11 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior)
 "geL" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/chair/wood/darkpack{
+	dir = 4
+	},
+/obj/machinery/light/prince/directional/west,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "geM" = (
 /obj/structure/closet,
@@ -24475,7 +24800,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "ggx" = (
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 6
@@ -24519,26 +24844,6 @@
 /obj/item/stack/dollar/hundred,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/bianchiBank)
-"ggM" = (
-/obj/structure/vampdoor/wood{
-	dir = 8;
-	lock_id = "primVentrue";
-	lockpick_difficulty = 16;
-	name = "board chair's quarters";
-	locked = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/door/access/primogen_ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/ten,
-/obj/effect/mapping_helpers/door/lock_difficulty/ten,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "ggO" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/toilet,
@@ -25030,11 +25335,6 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
-"gmo" = (
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/machinery/light/prince/directional/south,
-/turf/open/floor/carpet/green,
-/area/vtm/interior/jazzclub)
 "gmr" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
@@ -25251,14 +25551,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f4)
-"gpI" = (
-/obj/effect/decal/wallpaper/gold/low,
-/obj/structure/curtain/cloth/fancy/mechanical/luxurious{
-	id = "ventrueprim"
-	},
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "gpO" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/city/plating_mono,
@@ -25346,30 +25638,17 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/cog/pantry)
-"gqU" = (
-/obj/structure/chair/sofa/corp/left{
-	alpha = 225;
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "gqV" = (
 /obj/effect/decal/cleanable/litter,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "gro" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/directional/west,
-/obj/effect/decal/cleanable/litter,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "grt" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/theatre)
@@ -25394,10 +25673,9 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "grI" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/jazzclub)
 "grJ" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -25772,10 +26050,10 @@
 "gwI" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"gxo" = (
-/mob/living/carbon/human/npc/walkby,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+"gxr" = (
+/obj/structure/rack/tall/store_shelf_metal,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "gxu" = (
 /obj/effect/landmark/npcwall,
 /obj/item/cigbutt,
@@ -25902,10 +26180,6 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
-"gyX" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "gzc" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/city/plating_mono,
@@ -25959,6 +26233,12 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/gunshop)
+"gzA" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "gzB" = (
 /obj/structure/gargoyle{
 	dir = 8
@@ -25977,22 +26257,6 @@
 	},
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
-"gzE" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 14;
-	name = "board room"
-	},
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "gzP" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -26066,20 +26330,10 @@
 /turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/museum)
 "gBs" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/effect/turf_decal/siding/wood/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 6
-	},
-/obj/item/instrument/recorder,
-/obj/item/instrument/saxophone,
-/obj/item/instrument/trombone,
-/obj/structure/table/wood/fancy/black,
-/obj/item/instrument/trumpet,
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "gBv" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -26411,6 +26665,16 @@
 	},
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
+"gEX" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
+"gFf" = (
+/obj/machinery/light/prince/directional/south,
+/turf/open/floor/plating/sidewalk/rich,
+/area/vtm/outside/park)
 "gFj" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -26519,6 +26783,37 @@
 /obj/effect/landmark/start/darkpack/hospital/clinic_guard,
 /turf/open/floor/city/clinic,
 /area/vtm/interior/clinic)
+"gGD" = (
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 3;
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 3;
+	pixel_x = 8
+	},
+/obj/structure/table/wood/fancy/purple,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "gGP" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -26563,19 +26858,13 @@
 /turf/closed/wall/vampwall/city,
 /area/vtm/interior)
 "gHb" = (
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/structure/chair/sofa/corp/right{
+	color = "#36454F"
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "gHe" = (
 /obj/structure/table/wood/fancy/black,
@@ -26607,7 +26896,7 @@
 	},
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "gHD" = (
 /obj/structure/closet/cabinet,
 /obj/item/ammo_box/darkpack/c12g,
@@ -26709,6 +26998,23 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
+"gIG" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/obj/structure/platform/lowwall/rich,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/wine{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/bottle/whiskey,
+/obj/item/reagent_containers/cup/glass/bottle/maltliquor{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "gIJ" = (
 /turf/open/floor/wood/old,
 /area/vtm/outside/pacificheights/forest)
@@ -26757,6 +27063,15 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/church/haven)
+"gJj" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/obj/structure/railing/darkpack/metal{
+	dir = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "gJk" = (
 /obj/structure/vampdoor/wood{
 	dir = 8;
@@ -26825,6 +27140,10 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police/fed)
+"gJA" = (
+/obj/machinery/light/prince/directional/south,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "gJB" = (
 /obj/structure/table,
 /obj/structure/retail/costume_store{
@@ -26938,19 +27257,6 @@
 /mob/living/carbon/human/npc/guard,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/bianchiBank)
-"gLY" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 14;
-	name = "board room"
-	},
-/obj/effect/mapping_helpers/door/bash_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/jazzclub)
 "gMb" = (
 /obj/structure/vampdoor/old{
 	dir = 4
@@ -27043,12 +27349,6 @@
 /obj/structure/flora/tree/vamp/pine,
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
-"gNe" = (
-/obj/effect/turf_decal/bordur{
-	dir = 8
-	},
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "gNh" = (
 /obj/effect/landmark/npcwall,
 /obj/machinery/light/floor/lamppost/sidewalk,
@@ -27106,8 +27406,8 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/graveyard)
 "gOj" = (
-/turf/open/floor/city/toilet,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "gOl" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/darkpack,
@@ -27277,9 +27577,12 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/gummaguts)
 "gQi" = (
-/obj/structure/table/glass,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/jazzclub)
 "gQo" = (
 /obj/effect/landmark/npcwall,
 /turf/open/misc/beach/vamp,
@@ -27713,11 +28016,6 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/six,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
-"gVg" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "gVr" = (
 /obj/machinery/light/directional/west,
 /obj/structure/chair/wood{
@@ -27962,12 +28260,6 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
-"gYM" = (
-/obj/structure/chair/comfy/black{
-	name = "Praetor's Chair"
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "gYN" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/occult/artifact,
@@ -28275,6 +28567,12 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"hcu" = (
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "hcA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/qm{
@@ -28336,8 +28634,8 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/open/floor/city/toilet,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "hdn" = (
 /obj/structure/rack/food,
 /turf/open/floor/wood/smooth/old,
@@ -28364,10 +28662,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
-"hdD" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/jazzclub)
 "hdE" = (
 /obj/structure/vampdoor/reinf{
 	dir = 8;
@@ -28473,7 +28767,7 @@
 	},
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "hfp" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/carpet/darkpack/blacksilver,
@@ -28500,10 +28794,8 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/vjanitor)
 "hfC" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/turf/open/floor/carpet/green,
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "hfK" = (
 /obj/machinery/light/directional/south,
@@ -28635,7 +28927,8 @@
 /area/vtm/outside/pacificheights/community)
 "hhB" = (
 /obj/effect/landmark/navigate_destination,
-/turf/open/floor/carpet/red,
+/obj/effect/landmark/npcwall,
+/turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/jazzclub)
 "hhD" = (
 /obj/effect/turf_decal/siding/white,
@@ -28727,19 +29020,13 @@
 /obj/item/reagent_containers/cup/glass/bottle/champagne,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
-"hir" = (
-/obj/item/newspaper,
-/obj/structure/table/wood/fancy/blue,
-/obj/item/food/baguette,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/jazzclub)
 "hiu" = (
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/church)
 "hiy" = (
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "hiL" = (
 /obj/structure/hedge,
 /obj/structure/railing{
@@ -28959,29 +29246,6 @@
 	},
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
-"hlM" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/item/statuebust/hippocratic{
-	anchored = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "hlP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/pallet,
@@ -28999,32 +29263,14 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop/music_store)
 "hlZ" = (
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "hmb" = (
 /obj/structure/reagent_dispensers/cleaningfluid,
 /turf/open/floor/plating/concrete,
@@ -29542,6 +29788,15 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
+"hsQ" = (
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/structure/chair/sofa/corp/right{
+	color = "#36454F";
+	dir = 1
+	},
+/obj/machinery/light/prince/directional/south,
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "hsR" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 8
@@ -29634,11 +29889,6 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
-"htZ" = (
-/obj/effect/decal/wallpaper/paper/rich,
-/obj/structure/noticeboard,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
 "huh" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/vampire/bogatyr,
@@ -29703,6 +29953,27 @@
 /obj/item/radio,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic/haven)
+"huY" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/decal/painting/second{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
+	},
+/obj/item/kirbyplants/darkpack/plant2{
+	pixel_x = 5;
+	pixel_y = 15
+	},
+/obj/item/kirbyplants/darkpack/plant5{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "hvg" = (
 /obj/structure/statue/sandstone/venus,
 /turf/open/floor/wood/smooth/old,
@@ -29903,11 +30174,14 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/restricted)
 "hye" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "hyl" = (
 /obj/effect/decal/graffiti,
 /obj/structure/closet/crate/dumpster,
@@ -29959,10 +30233,11 @@
 /obj/machinery/light/directional/north,
 /obj/effect/decal/shadow,
 /turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm)
 "hzq" = (
+/obj/effect/decal/support,
 /turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm)
 "hzG" = (
 /obj/structure/stairs/west,
 /obj/structure/railing{
@@ -29976,8 +30251,16 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "hzQ" = (
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table/wood,
+/obj/item/folder/blue{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/item/folder/blue{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "hzY" = (
 /obj/machinery/light/directional/north,
@@ -30016,12 +30299,8 @@
 /area/vtm/interior/glasswalker)
 "hAj" = (
 /obj/effect/decal/shadow,
-/obj/effect/decal/support,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/water,
+/obj/item/food/grown/flower/rose,
+/turf/open/water/hot_spring,
 /area/vtm/interior/jazzclub)
 "hAp" = (
 /obj/effect/turf_decal/bordur{
@@ -30037,21 +30316,6 @@
 /obj/effect/turf_decal/siding/wood/dark,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
-"hAs" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4;
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/jazzclub)
 "hAG" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -30106,10 +30370,11 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm/outside/pacificheights/forest)
 "hBI" = (
-/obj/structure/table,
-/obj/item/newspaper,
-/obj/item/food/baguette,
-/turf/open/floor/wood/ornate,
+/obj/effect/decal/painting/third{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "hBM" = (
 /obj/structure/hydrant,
@@ -30135,6 +30400,24 @@
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/anarch)
+"hBT" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/reagent_containers/cup/glass/bottle/wine,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "hBU" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/bordur,
@@ -30208,6 +30491,15 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/smoke_shop)
+"hCR" = (
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "hCW" = (
 /obj/structure/rack,
 /obj/item/assembly/infra,
@@ -30258,14 +30550,6 @@
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/ghetto)
-"hDi" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/vampire_computer,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
 "hDp" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -30278,6 +30562,11 @@
 /obj/structure/chair/darkpack/red,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
+"hDs" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "hDt" = (
 /obj/effect/decal/cleanable/trash,
 /obj/structure/bed/maint{
@@ -30301,11 +30590,9 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/glasswalker)
 "hDv" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/carpet/purple,
+/obj/structure/chair/stool/bar/darkpack/blue,
+/obj/effect/turf_decal/siding/wood/dark/end,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "hDw" = (
 /obj/effect/turf_decal/darkpack/dirt{
@@ -30362,12 +30649,10 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/salubri)
-"hDZ" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
+"hDY" = (
+/obj/structure/railing,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "hEe" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -30455,10 +30740,6 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/ten,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
-"hEK" = (
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "hEQ" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/tree/vamp,
@@ -30528,7 +30809,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "hGB" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
@@ -30548,9 +30829,22 @@
 /turf/open/floor/iron/large,
 /area/vtm/interior/endron_facility/restricted)
 "hGK" = (
-/obj/structure/table/modern,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
+"hGQ" = (
+/obj/effect/turf_decal/bordur{
+	dir = 9
+	},
+/obj/effect/decal/support,
+/obj/effect/turf_decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "hGY" = (
 /obj/structure/retail/black_market,
 /obj/structure/table/wood,
@@ -30611,33 +30905,14 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/park)
 "hHI" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
 	},
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "hHK" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 1
@@ -30739,7 +31014,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "hJw" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -30747,8 +31022,16 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "hJz" = (
-/obj/fusebox,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/wallpaper/stone/low/tilt{
+	dir = 4
+	},
+/obj/effect/decal/wallpaper/stone/low/tilt{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/stairs/black{
+	dir = 8
+	},
 /area/vtm/interior/jazzclub)
 "hJB" = (
 /obj/effect/decal/pallet,
@@ -30824,12 +31107,6 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/shop/arts)
-"hKq" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/roofwalk/cobblestones,
-/area/vtm/interior/jazzclub)
 "hKx" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south{
 	max_integrity = 1000000
@@ -30961,13 +31238,6 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm/outside/park)
-"hMn" = (
-/obj/structure/table/wood,
-/obj/structure/curtain/bounty,
-/obj/effect/decal/wallpaper/paper/rich/low,
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "hMy" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -31288,27 +31558,6 @@
 	},
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer/nosferatu_town)
-"hQn" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/prince/directional/north,
-/obj/effect/turf_decal/siding/white,
-/obj/item/statuebust{
-	anchored = 1
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "hQo" = (
 /obj/structure/railing{
 	pixel_y = -10
@@ -31581,6 +31830,14 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"hUz" = (
+/obj/structure/platform/lowwall/rich,
+/obj/item/reagent_containers/cup/glass/trophy/gold_cup{
+	pixel_y = 13
+	},
+/obj/machinery/light/prince/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "hUI" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -31609,10 +31866,12 @@
 /turf/open/misc/dirt,
 /area/vtm)
 "hVb" = (
-/obj/effect/decal/wallpaper/gold/alt,
-/obj/structure/noticeboard,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/machinery/light/prince/directional/north,
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "hVg" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -31637,16 +31896,21 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
 "hVz" = (
-/obj/structure/closet/secure_closet/freezer,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/cup/glass/baggie/meth/cocaine,
-/obj/item/reagent_containers/cup/glass/baggie/meth,
-/obj/item/storage/box/aquarium_props,
-/obj/item/reagent_containers/blood/a_plus,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/clothing/suit/vampire/slickbackcoat,
+/obj/item/clothing/suit/vampire/fancy_gray,
+/obj/item/clothing/mask/vampire/venetian_mask/fancy,
+/obj/structure/closet/cabinet,
+/obj/machinery/light/prince/directional/north,
+/obj/item/clothing/under/vampire/rich,
+/obj/item/clothing/under/vampire/ventrue,
+/obj/item/clothing/under/vampire/ventrue/female,
+/obj/item/clothing/under/vampire/suit,
+/obj/item/clothing/under/vampire/suit/female,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "hVC" = (
 /obj/structure/table,
 /obj/vampire_computer{
@@ -31654,10 +31918,38 @@
 	},
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/techshop)
+"hVI" = (
+/obj/structure/hedge{
+	pixel_y = 6
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_yw/style_random{
+	pixel_y = 10
+	},
+/obj/structure/flora/bush/lavendergrass/style_random{
+	pixel_y = 13
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "hVQ" = (
-/obj/effect/decal/wallpaper/gold/alt,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "hVR" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -31684,6 +31976,12 @@
 /obj/machinery/vending/cola/blue,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
+"hWq" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "hWu" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -31707,15 +32005,6 @@
 	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
-"hWR" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/jazzclub)
 "hWS" = (
 /obj/structure/chair/pew{
 	dir = 4
@@ -31823,12 +32112,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/clothing_store)
 "hYC" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
 	},
-/obj/structure/vampdoor/wood,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "hYG" = (
 /obj/fusebox,
@@ -31881,11 +32172,6 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/chantry)
-"hZa" = (
-/obj/structure/platform/lowwall/rich/window,
-/obj/machinery/light/directional/north,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/jazzclub)
 "hZf" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/city/toilet,
@@ -32105,6 +32391,13 @@
 /obj/structure/stairs/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
+"icl" = (
+/obj/effect/turf_decal/bordur{
+	dir = 1
+	},
+/obj/structure/roofstuff/vent_end,
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "icm" = (
 /obj/structure/table,
 /obj/item/chair,
@@ -32215,8 +32508,11 @@
 /area/vtm/outside/pacificheights/community)
 "iee" = (
 /obj/effect/decal/wallpaper/gold,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "ieg" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -32254,26 +32550,6 @@
 /obj/machinery/sprinkler,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/bubway)
-"ieO" = (
-/obj/structure/vampdoor/wood{
-	dir = 8;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "Ventrue Office"
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "ieW" = (
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plating/rough/cave,
@@ -32282,10 +32558,14 @@
 /turf/open/openspace,
 /area/vtm/interior/salubri)
 "ieZ" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "ifc" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
@@ -32538,13 +32818,6 @@
 /obj/structure/hedge,
 /turf/open/misc/grass,
 /area/vtm/outside/financialdistrict)
-"iit" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "iiu" = (
 /turf/open/floor/plating/canal,
 /area/vtm/interior/endron_facility/plant)
@@ -32793,7 +33066,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "imu" = (
 /obj/effect/landmark/npcbeacon,
@@ -32938,6 +33211,12 @@
 	},
 /turf/open/floor/wood/herring,
 /area/vtm/interior/shop/clothing_store)
+"ior" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "iot" = (
 /obj/structure/vampipe{
 	pixel_y = 32
@@ -33073,6 +33352,10 @@
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/wood/herring,
 /area/vtm/interior/shop/clothing_store)
+"iqw" = (
+/obj/structure/musician/piano,
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "iqx" = (
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/wood/smooth/old,
@@ -33122,7 +33405,7 @@
 "irn" = (
 /obj/item/smartphone/payphone,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "irv" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -33133,10 +33416,23 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/bianchiBank)
 "irE" = (
-/obj/structure/chair/plastic/darkpack{
-	dir = 8
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
 	},
-/turf/open/floor/wood/ornate,
+/obj/item/kirbyplants/darkpack/random{
+	pixel_x = -14;
+	pixel_y = 5
+	},
+/obj/item/kirbyplants/darkpack/random{
+	pixel_x = -12;
+	pixel_y = 15
+	},
+/obj/item/kirbyplants/darkpack/random{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "irI" = (
 /obj/structure/coclock/grandpa,
@@ -33192,18 +33488,23 @@
 /obj/structure/vampdoor/old,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/mansion)
+"isj" = (
+/obj/structure/hedge,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "isk" = (
 /obj/effect/turf_decal/darkpack/grass,
 /obj/effect/turf_decal/darkpack/grass/corner,
 /turf/open/misc/dirt,
 /area/vtm)
 "isx" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "isy" = (
 /obj/effect/decal/cleanable/litter,
 /obj/effect/decal/cleanable/cardboard,
@@ -33470,12 +33771,6 @@
 "ivq" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm)
-"ivu" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/jazzclub)
 "ivz" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 4
@@ -33590,15 +33885,6 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
-"ixc" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/musician/piano{
-	icon_state = "piano"
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "ixh" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/shop/otolleys)
@@ -33764,10 +34050,10 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/community)
 "iAj" = (
-/obj/structure/chair/comfy/darkpack{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "iAk" = (
 /obj/structure/table/wood,
@@ -33981,8 +34267,8 @@
 /area/vtm/interior/tzimisce_manor)
 "iCG" = (
 /obj/machinery/light/prince/directional/south,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "iCH" = (
 /obj/machinery/hydroponics/simple/plastic,
 /obj/effect/turf_decal/weather/dirt{
@@ -34429,11 +34715,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"iIJ" = (
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/machinery/light/prince/directional/south,
-/turf/open/floor/mineral/plastitanium,
-/area/vtm/interior/jazzclub)
 "iIL" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -34767,14 +35048,25 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/vjanitor)
+"iNu" = (
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "iNG" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/banu/haven)
 "iNI" = (
-/obj/effect/decal/wallpaper/paper/rich,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy/black,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter/empty,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "iNK" = (
 /obj/structure/chair/plastic/darkpack{
 	dir = 4
@@ -34876,6 +35168,12 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
+"iOM" = (
+/obj/effect/decal/painting{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "iPi" = (
 /obj/machinery/sprinkler/area_managed,
 /obj/effect/turf_decal/siding/white,
@@ -34898,6 +35196,11 @@
 "iPt" = (
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
+"iPK" = (
+/obj/structure/chair/wood/darkpack/red,
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior/theatre)
 "iPO" = (
 /obj/structure/railing/darkpack/metal/industrial/solo{
 	dir = 1
@@ -34971,23 +35274,9 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "iQJ" = (
-/obj/structure/vampdoor/wood{
-	dir = 8;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "Ventrue Office"
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "iQL" = (
 /obj/structure/vampdoor/simple,
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
@@ -35285,6 +35574,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
+"iTO" = (
+/obj/effect/turf_decal/siding/wood/dark/end,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "iTQ" = (
 /obj/effect/decal/graffiti,
 /obj/effect/turf_decal/stripes/white/line{
@@ -35362,16 +35655,13 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
 "iUJ" = (
-/obj/effect/decal/wallpaper/paper/rich,
-/obj/effect/decal/wallpaper/paper/rich,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
-"iUL" = (
-/obj/structure/chair/darkpack{
-	dir = 1
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood/old,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/jazzclub)
 "iUY" = (
 /obj/structure/railing{
@@ -35421,6 +35711,24 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
+"iVt" = (
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
+"iVz" = (
+/obj/structure/railing/wooden_fence{
+	dir = 1;
+	pixel_y = 10
+	},
+/obj/structure/aquarium/prefilled,
+/obj/structure/platform/lowwall/rich,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "iVD" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -35527,6 +35835,11 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/mansion)
+"iWA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/directional/west,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/jazzclub)
 "iWE" = (
 /obj/structure/vampdoor/reinf{
 	dir = 8
@@ -35560,11 +35873,6 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
-"iWU" = (
-/obj/structure/chair/comfy/darkpack,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "iXd" = (
 /obj/item/cigbutt,
 /turf/open/floor/plating/rough/cave,
@@ -35659,9 +35967,15 @@
 /area/vtm/interior/library)
 "iYl" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/decal/carpet{
+	icon_state = "rug_blue";
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 4
+	},
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "iYp" = (
 /obj/structure/vampipe{
@@ -35669,6 +35983,11 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/sewer)
+"iYr" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "iYD" = (
 /obj/structure/table,
 /obj/item/gun/ballistic/shotgun/vampire,
@@ -35783,7 +36102,7 @@
 	},
 /obj/machinery/light/dim/directional/east,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "jaM" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/city/plating_stone,
@@ -36004,7 +36323,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "jdR" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/hedge,
@@ -36038,10 +36357,6 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/financialdistrict)
-"jeD" = (
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "jeG" = (
 /obj/fusebox,
 /turf/open/floor/plating/rough,
@@ -36169,7 +36484,7 @@
 /obj/machinery/light/dim/directional/east,
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "jgw" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -36277,7 +36592,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "jis" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -36327,15 +36642,6 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
-"jji" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/rack/food{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/jazzclub)
 "jjt" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcbeacon,
@@ -36413,20 +36719,12 @@
 	},
 /area/vtm)
 "jjV" = (
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 14;
-	name = "board room"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
+/obj/structure/vampdoor/wood,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
 /obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/jazzclub)
 "jjW" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/grass,
@@ -36469,13 +36767,6 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/outside/pacificheights/forest)
-"jkS" = (
-/obj/structure/chair/sofa/corp/left{
-	alpha = 225;
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "jkT" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer)
@@ -36572,7 +36863,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "jlM" = (
 /obj/item/kirbyplants/darkpack/random,
 /obj/structure/sign/flag/usa/directional/north,
@@ -36695,15 +36986,15 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf/ghetto)
 "jnd" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/siding/white{
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/dark{
 	dir = 1
 	},
-/obj/machinery/light/prince/directional/north,
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "jnf" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/pallet,
@@ -36799,12 +37090,6 @@
 /obj/structure/closet/secure_closet/freezer/commercial,
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/grocery)
-"joQ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "joS" = (
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/plating/sidewalk,
@@ -36948,18 +37233,19 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"jqY" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "jro" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/mannitol,
 /obj/item/storage/pill_bottle/mannitol,
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
-"jrs" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plating/roofwalk/cobblestones,
-/area/vtm/interior/jazzclub)
 "jrx" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/garbage{
@@ -37106,21 +37392,6 @@
 	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
-"jtC" = (
-/obj/item/ammo_box/darkpack/c556/incendiary,
-/obj/structure/guncase,
-/obj/item/ammo_box/magazine/darkpack556,
-/obj/item/ammo_box/magazine/darkpack556,
-/obj/item/ammo_box/magazine/darkpack556,
-/obj/item/ammo_box/darkpack/c556,
-/obj/structure/curtain/bounty{
-	icon_state = "bounty-closed";
-	open = 0
-	},
-/obj/item/wirecutters,
-/obj/item/gun/ballistic/automatic/darkpack/ar15,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "jtE" = (
 /obj/effect/decal/pallet,
 /obj/effect/decal/cleanable/cardboard,
@@ -37224,29 +37495,44 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
 "jus" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
+/obj/structure/table/countertop/black,
+/obj/item/plate{
+	pixel_y = 9
 	},
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/item/plate{
+	pixel_y = 9
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
+/obj/item/plate{
+	pixel_y = 9
 	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
+/obj/item/plate{
+	pixel_y = 9
 	},
-/obj/structure/railing{
-	dir = 4
+/obj/item/plate{
+	pixel_y = 9
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/item/plate{
+	pixel_y = 9
 	},
-/obj/structure/railing{
-	dir = 4
+/obj/item/plate{
+	pixel_y = 4
 	},
-/turf/open/floor/wood/old,
+/obj/item/plate{
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_y = 4
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "jut" = (
 /obj/structure/vampdoor/simple{
@@ -37258,10 +37544,6 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
-"juB" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/jazzclub)
 "juM" = (
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/endron_facility/restricted)
@@ -37332,10 +37614,6 @@
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
-"jvR" = (
-/obj/effect/decal/cleanable/litter,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "jvX" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 4
@@ -37389,11 +37667,6 @@
 /obj/structure/vampdoor/simple,
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
-"jwG" = (
-/obj/effect/decal/wallpaper/gold,
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "jwO" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/turf_decal/weather/dirt{
@@ -37474,7 +37747,11 @@
 /turf/open/misc/grass,
 /area/vtm)
 "jxM" = (
-/turf/open/floor/city/toilet,
+/obj/structure/railing/wooden_fence{
+	dir = 6
+	},
+/obj/structure/chair/stool/bar/darkpack/black,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "jxN" = (
 /obj/structure/table/wood,
@@ -37713,15 +37990,19 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/clothing_store)
 "jAQ" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/item/lighter,
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_x = 2;
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/siding/white,
-/obj/structure/railing{
-	pixel_y = -2
+/obj/structure/table/wood/fancy/red,
+/obj/effect/decal/carpet{
+	icon_state = "rug_red";
+	pixel_x = 8;
+	pixel_y = -6
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "jAW" = (
 /obj/structure/chair/sofa/middle/brown{
 	dir = 4
@@ -37877,6 +38158,21 @@
 /obj/effect/landmark/npcbeacon/directed,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/church)
+"jCx" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = 5
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "jCB" = (
 /obj/effect/turf_decal/siding/wood/dark/corner{
 	dir = 4
@@ -37899,6 +38195,10 @@
 /obj/structure/flora/grass/short/style_random,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"jCX" = (
+/obj/machinery/oven/range,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "jDc" = (
 /obj/structure/table,
 /obj/item/vampire_stake,
@@ -38063,6 +38363,14 @@
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry/basement)
+"jFc" = (
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/structure/dresser{
+	pixel_y = 16;
+	density = 0
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "jFg" = (
 /obj/structure/chair/darkpack{
 	dir = 4
@@ -38224,10 +38532,6 @@
 "jHi" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/chantry)
-"jHq" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/misc/grass,
-/area/vtm/interior/library)
 "jHt" = (
 /obj/effect/decal/coastline/corner{
 	dir = 4
@@ -38243,17 +38547,14 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/supply)
 "jHS" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
+/obj/structure/railing{
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "jIa" = (
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/mineral/plastitanium,
@@ -38383,6 +38684,15 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"jJW" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "jJZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38418,30 +38728,12 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "jKA" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
 	},
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "jKB" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/flare/candle/infinite,
@@ -38457,10 +38749,6 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/granite/black,
 /area/vtm/outside/park)
-"jKJ" = (
-/obj/structure/chair/office/darkpack/black,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "jKL" = (
 /obj/effect/decal/pallet,
 /obj/effect/decal/cleanable/cardboard,
@@ -38651,6 +38939,11 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/misc/dirt,
 /area/vtm/outside/fishermanswharf)
+"jMQ" = (
+/obj/machinery/light/prince/directional/north,
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "jMU" = (
 /obj/structure/bed,
 /obj/machinery/light/prince/broken/directional/north,
@@ -38817,6 +39110,18 @@
 	},
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
+"jPt" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/support,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/hedge,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "jPv" = (
 /obj/structure/sink/directional/west,
 /obj/effect/decal/cleanable/cardboard,
@@ -38972,12 +39277,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop/otolleys)
-"jQM" = (
-/obj/structure/curtain/bounty,
-/obj/effect/decal/wallpaper/paper/rich/low,
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "jQN" = (
 /obj/effect/turf_decal/bordur{
 	dir = 9
@@ -39030,13 +39329,6 @@
 /obj/effect/decal/pallet,
 /turf/open/floor/wood/old,
 /area/vtm/interior/sewer/nosferatu_town)
-"jRt" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/old,
-/area/vtm/interior/jazzclub)
 "jRG" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -39094,10 +39386,6 @@
 /obj/structure/food_cart,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
-"jST" = (
-/obj/machinery/light/prince/directional/north,
-/turf/open/openspace,
-/area/vtm/interior/millennium_tower/ventrue)
 "jSU" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
@@ -39251,6 +39539,14 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
+"jVa" = (
+/obj/structure/chair/comfy/darkpack/dark,
+/obj/effect/landmark/start/darkpack/primogen/ventrue,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "jVd" = (
 /mob/living/carbon/human/npc/campingstore,
 /obj/structure/chair/wood/darkpack{
@@ -39466,11 +39762,11 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
-"jYC" = (
-/obj/effect/decal/wallpaper/red/low,
-/obj/effect/decal/wallpaper/red/low,
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
+"jYF" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "jYJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -39608,6 +39904,13 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"kaP" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "kaQ" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -39686,14 +39989,6 @@
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
-"kbX" = (
-/obj/effect/turf_decal/bordur{
-	dir = 8
-	},
-/obj/effect/landmark/npcbeacon,
-/obj/effect/landmark/npcability,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "kbY" = (
 /obj/structure/closet,
 /obj/item/clothing/under/vampire/pentex_executive_suit,
@@ -39873,6 +40168,12 @@
 /obj/structure/dresser,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
+"kdN" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "kdP" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -40018,6 +40319,12 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
+"kfR" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "kfS" = (
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
@@ -40027,6 +40334,44 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
+"kfY" = (
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -11
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "kgk" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 9
@@ -40097,19 +40442,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"kha" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "khg" = (
 /obj/structure/sign/flag/spain{
 	pixel_y = 29;
@@ -40162,6 +40494,23 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
+"khR" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/vampdoor/wood{
+	dir = 1;
+	lock_id = "ventrue";
+	locked = 1;
+	lockpick_difficulty = 14;
+	name = "board room"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/unlock,
+/turf/open/floor/plating/roofwalk/cobblestones,
+/area/vtm/interior/jazzclub)
 "kij" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -40304,6 +40653,12 @@
 /obj/structure/curtain,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f3)
+"kkz" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "kkH" = (
 /obj/effect/landmark/npcwall,
 /obj/structure/flora/darkpack_flower/yerba,
@@ -40446,10 +40801,12 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/caern)
 "kmv" = (
-/obj/structure/curtain/bounty,
 /obj/structure/platform/lowwall/rich/window,
+/obj/structure/curtain/bounty{
+	pixel_y = 8
+	},
 /turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "kmy" = (
 /obj/structure/flora/grass/green,
 /obj/machinery/light/warm/directional/west,
@@ -40577,7 +40934,7 @@
 	},
 /obj/structure/vampfence/corner/rich,
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "kno" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
@@ -40745,6 +41102,15 @@
 /obj/effect/landmark/start/darkpack/law_enforcement/sergeant,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"kqs" = (
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/structure/chair/sofa/corp/left{
+	dir = 1;
+	color = "#36454F"
+	},
+/obj/machinery/light/prince/directional/south,
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "kqF" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small/directional/west,
@@ -40820,13 +41186,6 @@
 /obj/item/knife/vamp,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
-"krS" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "krV" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/old,
@@ -40854,15 +41213,6 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
-"kse" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "ksi" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/curtain,
@@ -41091,7 +41441,7 @@
 "kvw" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "kvF" = (
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
@@ -41185,12 +41535,6 @@
 /obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
-"kwQ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/jazzclub)
 "kwW" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 1
@@ -41226,10 +41570,14 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/baali)
 "kxk" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
 	},
-/turf/open/floor/carpet/purple,
+/obj/structure/chair/sofa/corp/corner{
+	color = "#36454F";
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "kxq" = (
 /obj/effect/decal/cleanable/garbage,
@@ -41250,7 +41598,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "kxD" = (
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/outside/financialdistrict)
@@ -41337,7 +41685,17 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
 "kza" = (
-/turf/open/floor/carpet/purple,
+/obj/structure/table/countertop/black,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "kzh" = (
 /obj/effect/decal/cleanable/cardboard,
@@ -41399,10 +41757,6 @@
 /obj/structure/lattice/pentex,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
-"kAh" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "kAm" = (
 /obj/machinery/computer/arcade/battle,
 /turf/open/floor/wood/smooth/old,
@@ -41693,6 +42047,14 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"kEs" = (
+/obj/machinery/light/prince/directional/west{
+	pixel_y = 8
+	},
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "kEw" = (
 /obj/structure/table,
 /obj/item/food/bbqribs,
@@ -41763,13 +42125,10 @@
 /turf/open/floor/light,
 /area/vtm/interior/strip)
 "kFk" = (
-/obj/item/pen/fountain/captain{
-	name = "director's fountain pen";
-	desc = "It's an expensive Oak fountain pen. The nib is quite sharp. The letter V is embossed."
-	},
-/obj/structure/table/wood/fancy/royalblue,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "kFn" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -41860,6 +42219,11 @@
 "kGl" = (
 /turf/open/water/beach/vamp/deep,
 /area/vtm/interior/cog/caern)
+"kGn" = (
+/obj/machinery/light/prince/directional/east,
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "kGu" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
@@ -42000,10 +42364,21 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "kIs" = (
-/obj/structure/chair/darkpack{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
 	},
-/turf/open/floor/wood/old,
+/obj/structure/platform/lowwall/rich,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/champagne,
+/obj/item/reagent_containers/cup/glass/bottle/curacao{
+	pixel_x = 13;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/glass/bottle/cognac{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "kIv" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -42502,9 +42877,7 @@
 	pixel_y = 6;
 	pixel_x = 0
 	},
-/obj/structure/chair/plastic{
-	pixel_y = 4
-	},
+/obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/jazzclub)
 "kOT" = (
@@ -42763,6 +43136,12 @@
 /obj/effect/decal/wallpaper/paper/green,
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior/hotel)
+"kRF" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "kRJ" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 4
@@ -42807,15 +43186,6 @@
 /obj/item/pen,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
-"kSl" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_x = 2;
-	pixel_y = 12
-	},
-/obj/item/lighter,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "kSq" = (
 /turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/bianchiBank)
@@ -42841,6 +43211,12 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/forest)
+"kSQ" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "kSR" = (
 /obj/structure/platform/lowwall/old/window,
 /turf/open/floor/plating/rough,
@@ -43036,21 +43412,34 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
 "kUO" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/effect/turf_decal/siding/white{
+	dir = 4
 	},
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "kUU" = (
 /obj/structure/flora/rock/stalagmite,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"kVf" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 6
+	},
+/obj/item/instrument/recorder,
+/obj/item/instrument/saxophone,
+/obj/item/instrument/trombone,
+/obj/structure/table/wood/fancy/black,
+/obj/item/instrument/trumpet,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "kVm" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/plating/rough,
@@ -43091,13 +43480,6 @@
 "kVF" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/interior/endron_facility)
-"kVN" = (
-/obj/machinery/light/prince/directional/east,
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/jazzclub)
 "kVV" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/item/cigarette/rollie,
@@ -43108,12 +43490,6 @@
 /obj/effect/turf_decal/trimline/dark_green,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/restricted)
-"kWa" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "kWd" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
@@ -43187,10 +43563,6 @@
 	},
 /turf/open/water/bloodwave,
 /area/vtm/interior/chantry/basement)
-"kWI" = (
-/obj/structure/chair/comfy/darkpack,
-/turf/open/floor/carpet/green,
-/area/vtm/interior/jazzclub)
 "kWJ" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/turf_decal/bordur{
@@ -43393,13 +43765,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"kZE" = (
-/obj/effect/turf_decal/siding/white,
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "kZH" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -43427,13 +43792,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
-"kZM" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/outside/financialdistrict)
 "kZN" = (
 /obj/effect/landmark/npcbeacon/directed,
 /obj/effect/landmark/npcactivity,
@@ -43476,10 +43835,13 @@
 /turf/open/misc/beach/vamp,
 /area/vtm/outside/northbeach)
 "lao" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/structure/railing/wooden_fence{
+	dir = 4
 	},
-/turf/open/floor/city/toilet,
+/obj/effect/decal/painting/second{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "laq" = (
 /obj/structure/fireplace,
@@ -43558,11 +43920,25 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
 "laW" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/cup/glass/bottle/rum/aged{
+	pixel_x = 8;
+	pixel_y = 18
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/reagent_containers/cup/glass/bottle/herbal_liqueur{
+	pixel_x = -1;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/cup/glass/bottle/aperitivo{
+	pixel_x = -9;
+	pixel_y = 20
+	},
+/obj/item/reagent_containers/cup/glass/bottle/aperitivo{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "lbb" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -43700,7 +44076,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "lcE" = (
 /turf/open/floor/glass,
 /area/vtm)
@@ -43719,24 +44095,19 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
 "lcY" = (
-/obj/item/clothing/suit/vampire/slickbackcoat,
-/obj/item/clothing/suit/vampire/fancy_gray,
-/obj/item/clothing/under/suit/white,
-/obj/item/clothing/under/suit/white,
-/obj/item/clothing/under/suit/burgundy,
-/obj/item/clothing/under/suit/charcoal,
-/obj/item/clothing/under/suit/black/skirt,
-/obj/item/clothing/under/rank/civilian/lawyer/purpsuit,
-/obj/item/clothing/mask/vampire/venetian_mask/fancy,
-/obj/structure/railing{
-	dir = 8
+/obj/item/ammo_box/darkpack/c556/incendiary,
+/obj/structure/guncase,
+/obj/item/ammo_box/magazine/darkpack556,
+/obj/item/ammo_box/magazine/darkpack556,
+/obj/item/ammo_box/magazine/darkpack556,
+/obj/item/ammo_box/darkpack/c556,
+/obj/item/wirecutters,
+/obj/item/gun/ballistic/automatic/darkpack/ar15,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/obj/structure/closet/cabinet,
-/obj/machinery/light/prince/directional/north,
-/obj/item/clothing/under/vampire/suit/female,
-/obj/item/clothing/under/vampire/suit,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "lcZ" = (
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
@@ -43878,13 +44249,6 @@
 /obj/structure/curtain/bounty,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
-"leS" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "leU" = (
 /obj/structure/platform/lowwall/rich/old,
 /obj/structure/gargoyle{
@@ -44145,11 +44509,13 @@
 /turf/open/misc/beach/vamp,
 /area/vtm)
 "lil" = (
-/obj/structure/railing{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/item/clothing/head/costume/crown{
+	pixel_x = 3;
+	pixel_y = 53
 	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "lio" = (
 /obj/structure/rack/clothing_hanger,
 /turf/open/floor/wood/smooth,
@@ -44227,15 +44593,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_sanctum)
 "ljE" = (
-/obj/structure/chair/plastic{
-	dir = 1;
-	name = "Seat of Shame"
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/light/directional/west,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "ljH" = (
 /obj/structure/platform/lowwall/rich/old,
 /obj/structure/gargoyle{
@@ -44295,12 +44657,6 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
-"lkL" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "lkM" = (
 /obj/effect/decal/cleanable/ash,
 /obj/item/vampire_stake,
@@ -44447,6 +44803,11 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/northbeach)
+"lnz" = (
+/obj/structure/railing/wooden_fence,
+/obj/structure/musician/piano,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "lnB" = (
 /obj/structure/vampdoor/simple{
 	lock_id = "lasombra";
@@ -44899,11 +45260,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/hotel)
-"lus" = (
-/obj/machinery/light/prince/directional/west,
-/obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "luy" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/rough,
@@ -45093,6 +45449,13 @@
 	},
 /turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
+"lxu" = (
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_y = -6;
+	pixel_x = -7
+	},
+/turf/open/openspace,
+/area/vtm)
 "lxx" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/pallet{
@@ -45133,10 +45496,14 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/old)
 "lxS" = (
-/mob/living/basic/cockroach/sewer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/obj/structure/railing/wooden_fence{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "lxT" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -45154,10 +45521,9 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
 "lxX" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/purple,
+/obj/structure/table/wood,
+/obj/structure/platform/lowwall/rich,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "lya" = (
 /obj/structure/chair/plastic/darkpack{
@@ -45174,6 +45540,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
+"lyl" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "lym" = (
 /turf/closed/wall/vampwall/city,
 /area/vtm/interior/laundromat)
@@ -45181,11 +45556,6 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f3)
-"lyp" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
 "lyz" = (
 /obj/structure/vampdoor/reinf{
 	dir = 8;
@@ -45484,6 +45854,13 @@
 /obj/effect/decal/wallpaper,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f4)
+"lDx" = (
+/obj/structure/roofstuff{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/bordur,
+/turf/open/floor/city/industrial/large,
+/area/vtm)
 "lDy" = (
 /obj/structure/railing{
 	dir = 8
@@ -45744,11 +46121,28 @@
 /obj/structure/vampfence/rich,
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
+"lGk" = (
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/computer/stockexchange{
+	name = "Luxurious stock exchange computer"
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "lGm" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
+"lGq" = (
+/obj/structure/roofstuff/vent,
+/obj/effect/turf_decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "lGA" = (
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 10
@@ -46137,7 +46531,7 @@
 "lLE" = (
 /obj/structure/ladder/manhole/down,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "lLG" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8;
@@ -46158,6 +46552,14 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf)
+"lLN" = (
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
+	},
+/obj/structure/table/wood,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "lLW" = (
 /obj/effect/turf_decal/asphaltline/yellow{
 	pixel_x = 0;
@@ -46261,11 +46663,15 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
+"lNk" = (
+/obj/effect/decal/wallpaper/red,
+/obj/effect/decal/wallpaper/blue/low,
+/turf/closed/wall/vampwall/city,
+/area/vtm/interior/theatre)
 "lNl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cardboard,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/machinery/light/prince/directional/west,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "lNm" = (
 /obj/effect/decal/coastline{
 	dir = 9
@@ -46591,6 +46997,10 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
+"lSB" = (
+/obj/effect/turf_decal/bordur,
+/turf/open/floor/plating/rough,
+/area/vtm)
 "lSE" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -46768,12 +47178,6 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/cog/caern)
-"lUz" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "lUB" = (
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 4
@@ -47005,31 +47409,6 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
-"lWG" = (
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/prince/directional/north,
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
 "lWI" = (
 /obj/structure/table/wood,
 /obj/structure/platform/lowwall/bar,
@@ -47138,10 +47517,21 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior)
+"lYo" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/old,
+/area/vtm/interior/theatre)
 "lYs" = (
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"lYz" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
+	},
+/obj/machinery/light/prince/directional/west,
+/turf/open/floor/wood/old,
+/area/vtm/interior/jazzclub)
 "lYG" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -47489,23 +47879,14 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "mdQ" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/obj/structure/railing{
 	dir = 4
 	},
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/railing{
-	pixel_y = -2
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "mdS" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 8
@@ -47680,6 +48061,13 @@
 /obj/item/ammo_box/darkpack/c44,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
+"mfU" = (
+/obj/structure/platform/lowwall/rich/window,
+/obj/structure/curtain/bounty{
+	pixel_y = 15
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "mgb" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/concrete,
@@ -47738,6 +48126,16 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/endron_facility/restricted)
+"mgs" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
+	},
+/obj/structure/chair/wood/darkpack{
+	dir = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "mgw" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/flashlight/flare/candle,
@@ -47747,12 +48145,6 @@
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
-"mgT" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "mgU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47998,6 +48390,15 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm)
+"mjW" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/structure/hedge,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "mkd" = (
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/baali)
@@ -48186,6 +48587,10 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
+"mmZ" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "mnf" = (
 /obj/structure/vampfence,
 /obj/effect/turf_decal/bordur{
@@ -48321,6 +48726,10 @@
 	},
 /turf/open/floor/iron/stairs,
 /area/vtm/interior)
+"moN" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "moQ" = (
 /obj/structure/food_cart,
 /turf/open/floor/plating/sidewalkalt,
@@ -48354,12 +48763,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop)
 "mpz" = (
-/obj/structure/chair/comfy{
-	dir = 4;
-	name = "Aedile's Seat"
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
 	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "mpC" = (
 /obj/structure/hedge,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -48475,8 +48886,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
+"mrp" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "mrB" = (
 /obj/machinery/light/floor/lamppost/sidewalk,
+/obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/jazzclub)
 "mrJ" = (
@@ -48509,6 +48926,16 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
+"mrT" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/item/instrument/accordion,
+/obj/item/instrument/piano_synth,
+/obj/item/instrument/harmonica,
+/obj/machinery/light/prince/directional/south,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "mrW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -48517,9 +48944,17 @@
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
 "mrZ" = (
-/obj/effect/landmark/npcwall,
-/obj/structure/vampdoor/wood,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/autoname,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/interior/jazzclub)
 "msa" = (
 /obj/machinery/light/directional/south,
@@ -48606,11 +49041,9 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
 "mtR" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/machinery/light/prince/directional/east,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table/countertop/black,
+/obj/machinery/microwave,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "mtU" = (
 /obj/structure/table,
@@ -48629,6 +49062,12 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/northbeach)
+"muh" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "mul" = (
 /obj/machinery/light/directional/west,
 /obj/item/clothing/neck/vampire/prayerbeads{
@@ -48680,12 +49119,25 @@
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/old)
+"muD" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "muJ" = (
 /obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/access/npc,
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
+"muK" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "muL" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -48758,10 +49210,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "mvX" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "mvY" = (
 /obj/effect/turf_decal/bordur,
@@ -48777,21 +49229,6 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/glasswalker)
-"mwh" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
-"mwm" = (
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/structure/table/wood,
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/mineral/plastitanium,
-/area/vtm/interior/jazzclub)
 "mwz" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 1
@@ -48811,14 +49248,12 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "mwB" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/lighter,
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_x = 2;
-	pixel_y = 12
+/obj/structure/chair/comfy/darkpack/darkblue,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "mwF" = (
 /turf/open/floor/iron/stairs/black{
 	dir = 4
@@ -48851,10 +49286,6 @@
 "mwS" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
-"mwZ" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "mxc" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -48914,6 +49345,17 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights)
+"mxR" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/obj/structure/chair/wood/darkpack{
+	dir = 8
+	},
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "mxS" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/turf_decal/darkpack/rough{
@@ -49091,6 +49533,13 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/ghetto)
+"mzX" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/jazzclub)
 "mzY" = (
 /obj/effect/turf_decal/bordur{
 	dir = 6
@@ -49217,6 +49666,21 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
+"mBK" = (
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/computer/stockexchange{
+	name = "Luxurious stock exchange computer"
+	},
+/obj/effect/decal/painting/third{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "mBV" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalkalt,
@@ -49488,10 +49952,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/church/haven)
-"mFl" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "mFC" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/rough,
@@ -49682,22 +50142,12 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/tzimisce_manor)
-"mIi" = (
-/obj/structure/table/glass,
-/obj/item/newspaper,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "mIj" = (
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/old)
 "mIk" = (
 /turf/open/floor/city/toilet,
 /area/vtm/interior/cog/pantry)
-"mIo" = (
-/obj/effect/decal/wallpaper/red/low,
-/obj/effect/decal/wallpaper/red,
-/turf/closed/wall/vampwall/city,
-/area/vtm/interior/jazzclub)
 "mIr" = (
 /obj/structure/vampdoor/wood,
 /obj/effect/mapping_helpers/door/access/theatre,
@@ -49900,9 +50350,27 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
 "mKD" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/closet/cabinet,
+/obj/machinery/light/prince/directional/north,
+/obj/item/clothing/under/vampire/sheriff,
+/obj/item/clothing/under/vampire/sheriff/female,
+/obj/item/clothing/under/vampire/slickback,
+/obj/item/clothing/under/vampire/prince,
+/obj/item/clothing/under/vampire/prince/female,
+/obj/item/clothing/under/vampire/gown_black,
+/obj/item/clothing/under/vampire/gown_white,
+/obj/item/clothing/suit/vampire/shawl_black,
+/obj/item/clothing/suit/vampire/shawl_white,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/item/clothing/shoes/vampire/heels,
+/obj/item/clothing/shoes/vampire/heels,
+/obj/item/clothing/shoes/vampire/heels/red,
+/obj/item/clothing/shoes/vampire/jackboots,
+/obj/item/clothing/shoes/vampire/jackboots,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "mKT" = (
 /obj/effect/decal/wallpaper,
 /turf/closed/wall/vampwall/rich/old,
@@ -49932,15 +50400,6 @@
 "mLp" = (
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/anarch/basement)
-"mLt" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "mLu" = (
 /obj/effect/decal/cleanable/trash{
 	icon_state = "trash5"
@@ -50115,18 +50574,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
-"mNC" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy/black,
-/obj/item/newspaper,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "mND" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/vampfence/corner/rich{
@@ -50265,6 +50712,13 @@
 /obj/structure/chair/office/darkpack/black,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/shop)
+"mPb" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/obj/structure/chair/wood/darkpack,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "mPc" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/dark_blue,
@@ -50340,6 +50794,12 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
+"mPU" = (
+/obj/effect/turf_decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/unionsquare)
 "mPV" = (
 /obj/effect/decal/graffiti,
 /obj/effect/decal/pallet,
@@ -50423,11 +50883,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "mQX" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 10
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "mRd" = (
 /obj/structure/table,
@@ -50504,13 +50963,16 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
 "mRK" = (
-/obj/machinery/griddle,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/item/knife/vamp,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/structure/chair/stool/bar/darkpack/blue,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
 	},
-/turf/open/floor/city/toilet,
+/obj/effect/decal/shadow,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "mRU" = (
 /obj/effect/decal/shadow{
@@ -50538,23 +51000,12 @@
 /turf/open/water,
 /area/vtm/outside/pacificheights/old)
 "mSr" = (
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 14;
-	name = "board room"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood/dark{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "mSu" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/vampire/sun,
@@ -50625,16 +51076,12 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
 "mSU" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/obj/structure/table/wood/fancy/royalblue,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "mSW" = (
 /obj/machinery/light/small/pink/directional/west,
 /turf/open/floor/carpet/darkpack/blacksilver,
@@ -50676,6 +51123,10 @@
 /obj/item/smartphone/payphone,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/financialdistrict)
+"mTu" = (
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "mTD" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
@@ -50725,6 +51176,11 @@
 /obj/effect/decal/gut_floor,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
+"mUh" = (
+/obj/structure/platform/lowwall/rich/window,
+/obj/effect/decal/wallpaper/blue/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "mUo" = (
 /obj/structure/platform/lowwall/rich/old,
 /turf/open/floor/plating/rough,
@@ -50735,6 +51191,10 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
+"mUA" = (
+/obj/machinery/light/prince/directional/north,
+/turf/open/openspace,
+/area/vtm/interior/jazzclub)
 "mUG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -50754,13 +51214,22 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/outside/fishermanswharf/lower)
-"mUW" = (
-/obj/effect/turf_decal/bordur{
-	dir = 4
+"mUX" = (
+/obj/structure/platform/lowwall/rich,
+/obj/structure/vampstatue/angel{
+	pixel_y = 26
 	},
-/obj/effect/landmark/npcability,
-/turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/obj/item/food/grown/flower/poppy/geranium,
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "mUY" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/darkpack/plant5{
@@ -51048,9 +51517,8 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/clothing_store)
 "mYc" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/turf/open/floor/carpet/lone,
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "mYi" = (
 /turf/open/floor/carpet/lone,
@@ -51460,13 +51928,6 @@
 "ndp" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/graveyard)
-"ndq" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/mineral/plastitanium,
-/area/vtm/interior/jazzclub)
 "ndy" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -51541,6 +52002,15 @@
 	},
 /turf/open/floor/city/factory,
 /area/vtm/interior/shop/smoke_shop)
+"neC" = (
+/obj/structure/railing,
+/obj/effect/decal/carpet{
+	icon_state = "rug_blue";
+	pixel_x = -2;
+	pixel_y = 17
+	},
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "neF" = (
 /obj/structure/bookcase,
 /turf/open/floor/wood/smooth,
@@ -51648,10 +52118,6 @@
 	},
 /turf/open/floor/city/industrial/large,
 /area/vtm/interior/shop/hardware_store)
-"nfF" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/turf/open/misc/grass,
-/area/vtm/interior/library)
 "nfL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -52073,11 +52539,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
-"nlw" = (
-/obj/structure/table/glass,
-/obj/item/flashlight/lamp,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "nlD" = (
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/carpet/green,
@@ -52444,14 +52905,6 @@
 "nrB" = (
 /turf/open/floor/iron/textured,
 /area/vtm/interior/endron_facility/restricted)
-"nrC" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/machinery/light/prince/directional/south,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/jazzclub)
 "nrD" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/carpet/darkpack,
@@ -52572,17 +53025,21 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/one,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/laundromat)
+"ntd" = (
+/obj/effect/turf_decal/bordur{
+	dir = 6
+	},
+/obj/structure/vampfence/corner/rich,
+/turf/open/floor/plating/sidewalk,
+/area/vtm/outside/unionsquare)
 "nte" = (
 /obj/machinery/light/directional/north,
 /turf/open/openspace,
 /area/vtm/interior)
 "ntk" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4;
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/royalblue,
+/obj/machinery/light/prince/directional/west,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "ntq" = (
 /turf/open/openspace,
@@ -52596,11 +53053,15 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/park)
 "ntz" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/fireplace{
+	dir = 4;
+	pixel_y = -17
+	},
+/obj/effect/turf_decal/siding/wideplating/end{
 	dir = 1
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/plating/sidewalk/rich,
+/area/vtm/interior/jazzclub)
 "ntD" = (
 /obj/structure/table,
 /obj/item/newspaper,
@@ -52759,6 +53220,12 @@
 	},
 /turf/open/floor/iron/small,
 /area/vtm/interior/endron_facility/restricted)
+"nvH" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "nvJ" = (
 /obj/machinery/light/red/directional/north,
 /turf/open/floor/city/toilet,
@@ -52901,6 +53368,9 @@
 /obj/effect/turf_decal/trimline/dark_green/filled,
 /turf/open/floor/iron/white/textured,
 /area/vtm/interior/endron_facility/restricted)
+"nxK" = (
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "nxL" = (
 /obj/structure/vampdoor/reinf{
 	dir = 4;
@@ -53072,10 +53542,6 @@
 /mob/living/carbon/human/npc/walkby,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
-"nAq" = (
-/obj/structure/chair/comfy/darkpack,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "nAM" = (
 /obj/effect/decal/pallet,
 /obj/structure/closet/crate/large,
@@ -53178,6 +53644,12 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower)
+"nBM" = (
+/obj/structure/platform/lowwall/rich,
+/obj/structure/aquarium/prefilled,
+/obj/effect/decal/wallpaper/red/low,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "nBP" = (
 /obj/effect/decal/graffiti,
 /obj/structure/closet/cardboard,
@@ -53636,17 +54108,13 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "nHO" = (
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/structure/chair/sofa/corp{
+	color = "#36454F"
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/old,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "nHS" = (
 /obj/structure/vampipe{
@@ -53798,8 +54266,8 @@
 /obj/structure/railing{
 	pixel_y = -2
 	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "nJF" = (
 /obj/structure/table/wood,
 /obj/item/megaphone,
@@ -54027,11 +54495,6 @@
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
-"nLV" = (
-/obj/structure/hedge,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/wood/old,
-/area/vtm/interior/jazzclub)
 "nMa" = (
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 5
@@ -54093,8 +54556,12 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/tzimisce_manor)
 "nMG" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/water,
+/obj/structure/flora/rock/darkpack{
+	pixel_x = 5;
+	pixel_y = 7;
+	density = 0
+	},
+/turf/open/water/hot_spring,
 /area/vtm/interior/jazzclub)
 "nML" = (
 /obj/effect/turf_decal/bordur{
@@ -54739,6 +55206,14 @@
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
+"nTN" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "nTU" = (
 /obj/effect/decal/wallpaper/stone/low/tilt{
 	dir = 4
@@ -54854,6 +55329,16 @@
 /obj/darkpack_car/retro/rand,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
+"nVM" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "nVQ" = (
 /obj/structure/vampdoor/simple{
 	dir = 4
@@ -54942,16 +55427,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior)
-"nWO" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/chair/plastic/darkpack{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/jazzclub)
 "nWU" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -55098,10 +55573,6 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/beach/vamp,
 /area/vtm/outside/northbeach)
-"nYH" = (
-/obj/structure/table,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
 "nYJ" = (
 /obj/machinery/light/floor/lamppost/one,
 /turf/open/floor/plating/sidewalk/old,
@@ -55131,6 +55602,13 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
+"nZd" = (
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "nZf" = (
 /obj/effect/decal/kopatich{
 	pixel_x = -20;
@@ -55217,6 +55695,14 @@
 /obj/structure/coclock,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
+"nZX" = (
+/obj/structure/mirror/directional/north,
+/obj/structure/dresser{
+	pixel_y = 16;
+	density = 0
+	},
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "oaa" = (
 /obj/machinery/light/directional/west,
 /obj/structure/chair/wood/darkpack/red{
@@ -55265,6 +55751,15 @@
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
+"oaJ" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "oaP" = (
 /obj/item/flashlight/flare/candle/infinite,
 /obj/effect/landmark/start/darkpack/forest_wolves/council,
@@ -55668,11 +56163,9 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
 "ogY" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/machinery/light/prince/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "ohh" = (
 /obj/machinery/shower/directional/west,
 /obj/machinery/light/directional/south,
@@ -55714,6 +56207,33 @@
 /obj/structure/roadsign/parking,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf)
+"ohC" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/structure/rack/tall/store_shelf_metal,
+/obj/item/storage/box/aquarium_props{
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/item/storage/box/aquarium_props{
+	pixel_x = -5;
+	pixel_y = 24
+	},
+/obj/item/storage/box/aquarium_props{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/storage/box/aquarium_props{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/storage/box/aquarium_props{
+	pixel_x = 8;
+	pixel_y = 34
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "ohE" = (
 /obj/fusebox,
 /turf/open/floor/city/church,
@@ -55826,15 +56346,6 @@
 	},
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
-"oiK" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "oiP" = (
 /obj/structure/chair/darkpack{
 	dir = 4
@@ -55857,11 +56368,14 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/techshop)
 "ojk" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "ojl" = (
 /obj/item/kirbyplants/random,
 /obj/structure/coclock,
@@ -55886,6 +56400,20 @@
 /obj/structure/roadsign/busstop,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"ojH" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 16
+	},
+/obj/structure/railing/wooden_fence{
+	dir = 1;
+	pixel_y = 10
+	},
+/obj/structure/chair/wood/darkpack,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "ojR" = (
 /obj/machinery/light/prince/broken/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -56022,6 +56550,11 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
+"olu" = (
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "olw" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/smooth,
@@ -56119,17 +56652,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"omV" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
-"omW" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "ona" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/siding/grey{
@@ -56183,6 +56705,15 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
+"onV" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "ooa" = (
 /obj/structure/railing{
 	dir = 8
@@ -56195,7 +56726,7 @@
 	},
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "oon" = (
 /obj/structure/platform/lowwall/old/window,
 /obj/structure/curtain/cloth/fancy/mechanical/luxurious{
@@ -56235,11 +56766,11 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "ooV" = (
-/obj/effect/turf_decal/siding/white{
+/obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/turf/open/floor/city/toilet,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "ooW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -56335,11 +56866,11 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/forest)
 "oqb" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/south{
-	max_integrity = 1000000
-	},
 /obj/effect/decal/wallpaper/red/low,
 /obj/structure/platform/lowwall/rich/window,
+/obj/structure/window/reinforced/tinted/spawner/directional/south{
+	opacity = 1
+	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/jazzclub)
 "oqd" = (
@@ -56410,25 +56941,12 @@
 /turf/open/misc/beach/vamp,
 /area/vtm/outside/northbeach)
 "oqC" = (
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
+/obj/structure/table/countertop/black,
+/obj/item/clothing/suit/toggle/chef,
+/obj/item/clothing/head/utility/chefhat,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/item/clothing/suit/apron/chef,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "oqD" = (
 /obj/structure/chair/comfy/darkpack/dark,
@@ -56689,30 +57207,11 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/old)
 "ouf" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
+/obj/structure/chair/wood/darkpack/red{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	pixel_y = -2
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "ouj" = (
 /obj/structure/chair/wood/darkpack{
 	dir = 4
@@ -56723,6 +57222,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
+"oum" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/table/wood,
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "oun" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -56799,7 +57304,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "ovt" = (
 /obj/machinery/hydroponics/simple/plastic,
 /obj/effect/turf_decal/weather/dirt{
@@ -56833,15 +57338,14 @@
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/shop/clothing_store)
 "ovK" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/storage/briefcase/secure{
-	pixel_y = -10
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table/wood/fancy/red,
+/obj/item/documents/nanotrasen{
+	desc = "A handful of papers detailing the profits and losses of various Ventrue-owned businesses in the city.";
+	name = "profit and loss reports"
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "ovR" = (
 /obj/structure/railing/darkpack/metal{
 	dir = 9
@@ -56922,11 +57426,6 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
-"owH" = (
-/obj/structure/table/glass,
-/obj/vampire_computer,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "owL" = (
 /turf/open/floor/iron/stairs/left,
 /area/vtm)
@@ -57015,10 +57514,11 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/ghetto)
 "oxU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "oxW" = (
 /obj/machinery/light/prince/directional/north,
 /obj/structure/table/wood/fancy,
@@ -57125,15 +57625,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
-"ozt" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "ozy" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/smooth/old,
@@ -57373,11 +57864,13 @@
 /turf/open/floor/plating/grate,
 /area/vtm/interior/endron_facility/plant)
 "oCg" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/structure/table/wood/fancy/black,
+/obj/vampire_computer,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/jazzclub)
 "oCh" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -57464,6 +57957,15 @@
 	},
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/clinic)
+"oCW" = (
+/obj/structure/platform/lowwall/rich,
+/obj/item/clothing/head/costume/crown/fancy{
+	desc = "A crown that bears a striking resemblance to the missing Portugese crown jewels.";
+	pixel_y = 5
+	},
+/obj/machinery/light/prince/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "oCZ" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -57589,12 +58091,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "oEL" = (
-/obj/structure/chair/comfy{
-	dir = 8;
-	name = "Aedile's Seat"
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
 	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "oER" = (
 /obj/structure/vampdoor/old{
 	dir = 4
@@ -57621,6 +58125,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
+"oFb" = (
+/obj/machinery/light/floor/lamppost/sidewalk,
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/unionsquare)
 "oFd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -57650,12 +58158,6 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower)
-"oFp" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "oFr" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -57694,12 +58196,15 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
 "oFK" = (
+/obj/machinery/light/prince/directional/north,
 /obj/structure/closet/cabinet,
-/obj/item/clothing/under/vampire/ventrue,
-/obj/item/clothing/under/vampire/ventrue/female,
-/obj/item/clothing/mask/vampire/venetian_mask,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/clothing/shoes/vampire/jackboots,
+/obj/item/clothing/shoes/vampire/heels,
+/obj/item/clothing/under/vampire/gown_black,
+/obj/item/clothing/under/vampire/suit,
+/obj/item/clothing/under/vampire/suit/female,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "oFL" = (
 /obj/machinery/button/door{
 	id = "clinic";
@@ -57726,6 +58231,12 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"oGj" = (
+/obj/effect/landmark/npcbeacon/directed{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/ghetto)
 "oGk" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -57733,9 +58244,8 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
 "oGl" = (
-/obj/structure/hedge,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/turf/open/floor/wood/old,
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/jazzclub)
 "oGs" = (
 /obj/structure/closet/crate/bin,
@@ -57908,17 +58418,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
-"oIy" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/vampdoor/wood{
-	dir = 1;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 14;
-	name = "board room"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/jazzclub)
 "oII" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -58304,7 +58803,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "oNF" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -58484,10 +58983,12 @@
 	},
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
-"oPU" = (
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/structure/table/wood,
-/turf/open/floor/mineral/plastitanium,
+"oPP" = (
+/obj/structure/platform/lowwall/rich,
+/obj/structure/vampstatue/angel{
+	pixel_y = 26
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/jazzclub)
 "oPV" = (
 /obj/structure/railing{
@@ -58822,15 +59323,6 @@
 /obj/structure/table/wood/billiard,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
-"oTm" = (
-/obj/structure/curtain/bounty,
-/obj/structure/window/reinforced/tinted/spawner/directional/south{
-	max_integrity = 1000000
-	},
-/obj/effect/decal/wallpaper/gold/low,
-/obj/structure/platform/lowwall/rich/window/reinforced,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "oTy" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/darkpack/blacksilver,
@@ -59028,6 +59520,17 @@
 /obj/structure/roadblock,
 /turf/open/misc/dirt,
 /area/vtm/interior/supply)
+"oWv" = (
+/obj/structure/table/countertop/black,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 4
+	},
+/obj/item/rag{
+	pixel_x = 14;
+	pixel_y = 14
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "oWH" = (
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/rough/cave,
@@ -59089,17 +59592,17 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
 "oXC" = (
-/obj/structure/table,
-/turf/open/floor/wood/old,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "oXD" = (
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/carpet/lone,
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "oXE" = (
 /obj/machinery/light/directional/north,
@@ -59145,11 +59648,13 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
 "oXZ" = (
-/obj/structure/chair/darkpack{
-	dir = 8
+/obj/structure/platform/lowwall/rich/window,
+/obj/structure/curtain/bounty{
+	pixel_y = 8
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/decal/wallpaper/paper/fancy/red/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "oYa" = (
 /obj/structure/railing{
 	dir = 4
@@ -59270,8 +59775,10 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/fishermanswharf)
 "par" = (
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
 "pat" = (
 /obj/effect/turf_decal/bordur{
@@ -59283,27 +59790,13 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "paC" = (
-/obj/structure/vampdoor/wood{
-	dir = 8;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "Ventrue Office"
+/obj/structure/table/wood/fancy/black,
+/obj/vampire_computer,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
 	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/door/access/ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock_difficulty/seven,
-/obj/effect/mapping_helpers/door/lock,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/jazzclub)
 "paD" = (
 /obj/machinery/lift_indicator/directional/north{
 	pixel_x = -5;
@@ -59508,18 +60001,6 @@
 "pdE" = (
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f3)
-"pdG" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/vampdoor/glass,
-/obj/effect/mapping_helpers/door/access/jazz_club,
-/obj/effect/mapping_helpers/door/lock,
-/obj/effect/mapping_helpers/door/bash_difficulty/five,
-/obj/effect/mapping_helpers/door/lock_difficulty/five,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/jazzclub)
 "pdK" = (
 /obj/machinery/sprinkler,
 /obj/effect/turf_decal/siding/white{
@@ -59598,6 +60079,11 @@
 /obj/structure/sign/city/chinese/directional/east,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/chinatown)
+"peJ" = (
+/obj/structure/chair/stool/bar/darkpack/black,
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "peK" = (
 /obj/machinery/chem_heater{
 	pixel_x = -1;
@@ -59632,6 +60118,15 @@
 /obj/item/melee/vamp/handsickle,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
+"pft" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "pfu" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -59707,6 +60202,16 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"pgx" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/machinery/jukebox/no_access{
+	density = 0;
+	pixel_y = 19
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "pgA" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/rough,
@@ -59868,7 +60373,7 @@
 "piU" = (
 /obj/machinery/light/floor/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "piX" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -60020,13 +60525,6 @@
 	},
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm)
-"pks" = (
-/obj/machinery/light/prince/directional/east,
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/jazzclub)
 "pkK" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/haven)
@@ -60104,12 +60602,21 @@
 /turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/endron_facility/restricted)
 "pmo" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/structure/table/wood/fancy/red,
+/obj/item/binoculars{
+	pixel_y = -2;
+	pixel_x = 5
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 4
+	},
+/obj/vampire_computer{
+	icon_state = "computerprince";
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "pmw" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -60206,8 +60713,7 @@
 /area/vtm)
 "pnH" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
-/obj/item/kirbyplants/random,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "pnK" = (
 /obj/structure/chair/sofa/corp/right{
@@ -60289,10 +60795,22 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/northbeach)
 "poI" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/flashlight/flare/candle/infinite{
+	anchored = 1;
+	pixel_y = 12;
+	pixel_x = -12
 	},
-/turf/open/floor/carpet/green,
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 4;
+	pixel_y = 13
+	},
+/obj/item/lighter{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "poJ" = (
 /obj/effect/turf_decal/bordur,
@@ -60338,6 +60856,13 @@
 /obj/structure/platform/lowwall/market/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop/bacotell)
+"ppt" = (
+/obj/effect/turf_decal/bordur{
+	dir = 4
+	},
+/obj/structure/vampfence/rich,
+/turf/open/floor/plating/sidewalk,
+/area/vtm/outside/unionsquare)
 "ppz" = (
 /obj/structure/vampipe{
 	icon_state = "piping41"
@@ -60540,6 +61065,34 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
+"prQ" = (
+/obj/item/storage/fancy/cigarettes/cigars/havana{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/flashlight/flare/candle/infinite{
+	anchored = 1;
+	pixel_y = 15;
+	pixel_x = -9
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/obj/item/newspaper{
+	pixel_x = 1;
+	pixel_y = 15
+	},
+/obj/item/newspaper{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/obj/item/lighter{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "prX" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -60951,7 +61504,7 @@
 "pxc" = (
 /obj/structure/city_map,
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "pxe" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -61193,10 +61746,6 @@
 /obj/structure/chair/darkpack,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
-"pzZ" = (
-/obj/structure/chair/plastic/darkpack,
-/turf/open/floor/plating/roofwalk/cobblestones,
-/area/vtm/interior/jazzclub)
 "pAc" = (
 /obj/structure/chair/sofa/corp{
 	pixel_x = -7;
@@ -61217,7 +61766,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "pAp" = (
 /obj/item/kirbyplants/darkpack/plant3{
 	pixel_y = 15;
@@ -61225,6 +61774,13 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
+"pAr" = (
+/obj/structure/platform/lowwall/rich/window,
+/obj/structure/window/reinforced/tinted/spawner/directional/east{
+	opacity = 1
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "pAS" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/cup/watering_can/metal,
@@ -61471,11 +62027,17 @@
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer)
 "pDy" = (
-/obj/structure/chair/sofa/corp/left{
-	alpha = 225;
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/platform/lowwall/rich,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -11;
+	pixel_y = -1
 	},
-/turf/open/floor/carpet/purple,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "pDB" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -61629,9 +62191,8 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
 "pFt" = (
-/obj/structure/flora/rock/darkpack_big,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/water,
+/obj/item/food/grown/flower/rose,
+/turf/open/water/hot_spring,
 /area/vtm/interior/jazzclub)
 "pFF" = (
 /obj/structure/vampfence/rich{
@@ -61641,33 +62202,17 @@
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
 "pFO" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/south,
-/obj/structure/curtain/bounty,
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light/end,
+/obj/structure/chair/wood/darkpack{
+	dir = 1;
+	pixel_y = 4
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "pFV" = (
 /obj/structure/dresser,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
-"pFX" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
-	pixel_x = 7
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
-	pixel_y = -6;
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/cup/glass/bottle/absinthe{
-	pixel_y = 12;
-	pixel_x = -9
-	},
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "pGa" = (
 /obj/structure/closet/crate/dumpster,
 /obj/machinery/light/small/directional/north,
@@ -61699,7 +62244,19 @@
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/clinic)
 "pGK" = (
-/turf/open/floor/iron/stairs/medium,
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/unlock,
+/turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/interior/jazzclub)
 "pGP" = (
 /obj/structure/railing/darkpack/metal/industrial/solo{
@@ -61763,16 +62320,6 @@
 	color = "#8f8f8f"
 	},
 /area/vtm)
-"pHq" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "pHA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
@@ -61846,6 +62393,22 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"pIE" = (
+/obj/structure/platform/lowwall/rich,
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "pIF" = (
 /obj/effect/decal/wallpaper,
 /turf/closed/wall/vampwall/market,
@@ -61871,15 +62434,12 @@
 /turf/open/misc/beach/vamp,
 /area/vtm)
 "pJs" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/decal/shadow,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
+/obj/structure/flora/rock/darkpack_big{
+	pixel_x = -1;
+	pixel_y = -25
 	},
-/turf/open/misc/grass,
+/turf/open/water/hot_spring,
 /area/vtm/interior/jazzclub)
 "pJu" = (
 /obj/effect/mapping_helpers/door/access/sabbat,
@@ -61898,11 +62458,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/five,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
-"pJH" = (
-/obj/machinery/light/prince/directional/south,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "pJP" = (
 /obj/structure/table,
 /turf/open/floor/wood/smooth/old,
@@ -62105,7 +62660,7 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/tree/vamp,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "pLb" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -62176,11 +62731,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
-"pMg" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/food/cake/chocolate,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "pMh" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -62190,6 +62740,23 @@
 	},
 /turf/open/misc/grass,
 /area/vtm)
+"pMk" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/vampdoor/wood{
+	dir = 1;
+	lock_id = "ventrue";
+	locked = 1;
+	lockpick_difficulty = 14;
+	name = "board room"
+	},
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/turf/open/floor/plating/roofwalk/cobblestones,
+/area/vtm/interior/jazzclub)
 "pMr" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 4
@@ -62402,16 +62969,6 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"pPs" = (
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/sign/city/anarch,
-/turf/open/floor/plating/sidewalk/old,
-/area/vtm/interior/jazzclub)
 "pPw" = (
 /obj/structure/vampfence/rich,
 /obj/effect/turf_decal/bordur{
@@ -62578,6 +63135,16 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
+"pRH" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "pRI" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -62589,6 +63156,15 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"pRL" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "pRX" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/white{
@@ -62988,13 +63564,6 @@
 	},
 /turf/open/floor/plating/grate,
 /area/vtm/interior/endron_facility/plant)
-"pXA" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "pXJ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/openspace,
@@ -63015,6 +63584,15 @@
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"pXZ" = (
+/obj/structure/chair/sofa/corp/corner{
+	color = "#36454F"
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "pYb" = (
 /obj/structure/bookcase/random/kindred,
 /turf/open/floor/wood/smooth/old,
@@ -63049,16 +63627,6 @@
 	dir = 8
 	},
 /area/vtm/outside/ghetto)
-"pYw" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 2;
-	pixel_x = 0
-	},
-/turf/open/floor/iron/stairs{
-	dir = 4
-	},
-/area/vtm/interior/millennium_tower/ventrue)
 "pYx" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/food/spaghetti/chowmein,
@@ -63259,14 +63827,11 @@
 /obj/effect/decal/wallpaper/paper/green,
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior)
-"qcm" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/turf/open/floor/carpet/green,
+"qcg" = (
+/obj/structure/platform/lowwall/rich,
+/obj/structure/aquarium/prefilled,
+/obj/effect/decal/wallpaper/paper/fancy/red/low,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "qct" = (
 /obj/machinery/barsign{
@@ -63354,18 +63919,23 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
 "qdo" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/obj/item/newspaper,
+/obj/item/newspaper{
+	pixel_x = 4;
+	pixel_y = 2
 	},
-/obj/structure/chair/sofa/corp/left{
-	pixel_x = -7;
-	pixel_y = 12
+/obj/item/phone{
+	pixel_x = -8;
+	pixel_y = 9
 	},
-/obj/structure/railing{
-	dir = 1;
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter{
+	pixel_x = 5;
 	pixel_y = 5
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "qdt" = (
 /obj/structure/vampdoor/glass,
@@ -63571,6 +64141,16 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"qgh" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 1;
+	color = "#36454F"
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "qgi" = (
 /obj/structure/table,
 /obj/item/bong,
@@ -63637,7 +64217,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/item/trash/can/food,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "qgD" = (
 /obj/structure/table/wood,
 /obj/item/melee/vamp/tire,
@@ -63649,12 +64229,7 @@
 /area/vtm/interior)
 "qgG" = (
 /obj/effect/decal/shadow,
-/obj/structure/flora/rock/darkpack_big,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/water,
+/turf/open/water/hot_spring,
 /area/vtm/interior/jazzclub)
 "qgK" = (
 /obj/structure/table/wood,
@@ -63822,7 +64397,10 @@
 /turf/open/floor/wood/old,
 /area/vtm/outside/pacificheights/forest)
 "qiT" = (
-/turf/open/floor/carpet/lone,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "qiW" = (
 /obj/effect/decal/support,
@@ -63834,6 +64412,19 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
+"qjb" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp{
+	color = "#36454F";
+	dir = 8
+	},
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "qjd" = (
 /obj/structure/table/wood/fancy,
 /obj/item/plate,
@@ -64238,6 +64829,15 @@
 /obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/plating/rust,
 /area/vtm/interior/strip)
+"qoF" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/support,
+/obj/structure/hedge,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "qoM" = (
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f2)
@@ -64252,10 +64852,12 @@
 	},
 /turf/open/misc/beach/vamp,
 /area/vtm)
-"qpk" = (
-/obj/machinery/light/prince/directional/south,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+"qoY" = (
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "qpl" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/city/toilet,
@@ -64274,7 +64876,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "qpy" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 8
@@ -64337,9 +64939,6 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
 "qqB" = (
-/obj/structure/chair/plastic/darkpack{
-	dir = 1
-	},
 /obj/machinery/light/prince/directional/west,
 /turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/interior/jazzclub)
@@ -64506,21 +65105,9 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/ghetto)
 "qsP" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 4;
-	pixel_x = 0
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "qsQ" = (
 /obj/structure/barrels{
 	icon_state = "barrels9"
@@ -64610,12 +65197,6 @@
 /obj/item/ammo_box/darkpack/c556,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
-"qtT" = (
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "qtU" = (
 /obj/structure/railing{
 	dir = 8;
@@ -64623,6 +65204,13 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
+"qtW" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "qtZ" = (
 /obj/effect/turf_decal/siding/wood/rough/corner{
 	dir = 1
@@ -64680,11 +65268,6 @@
 /obj/structure/hydrant,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
-"quz" = (
-/obj/machinery/light/prince/directional/west,
-/obj/structure/chair/comfy/darkpack,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "quA" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -64712,8 +65295,8 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/chantry/basement)
 "quI" = (
-/obj/effect/decal/wallpaper/red,
 /obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/wallpaper/gold,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/jazzclub)
 "quM" = (
@@ -65238,20 +65821,6 @@
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
-"qAl" = (
-/obj/structure/vampdoor/wood{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/door/access/jazz_club,
-/obj/effect/mapping_helpers/door/lock,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/obj/effect/mapping_helpers/door/lock_difficulty/eight,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/jazzclub)
 "qAn" = (
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/wood/smooth,
@@ -65332,6 +65901,14 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"qBC" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/decal/painting/yankovic{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "qBR" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood/smooth/old,
@@ -65649,6 +66226,10 @@
 	},
 /turf/open/water,
 /area/vtm/outside/pacificheights/old)
+"qGS" = (
+/obj/effect/decal/wallpaper/gold/alt,
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior/jazzclub)
 "qGV" = (
 /obj/structure/vampdoor/simple{
 	name = "Toilet"
@@ -65837,15 +66418,6 @@
 "qIU" = (
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/techshop)
-"qIW" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "qIX" = (
 /turf/open/misc/beach/vamp,
 /area/vtm/outside/northbeach)
@@ -66153,6 +66725,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/city/industrial/large,
 /area/vtm/interior/shop/hardware_store)
+"qMn" = (
+/obj/structure/platform/lowwall/rich/window,
+/obj/effect/decal/wallpaper/red/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "qMr" = (
 /obj/structure/platform/lowwall/old/window/reinforced,
 /turf/open/floor/plating/rough,
@@ -66241,6 +66818,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
+"qNH" = (
+/obj/structure/table/countertop/black,
+/obj/machinery/processor,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "qNL" = (
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
@@ -66400,6 +66982,12 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/outside/pacificheights/forest)
+"qQp" = (
+/obj/structure/railing/darkpack/metal{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/theatre)
 "qQr" = (
 /obj/structure/hydrant,
 /obj/effect/landmark/npcactivity,
@@ -66732,11 +67320,11 @@
 /turf/open/misc/dirt,
 /area/vtm/graveyard)
 "qTD" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/effect/decal/painting/second{
+	pixel_y = 32
 	},
 /turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "qTJ" = (
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/rich,
@@ -66832,28 +67420,23 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
 "qUB" = (
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
+/obj/structure/chair/sofa/corp/corner{
+	color = "#36454F"
 	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/railing/wooden_fence{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
+"qUF" = (
+/turf/closed/wall/vampwall/rich{
+	density = 0;
+	color = "#BBBBBB"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "qUJ" = (
 /obj/effect/turf_decal/siding/wideplating/red/corner{
@@ -67027,11 +67610,11 @@
 "qXB" = (
 /obj/structure/flora/tree/vamp,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "qXE" = (
-/obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "qXL" = (
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/plating/concrete,
@@ -67123,8 +67706,9 @@
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
 "qYL" = (
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "qYM" = (
 /obj/structure/railing{
 	dir = 4
@@ -67132,7 +67716,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
 "qYQ" = (
-/obj/machinery/light/directional/west,
+/obj/machinery/light/prince/directional/west,
 /turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/jazzclub)
 "qYS" = (
@@ -67144,12 +67728,13 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior)
 "qZc" = (
-/obj/structure/table/wood,
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/item/newspaper,
-/obj/item/phone,
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "qZd" = (
 /obj/machinery/light/prince/directional/west,
@@ -67185,22 +67770,6 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
-"qZA" = (
-/obj/structure/vampdoor/wood{
-	dir = 8;
-	lock_id = "ventrue";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "Ventrue Office"
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "qZD" = (
 /obj/structure/platform/lowwall/painted/window,
 /turf/open/floor/plating/rough,
@@ -67425,12 +67994,14 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
 "rcD" = (
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 1
+/obj/structure/chair/stool/bar/darkpack/blue,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/carpet/lone,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "rcG" = (
 /obj/effect/decal/shadow,
@@ -67581,11 +68152,8 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "ree" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/misc/grass,
+/obj/effect/decal/support,
+/turf/open/water/hot_spring,
 /area/vtm/interior/jazzclub)
 "ref" = (
 /obj/machinery/light/directional/north,
@@ -67681,6 +68249,11 @@
 	},
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/salubri)
+"rfw" = (
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "rfy" = (
 /obj/effect/decal/cleanable/trash,
 /obj/item/cigbutt,
@@ -67770,6 +68343,31 @@
 /obj/structure/dresser,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
+"rhr" = (
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/hedge{
+	pixel_y = 6
+	},
+/obj/structure/flora/bush/lavendergrass/style_random{
+	pixel_y = 13
+	},
+/obj/structure/flora/bush/flowers_yw/style_random{
+	pixel_y = 10
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/old,
+/area/vtm)
 "rhs" = (
 /obj/effect/decal/pallet,
 /obj/structure/railing{
@@ -67796,16 +68394,14 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"rhy" = (
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "rhB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/clinic/haven)
-"rhF" = (
-/obj/structure/chair/plastic/darkpack{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/jazzclub)
 "rhK" = (
 /obj/structure/railing{
 	dir = 4
@@ -67903,12 +68499,6 @@
 /obj/machinery/light/prince/directional/west,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/tzimisce_manor)
-"rij" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "rik" = (
 /obj/structure/table/wood,
 /obj/item/pen/red,
@@ -68361,26 +68951,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
-"roo" = (
-/mob/living/carbon/human/npc/bouncer/elysium/theatre_backdoor,
-/obj/structure/chair/wood/darkpack/red{
-	dir = 1
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/jazzclub)
-"ror" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/curtain/cloth/fancy/mechanical{
-	id = 2005
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/theatre)
 "rot" = (
 /obj/structure/chair/comfy/darkpack{
 	dir = 8
@@ -68637,12 +69207,6 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/bubway)
-"rrh" = (
-/obj/structure/chair/comfy/darkpack{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/jazzclub)
 "rrj" = (
 /obj/structure/table/wood,
 /obj/item/stack/dollar/hundred,
@@ -68680,6 +69244,13 @@
 "rrB" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
+"rrD" = (
+/obj/effect/turf_decal/bordur{
+	dir = 8
+	},
+/obj/structure/vampfence/rich,
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/unionsquare)
 "rrK" = (
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/brick_old,
@@ -68802,12 +69373,23 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "rtk" = (
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
+	},
+/obj/structure/railing/darkpack/metal,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/old,
+/area/vtm)
 "rtl" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"rts" = (
+/obj/machinery/light/prince/directional/north,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "rtt" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
@@ -69016,11 +69598,10 @@
 /turf/open/misc/dirt,
 /area/vtm)
 "ruT" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "ruU" = (
 /obj/structure/vampfence/rich{
@@ -69314,6 +69895,18 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
+"ryz" = (
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/unlock,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "ryA" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/darkpack/redsilver,
@@ -69386,6 +69979,10 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
+"rzA" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "rzB" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth,
@@ -69581,7 +70178,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/tzimisce_manor)
 "rBR" = (
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
 "rBZ" = (
 /obj/structure/curtain,
@@ -69600,6 +70200,15 @@
 /obj/item/newspaper,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights)
+"rCt" = (
+/obj/structure/plaque/static_plaque/golden{
+	pixel_y = 21;
+	name = "Golden memorial plaque";
+	desc = "A gold emblazened plaque commemorating a long since deceased jazz star.";
+	pixel_x = 0
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "rCv" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -69892,6 +70501,13 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/ghetto)
+"rHd" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "rHg" = (
 /obj/effect/decal/wallpaper,
 /turf/closed/wall/vampwall/brick,
@@ -69953,6 +70569,14 @@
 /obj/item/folder/blue,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"rHW" = (
+/obj/effect/turf_decal/siding/wood/light/corner,
+/obj/structure/railing/corner{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "rIb" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen{
@@ -69974,6 +70598,13 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior)
+"rIs" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "rIu" = (
 /obj/machinery/light/prince/directional/west,
 /turf/open/floor/carpet/green,
@@ -70091,6 +70722,13 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"rKg" = (
+/obj/structure/chair/stool/bar/darkpack/blue,
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "rKm" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -70186,6 +70824,26 @@
 	},
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/shop/bubway)
+"rLm" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "rLo" = (
 /obj/effect/turf_decal/darkpack/grass{
 	dir = 6
@@ -70208,6 +70866,12 @@
 /obj/machinery/light/floor/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/giovanni/courtyard)
+"rLu" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "rLw" = (
 /obj/effect/turf_decal/siding/dark_blue/corner{
 	dir = 1
@@ -70385,12 +71049,6 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/misc/dirt,
 /area/vtm/interior/sewer)
-"rNZ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "rOd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -70488,6 +71146,12 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
+"rPo" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "rPp" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -70663,6 +71327,17 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer/nosferatu_town)
+"rSi" = (
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 8;
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "rSp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/sofa/corp/right{
@@ -70787,6 +71462,10 @@
 	},
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
+"rUs" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "rUv" = (
 /obj/structure/vampdoor/glass,
 /obj/effect/mapping_helpers/door/unlock,
@@ -70821,6 +71500,16 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/misc/dirt,
 /area/vtm/interior/sewer)
+"rVe" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "rVf" = (
 /obj/structure/vampdoor/wood{
 	dir = 1;
@@ -70847,12 +71536,6 @@
 /mob/living/basic/pet/cat/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
-"rVw" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/glass/baggie/meth/cocaine,
-/obj/item/reagent_containers/cup/glass/baggie/meth/cocaine,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "rVz" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood/smooth,
@@ -70940,6 +71623,15 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic)
+"rWN" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/obj/structure/chair/wood/darkpack{
+	dir = 8
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "rWS" = (
 /obj/effect/turf_decal/bordur{
 	dir = 6
@@ -71021,6 +71713,15 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
+"rXI" = (
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "rXL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -71044,10 +71745,21 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/bianchiBank)
+"rXS" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/obj/structure/chair/wood/darkpack{
+	dir = 4
+	},
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "rXV" = (
 /mob/living/basic/pet/cat/darkpack,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "rYb" = (
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalk,
@@ -71155,21 +71867,29 @@
 /turf/open/floor/iron/dark,
 /area/vtm/interior/millennium_tower/f4)
 "rYY" = (
-/obj/effect/decal/support,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/chair/sofa/corp/corner{
+	color = "#36454F";
+	dir = 1
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "rZd" = (
 /obj/structure/flora/bush/grassy/style_random,
 /obj/structure/flora/grass/tall/style_random,
 /turf/open/misc/grass,
 /area/vtm/interior/cog/caern)
 "rZj" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/siding/wood/light/corner,
+/turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "rZq" = (
 /obj/structure/hedge,
@@ -71316,7 +72036,7 @@
 /obj/effect/decal/cleanable/litter,
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "sas" = (
 /obj/structure/vampfence/rich{
 	dir = 4
@@ -71536,6 +72256,31 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm)
+"scN" = (
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/hedge{
+	pixel_y = 6
+	},
+/obj/structure/flora/bush/lavendergrass/style_random{
+	pixel_y = 13
+	},
+/obj/structure/flora/bush/flowers_yw/style_random{
+	pixel_y = 10
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "scR" = (
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop)
@@ -71588,6 +72333,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/small,
 /area/vtm/interior/endron_facility/restricted)
+"sdx" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/support,
+/obj/structure/hedge,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "sdz" = (
 /obj/structure/chair/plastic/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
@@ -72009,11 +72763,6 @@
 /obj/machinery/light/floor/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/park)
-"sjL" = (
-/obj/item/fish/darkpack/shark,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/water,
-/area/vtm/interior/jazzclub)
 "sjN" = (
 /obj/structure/chair/plastic/darkpack,
 /mob/living/carbon/human/npc/bandit,
@@ -72056,15 +72805,6 @@
 	},
 /turf/open/floor/city/circled,
 /area/vtm/interior/clinic)
-"sku" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "sky" = (
 /obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/city/plating_mono,
@@ -72132,7 +72872,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
 "slo" = (
-/obj/structure/chair/plastic{
+/obj/structure/chair/plastic/darkpack{
 	dir = 1;
 	name = "Seat of Shame"
 	},
@@ -72197,14 +72937,6 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic)
-"sms" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "smt" = (
 /obj/structure/dresser,
 /turf/open/floor/wood/smooth/old,
@@ -72402,6 +73134,11 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
+"sow" = (
+/obj/structure/platform/lowwall/rich/window,
+/obj/effect/decal/wallpaper/paper/fancy/red/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/jazzclub)
 "soN" = (
 /obj/structure/railing{
 	dir = 1;
@@ -72656,6 +73393,7 @@
 /obj/structure/hedge{
 	pixel_y = 6
 	},
+/obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/jazzclub)
 "ssk" = (
@@ -72726,14 +73464,6 @@
 /obj/item/food/grown/cannabis,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
-"ssN" = (
-/obj/structure/chair/wood/darkpack/red,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior/theatre)
 "ssW" = (
 /obj/structure/transport/linear/public,
 /obj/effect/abstract/elevator_music_zone{
@@ -73033,18 +73763,6 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior)
-"swG" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/clothing/accessory/medal/gold{
-	name = "olympic gold medal";
-	desc = "A prestigious golden medal from the Olypmic Games"
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "swL" = (
 /obj/structure/vampipe{
 	pixel_y = 32
@@ -73137,12 +73855,6 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights)
-"sxC" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/litter,
-/obj/vampire_computer,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "sxD" = (
 /obj/structure/table,
 /obj/item/stack/medical/suture,
@@ -73160,22 +73872,19 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
 "sxM" = (
-/obj/effect/landmark/npcwall,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
 /obj/structure/vampdoor/wood{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/door/access/jazz_club,
 /obj/effect/mapping_helpers/door/lock,
-/obj/effect/mapping_helpers/door/lock_difficulty/five,
-/obj/effect/mapping_helpers/door/bash_difficulty/five,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/interior/jazzclub)
 "sxN" = (
 /obj/structure/hedge,
@@ -73359,6 +74068,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
+"szW" = (
+/obj/effect/decal/wallpaper/paper/purple,
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior/jazzclub)
 "sAb" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
@@ -73543,8 +74256,19 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower)
 "sCV" = (
-/turf/open/floor/iron/stairs,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/white,
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/chair/sofa/corp/right{
+	color = "#36454F";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "sCW" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas,
@@ -73602,12 +74326,15 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sabbat_lair)
 "sDv" = (
-/obj/effect/landmark/start/darkpack/primogen/ventrue,
-/obj/structure/chair/comfy/black{
-	name = "Praetor's Chair"
+/obj/structure/chair/comfy/darkpack/dark,
+/obj/effect/decal/carpet{
+	icon_state = "rug_red";
+	pixel_x = 0;
+	pixel_y = -14
 	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/landmark/start/darkpack/primogen/ventrue,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "sDz" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -73627,6 +74354,18 @@
 /obj/structure/flora/rock/pile/darkpack,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/community)
+"sDT" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = 3
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "sDV" = (
 /obj/fusebox,
 /obj/effect/turf_decal/siding/wood{
@@ -73956,6 +74695,10 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/museum)
+"sII" = (
+/obj/structure/railing/corner,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/jazzclub)
 "sIJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -74142,14 +74885,6 @@
 /obj/item/seeds/cannabis,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
-"sKZ" = (
-/obj/machinery/light/prince/directional/north,
-/obj/structure/chair/sofa/corp,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "sLk" = (
 /obj/structure/vampdoor/old{
 	dir = 4
@@ -74295,6 +75030,22 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer/nosferatu_town)
+"sNU" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "sNW" = (
 /obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/floor/city/plating,
@@ -74346,7 +75097,7 @@
 "sOD" = (
 /obj/effect/landmark/npcbeacon/directed,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "sOE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -74635,11 +75386,11 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/salubri)
 "sTy" = (
-/obj/machinery/light/prince/directional/north,
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/flare/candle,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/jazzclub)
 "sTB" = (
 /obj/structure/vampdoor/wood{
 	dir = 4
@@ -74701,11 +75452,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
-"sUd" = (
-/obj/effect/landmark/npcbeacon,
-/obj/effect/landmark/npcability,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "sUi" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/sidewalk,
@@ -74744,6 +75490,12 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f3)
+"sUG" = (
+/obj/structure/vampdoor/woodglass,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "sUH" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/vampirewater,
@@ -75061,6 +75813,11 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
+"sYw" = (
+/obj/machinery/light/prince/directional/west,
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "sYx" = (
 /obj/structure/table/optable,
 /turf/open/indestructible/necropolis/air,
@@ -75101,11 +75858,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
-"sZr" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/litter,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "sZt" = (
 /obj/structure/vampdoor{
 	dir = 8;
@@ -75365,7 +76117,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/chinatown)
 "tcp" = (
-/obj/structure/chair/comfy{
+/obj/structure/chair/comfy/darkpack{
 	dir = 4
 	},
 /mob/living/basic/pet/cat/darkpack,
@@ -75900,15 +76652,6 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
-"tjp" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "tjq" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
@@ -76022,12 +76765,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower)
 "tlx" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
+/obj/structure/table/wood/fancy/black,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter/empty,
 /turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "tlA" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -76132,11 +76874,12 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
 "tna" = (
-/obj/structure/hedge{
-	pixel_x = 3
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
 	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/wood/old,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "tno" = (
 /obj/structure/closet/crate,
@@ -76371,13 +77114,6 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
-"tqz" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/iron/stairs,
-/area/vtm/interior/millennium_tower/ventrue)
 "tqA" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/wood/smooth/old,
@@ -76445,13 +77181,6 @@
 /obj/item/reagent_containers/cup/glass/coffee/vampire/robust,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
-"trh" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "trk" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/green,
@@ -76471,15 +77200,13 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
 "trt" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
+/obj/effect/turf_decal/siding/wood/dark/end,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "tru" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "trz" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -76671,6 +77398,10 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/dirt,
 /area/vtm/graveyard)
+"ttI" = (
+/obj/item/food/grown/flower/poppy/lily,
+/turf/open/water/hot_spring,
+/area/vtm/interior/jazzclub)
 "ttO" = (
 /obj/structure/chair/sofa/corner/brown{
 	dir = 8
@@ -76705,6 +77436,15 @@
 /obj/structure/closet/cardboard,
 /turf/open/misc/dirt,
 /area/vtm/interior/supply)
+"ttZ" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "tug" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -76783,19 +77523,6 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"tvv" = (
-/obj/structure/table/wood/fancy/black,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/item/storage/fancy/cigarettes/cigars,
-/obj/item/lighter,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "tvz" = (
 /obj/structure/table/wood,
 /obj/item/plate,
@@ -76912,13 +77639,6 @@
 	},
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior)
-"txe" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/support,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
 "txp" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 4
@@ -76948,10 +77668,10 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/church)
 "txK" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 10
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "txM" = (
 /obj/effect/decal/cleanable/trash,
@@ -76981,6 +77701,22 @@
 /obj/effect/gibspawner/human,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
+"tyi" = (
+/obj/structure/platform/lowwall/rich,
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/food/grown/flower/poppy/lily{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "typ" = (
 /mob/living/basic/pet/cat/darkpack,
 /turf/open/floor/plating/sidewalk/poor,
@@ -77144,18 +77880,18 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior)
+"tBg" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "tBi" = (
 /obj/effect/decal/wallpaper/light,
 /obj/structure/sign/painting/library,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/techshop)
-"tBj" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/decal/wallpaper/paper/rich,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
 "tBk" = (
 /obj/structure/hedge,
 /turf/open/floor/plating/concrete,
@@ -77248,8 +77984,19 @@
 /turf/open/water/beach/vamp/deep,
 /area/vtm/interior/cog/caern)
 "tCE" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = 3
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "tCI" = (
 /obj/effect/turf_decal/siding/wood{
@@ -77259,10 +78006,24 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "tCS" = (
-/obj/structure/chair/darkpack{
-	dir = 8
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/turf/open/floor/wood/old,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/lighter{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -2;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "tCT" = (
 /turf/open/floor/wood/smooth/old,
@@ -77399,7 +78160,10 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/strip)
 "tEg" = (
-/turf/open/floor/carpet/green,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "tEi" = (
 /obj/machinery/light/directional/south,
@@ -77507,10 +78271,14 @@
 /turf/open/misc/grass,
 /area/vtm/graveyard)
 "tEV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "tFl" = (
 /obj/structure/platform/lowwall/painted/window,
 /turf/open/floor/plating/rough,
@@ -77541,6 +78309,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/city/plating,
 /area/vtm/interior/shop/flower_shop)
+"tFS" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "tFZ" = (
 /obj/structure/table/reinforced,
 /obj/item/knife/vamp,
@@ -77581,6 +78356,23 @@
 /obj/machinery/griddle,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
+"tGt" = (
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/obj/structure/chair/sofa/corp/right{
+	color = "#36454F";
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
+"tGu" = (
+/obj/machinery/light/prince/directional/west{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "tGw" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -77654,17 +78446,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"tHd" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/instrument/guitar,
-/obj/item/instrument/eguitar,
-/obj/item/instrument/banjo,
-/obj/item/instrument/violin{
-	name = "violin"
-	},
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/jazzclub)
 "tHe" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/city/plating_mono,
@@ -77799,24 +78580,16 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "tJu" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/platform/lowwall/rich,
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = 6;
+	pixel_y = 5
 	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = -4;
+	pixel_y = 0
 	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/item/statuebust{
-	anchored = 1
-	},
-/turf/open/floor/plating/granite/black,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "tJB" = (
 /obj/machinery/light/prince/directional/west,
@@ -77939,10 +78712,13 @@
 /turf/open/floor/plating,
 /area/vtm/interior/clinic)
 "tLz" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
+/obj/structure/table/countertop/black,
+/obj/item/reagent_containers/cup/coffeepot,
+/obj/item/reagent_containers/cup/coffeepot{
+	pixel_x = 8;
+	pixel_y = 7
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "tLB" = (
 /obj/effect/landmark/start/darkpack/forest_wolves/warder,
@@ -78032,18 +78808,6 @@
 /obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
-"tMT" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/machinery/light/prince/directional/north,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/structure/table/wood/fancy/royalblue,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
 "tMU" = (
 /obj/structure/sink/directional/south,
 /turf/open/floor/city/toilet,
@@ -78297,7 +79061,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "tRJ" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 4
@@ -78336,6 +79100,15 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/outside/pacificheights/forest)
+"tSa" = (
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/unlock,
+/obj/effect/mapping_helpers/door/lock_difficulty/two,
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "tSg" = (
 /obj/effect/turf_decal/siding/grey,
 /turf/open/floor/city/circled/large,
@@ -78374,8 +79147,13 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/oldchurch)
 "tSq" = (
-/obj/structure/table,
-/turf/open/floor/wood/ornate,
+/obj/machinery/light/prince/directional/north,
+/obj/structure/platform/lowwall/rich,
+/obj/item/statuebust{
+	anchored = 1;
+	pixel_y = 13
+	},
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "tSy" = (
 /obj/item/storage/box/lights/mixed,
@@ -78383,6 +79161,23 @@
 /obj/structure/table,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
+"tSz" = (
+/obj/structure/chair/stool/bar/darkpack/blue,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
+"tSF" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/obj/vampire_computer{
+	icon_state = "computerprince"
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "tSJ" = (
 /obj/item/toy/seashell,
 /turf/open/misc/beach/vamp,
@@ -78660,10 +79455,10 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf)
 "tXb" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass,
-/obj/item/reagent_containers/cup/glass/bottle/wine,
-/turf/open/floor/carpet/lone,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "tXc" = (
 /obj/structure/closet/crate/freezer,
@@ -78709,6 +79504,12 @@
 /obj/effect/landmark/start/darkpack/citizen/priest,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
+"tXG" = (
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "tXK" = (
 /obj/effect/turf_decal/siding/wideplating/red{
 	dir = 1
@@ -78720,26 +79521,20 @@
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/shop/clothing_store)
 "tXQ" = (
-/obj/structure/hedge{
-	pixel_y = 6
+/obj/structure/platform/lowwall/rich,
+/obj/machinery/light/prince/directional/north,
+/obj/item/statuebust/hippocratic{
+	desc = "A bust of the famous Greek physician Hippocrates of Kos, often referred to as the father of western medicine. Stop... Is that a black mark in the shape of a rose?...";
+	pixel_x = 2;
+	pixel_y = 14;
+	anchored = 1
 	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
+/obj/item/stack/sheet/mineral/diamond/crown{
+	pixel_x = 10;
+	pixel_y = -2
 	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "tXV" = (
 /obj/effect/turf_decal/bordur{
 	dir = 9
@@ -78748,10 +79543,17 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "tXY" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
+/obj/structure/table/countertop/black,
+/obj/machinery/reagentgrinder/kitchen,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 10;
+	pixel_y = 10
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "tYd" = (
 /obj/structure/table,
@@ -78859,6 +79661,14 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"tYZ" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 4
+	},
+/obj/item/binoculars,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "tZg" = (
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/city/toilet,
@@ -78932,12 +79742,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/hotel)
-"uaD" = (
-/obj/structure/table/wood{
-	density = 0
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/jazzclub)
 "uaQ" = (
 /obj/effect/decal/graffiti/large,
 /turf/open/misc/dirt,
@@ -79083,8 +79887,10 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
 "udf" = (
-/obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet/royalblue,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
 "udg" = (
 /obj/machinery/light/small/directional/east,
@@ -79114,6 +79920,16 @@
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/brick_old,
 /area/vtm/interior)
+"udM" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "udN" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
@@ -79560,11 +80376,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
-"ukB" = (
-/obj/machinery/light/prince/directional/north,
-/obj/structure/chair/comfy/darkpack/dark,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "ukG" = (
 /obj/structure/chair/darkpack{
 	dir = 8
@@ -79753,10 +80564,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "umW" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "una" = (
 /obj/effect/decal/pallet{
@@ -79915,10 +80726,13 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/community)
 "upf" = (
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/structure/table/wood,
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
+/obj/structure/chair/comfy/darkpack/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "upg" = (
 /obj/machinery/vending/snack/orange{
@@ -79963,6 +80777,10 @@
 /obj/item/toy/basketball,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"upC" = (
+/mob/living/basic/pet/cat/darkpack,
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/unionsquare)
 "upI" = (
 /obj/machinery/light/floor/lamppost/three{
 	dir = 8
@@ -80080,6 +80898,19 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/fishermanswharf/lower)
+"uqE" = (
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/structure/railing/darkpack/metal,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/old,
+/area/vtm)
 "uqH" = (
 /obj/effect/decal/fakelattice{
 	density = 0
@@ -80090,6 +80921,12 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/police/fed)
+"uqK" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "uqL" = (
 /obj/effect/decal/pallet{
 	pixel_y = -7
@@ -80254,6 +81091,17 @@
 /obj/effect/landmark/start/darkpack/hecata/nonni,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"usL" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/instrument/guitar,
+/obj/item/instrument/eguitar,
+/obj/item/instrument/banjo,
+/obj/item/instrument/violin{
+	name = "violin"
+	},
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "usM" = (
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating/rough,
@@ -80303,6 +81151,18 @@
 	},
 /turf/open/water/vamp_sewer,
 /area/vtm/interior/sewer/nosferatu_town)
+"utt" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/structure/chair/stool/bar/darkpack/blue,
+/obj/effect/turf_decal/siding/wideplating/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "utx" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -80477,14 +81337,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
-"uvV" = (
-/obj/structure/curtain/bounty,
-/obj/structure/window/reinforced/tinted/spawner/directional/south{
-	max_integrity = 1000000
-	},
-/obj/structure/platform/lowwall/painted/window/reinforced,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "uvX" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -80517,9 +81369,16 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
 "uwt" = (
-/obj/effect/decal/shadow,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/white,
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/chair/sofa/corp{
+	color = "#36454F";
+	dir = 1
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "uwu" = (
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/plating/sidewalk/old,
@@ -80564,18 +81423,20 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior)
 "uwW" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/wine{
+	pixel_x = -9;
+	pixel_y = 7
 	},
-/obj/structure/chair/sofa/corp{
-	pixel_x = -7;
-	pixel_y = 12
+/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass{
+	pixel_x = 2;
+	pixel_y = 9
 	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
+/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass{
+	pixel_x = 9;
+	pixel_y = 3
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "uxa" = (
 /obj/structure/table/wood,
@@ -80707,6 +81568,13 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/clinic)
+"uyQ" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "uyT" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -80766,20 +81634,6 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/wood/old,
 /area/vtm)
-"uzp" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/light/prince/directional/west,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/musician/piano{
-	icon_state = "piano"
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "uzq" = (
 /obj/effect/turf_decal/siding/grey/inner_corner{
 	dir = 8
@@ -80823,6 +81677,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
+"uzS" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "uzW" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -81244,6 +82105,15 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"uEu" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "uEE" = (
 /obj/machinery/oven/range,
 /turf/open/floor/city/toilet,
@@ -81545,6 +82415,18 @@
 "uIl" = (
 /turf/open/openspace,
 /area/vtm/interior/bianchiBank)
+"uIm" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/pen{
+	pixel_y = 6;
+	pixel_x = 5
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "uIz" = (
 /obj/effect/turf_decal/darkpack/grass{
 	dir = 1
@@ -81724,9 +82606,16 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "uKH" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/ornate,
+/obj/effect/decal/shadow{
+	icon_state = "shadow-alt";
+	pixel_y = 32
+	},
+/obj/structure/bedsheetbin/basket{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "uKI" = (
 /obj/structure/chair/sofa/corp/right{
@@ -81735,6 +82624,24 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
+"uKP" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
+"uKZ" = (
+/obj/structure/platform/lowwall/rich,
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "uLu" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/white{
@@ -81742,6 +82649,15 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
+"uLA" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/obj/structure/chair/sofa/corp/right{
+	color = "#36454F"
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "uLD" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 4
@@ -81860,6 +82776,16 @@
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/shop/otolleys)
+"uNl" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/obj/structure/chair/sofa/corp/corner{
+	color = "#36454F";
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "uNq" = (
 /obj/structure/chair/office/darkpack/black,
 /mob/living/carbon/human/npc/shop,
@@ -81904,9 +82830,8 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "uOc" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "uOf" = (
 /obj/structure/hedge,
@@ -82160,20 +83085,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
-"uSa" = (
-/obj/structure/coclock,
-/obj/structure/closet/secure_closet/freezer,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/storage/fancy/egg_box,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/food/burger/plain,
-/obj/item/food/burger/plain,
-/obj/item/food/burger/plain,
-/obj/item/food/burger/plain,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/jazzclub)
 "uSe" = (
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
 /obj/structure/railing{
@@ -82225,6 +83136,15 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"uSv" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "uSB" = (
 /obj/structure/filingcabinet/medical{
 	pixel_x = -10;
@@ -82401,7 +83321,6 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/bianchiBank)
 "uUt" = (
-/obj/structure/table,
 /obj/machinery/vending/boozeomat,
 /obj/structure/platform/lowwall/old,
 /obj/structure/table,
@@ -82509,22 +83428,9 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/church/staff)
 "uVM" = (
-/obj/item/statuebust{
-	anchored = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "uWj" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -82555,8 +83461,13 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "uWo" = (
-/obj/structure/hedge,
-/turf/open/floor/wood/old,
+/obj/machinery/light/prince/directional/north,
+/obj/structure/platform/lowwall/rich,
+/obj/item/statuebust/hippocratic{
+	pixel_y = 14;
+	anchored = 1
+	},
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "uWt" = (
 /turf/closed/wall/vampwall/bar,
@@ -82572,16 +83483,11 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/unionsquare)
 "uWA" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 1
 	},
-/obj/item/binoculars,
-/obj/machinery/button/curtain{
-	id = 2004
-	},
-/obj/structure/table/wood/fancy/red,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "uWC" = (
 /obj/structure/closet/secure_closet/weapons,
 /obj/item/storage/fancy/hardcase,
@@ -82635,12 +83541,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "uWS" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/light/prince/directional/west,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood/dark,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "uWW" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
@@ -82682,6 +83586,9 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/antiques)
+"uXm" = (
+/turf/open/water/hot_spring,
+/area/vtm/interior/jazzclub)
 "uXy" = (
 /obj/structure/rack/clothing/rand{
 	dir = 8
@@ -82776,13 +83683,6 @@
 /obj/item/clothing/gloves/vampire/work,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch)
-"uYx" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "uYz" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -82792,12 +83692,10 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/salubri)
 "uYB" = (
-/obj/structure/hedge,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
+/obj/structure/railing/wooden_fence{
+	dir = 8
 	},
-/turf/open/floor/wood/old,
+/turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/jazzclub)
 "uYF" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -82815,6 +83713,15 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"uYL" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "uYN" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/vampfence{
@@ -82888,27 +83795,6 @@
 	},
 /turf/open/floor/cult,
 /area/vtm/interior/chantry/basement)
-"val" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/item/statuebust/hippocratic{
-	anchored = 1
-	},
-/obj/machinery/light/prince/directional/north,
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "vav" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/chair/sofa/corp/corner,
@@ -83309,10 +84195,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "vfi" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
 	},
-/turf/open/floor/carpet/green,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	color = "#36454F"
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "vfs" = (
 /obj/effect/turf_decal/bordur{
@@ -83375,6 +84265,17 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/arts)
+"vgm" = (
+/obj/effect/decal/wallpaper/gold,
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior/jazzclub)
+"vgo" = (
+/obj/structure/chair/sofa/corp{
+	color = "#36454F";
+	dir = 1
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "vgp" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -83389,24 +84290,12 @@
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/misc/dirt,
 /area/vtm/graveyard)
-"vgy" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/instrument/violin,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "vgB" = (
 /obj/structure/vampdoor/old{
 	locked = 1
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"vgC" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "vgD" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/concrete,
@@ -83437,6 +84326,12 @@
 /obj/structure/barrels/rand,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
+"vgX" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "vgY" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/wood/smooth/old,
@@ -83480,10 +84375,6 @@
 "vhv" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm)
-"vhw" = (
-/obj/structure/chair/comfy/darkpack,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "vhx" = (
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/brick_old,
@@ -83633,9 +84524,10 @@
 /turf/open/floor/wood,
 /area/vtm/interior/church/haven)
 "vjR" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/ornate,
+/obj/effect/decal/painting/second{
+	pixel_y = 32
+	},
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/jazzclub)
 "vkl" = (
 /obj/effect/turf_decal/bordur{
@@ -83648,25 +84540,14 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
 "vkm" = (
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/mapping_helpers/door/access/primogen_ventrue,
 /obj/structure/vampdoor/wood{
-	dir = 4;
-	lock_id = "primVentrue";
-	lockpick_difficulty = 16;
-	name = "board chair's office";
-	locked = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/door/access/primogen_ventrue,
-/obj/effect/mapping_helpers/door/bash_difficulty/ten,
-/obj/effect/mapping_helpers/door/lock_difficulty/ten,
-/obj/effect/mapping_helpers/door/lock,
-/turf/open/floor/mineral/plastitanium/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vks" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -83777,17 +84658,17 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/outside/park)
 "vlu" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vlz" = (
 /obj/structure/railing/darkpack/metal/industrial/solo{
 	dir = 1
@@ -83902,14 +84783,30 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/millennium_tower)
 "vns" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
+/obj/structure/table/countertop/black,
+/obj/item/reagent_containers/condiment/hotsauce{
+	pixel_y = 16;
+	pixel_x = -8
 	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
+/obj/item/reagent_containers/condiment/olive_oil{
+	pixel_y = 16
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/item/reagent_containers/condiment/mayonnaise{
+	pixel_x = 9;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/condiment/bbqsauce{
+	pixel_y = 4;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/condiment/soysauce{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/ketchup{
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "vnt" = (
 /obj/structure/table,
@@ -83947,6 +84844,12 @@
 /obj/effect/turf_decal/siding/wood/dark,
 /turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/endron_facility/restricted)
+"voi" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "vol" = (
 /obj/structure/flora/bush/style_random,
 /turf/open/misc/grass,
@@ -83997,11 +84900,20 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "voT" = (
-/obj/machinery/light/directional/south,
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/item/reagent_containers/cup/glass/bottle/wine{
+	pixel_x = 8;
+	pixel_y = 17
 	},
-/turf/open/floor/carpet/green,
+/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/martini_glass{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "vpb" = (
 /obj/structure/vampdoor/wood{
@@ -84032,6 +84944,13 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/ghetto)
+"vpo" = (
+/obj/effect/decal/painting/third{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "vpp" = (
 /obj/structure/vampdoor/old,
 /obj/effect/mapping_helpers/door/access/coggie,
@@ -84434,6 +85353,9 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
+"vuJ" = (
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior/theatre)
 "vuW" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/landmark/npcwall,
@@ -84549,13 +85471,6 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/forest)
-"vwj" = (
-/obj/structure/table/modern,
-/obj/machinery/button/curtain{
-	id = 2004
-	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
 "vwp" = (
 /obj/effect/turf_decal/stripes/line{
 	pixel_y = -9
@@ -84667,6 +85582,19 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
+"vyt" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 16
+	},
+/obj/structure/railing/wooden_fence{
+	dir = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "vyw" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 5
@@ -84821,13 +85749,7 @@
 	},
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
-"vBM" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/outside/financialdistrict)
 "vBN" = (
 /obj/structure/railing{
 	dir = 4
@@ -84896,8 +85818,12 @@
 /turf/open/misc/grass,
 /area/vtm/interior/endron_facility)
 "vCy" = (
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/chair/comfy/darkpack/darkblue,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vCz" = (
 /obj/structure/table,
 /obj/item/food/burger/plain,
@@ -84917,7 +85843,7 @@
 "vCD" = (
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/ghetto)
 "vCE" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 4
@@ -85351,11 +86277,14 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/restricted)
 "vIq" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "vIF" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/flag/usa{
@@ -85391,6 +86320,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"vJa" = (
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "vJb" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
@@ -85476,9 +86409,13 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "vKp" = (
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/binoculars,
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vKr" = (
 /turf/closed/wall/vampwall/junk{
 	density = 0
@@ -85520,11 +86457,6 @@
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
-"vLo" = (
-/obj/effect/decal/wallpaper/paper/rich/low,
-/obj/effect/decal/wallpaper/gold,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/ventrue)
 "vLu" = (
 /obj/structure/bed/maint,
 /turf/open/floor/plating/rough,
@@ -85546,6 +86478,26 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
+"vLL" = (
+/obj/item/flashlight/flare/candle/infinite{
+	anchored = 1;
+	pixel_y = 13;
+	pixel_x = 9
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = 3
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "vLV" = (
 /obj/structure/toilet{
 	dir = 1
@@ -85553,12 +86505,16 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite/basement)
 "vMa" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/sink/directional/south,
+/obj/machinery/light/prince/directional/east,
+/obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/structure/sink/directional/south,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "vMc" = (
 /obj/structure/railing{
 	pixel_y = -2
@@ -85684,14 +86640,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
-"vOe" = (
-/obj/structure/mop_bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/cup/bucket,
-/obj/structure/sink/directional/south,
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/jazzclub)
 "vOh" = (
 /obj/structure/closet/secure_closet,
 /turf/open/floor/wood/smooth/old,
@@ -85851,10 +86799,6 @@
 /obj/structure/statue/bone/rib,
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/sewer)
-"vQC" = (
-/obj/structure/table/wood/fancy/green,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "vQN" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 1
@@ -86027,6 +86971,12 @@
 	},
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
+"vTb" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "vTd" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -86041,6 +86991,10 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"vTv" = (
+/obj/machinery/light/prince/directional/west,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vTC" = (
 /obj/structure/chair/wood/darkpack{
 	dir = 4
@@ -86140,23 +87094,10 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/pacificheights/old)
 "vUx" = (
-/obj/structure/chair/sofa/corp{
-	pixel_x = -7;
-	pixel_y = 12
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/jazzclub)
-"vUA" = (
-/obj/structure/chair/comfy/darkpack,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "vUC" = (
 /obj/structure/railing/darkpack/metal/industrial/solo{
@@ -86262,11 +87203,9 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
 "vVW" = (
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/chair/comfy/darkpack/dark,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vVY" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/misc/dirt/rails,
@@ -86387,16 +87326,18 @@
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/salubri)
 "vXc" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
+/obj/structure/platform/lowwall/rich,
+/obj/machinery/light/prince/directional/north,
+/obj/item/statuebust{
+	anchored = 1;
+	pixel_y = 13
 	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/clothing/accessory/medal/silver{
-	desc = "A silver World War 2 medal";
-	name = "World War 2 Medal"
+/obj/item/stack/sheet/mineral/diamond{
+	pixel_x = -10;
+	pixel_y = -1
 	},
 /turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm/interior/jazzclub)
 "vXm" = (
 /obj/machinery/hydroponics/simple/plastic,
 /obj/effect/decal/graffiti,
@@ -86480,12 +87421,6 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/millennium_tower)
-"vYs" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "vYt" = (
 /obj/structure/vampdoor/wood{
 	lock_id = "bianchiBank";
@@ -86565,6 +87500,10 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"vYY" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vZa" = (
 /obj/structure/chair/plastic/darkpack{
 	dir = 8
@@ -86583,8 +87522,25 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop)
 "vZk" = (
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/structure/table/no_smooth/large/wood/stand/alt{
+	pixel_x = -15;
+	pixel_y = 13
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 18
+	},
+/obj/item/stack/dollar/rand/hundred{
+	pixel_x = 12;
+	pixel_y = 18
+	},
+/obj/item/stack/dollar/rand/hundred{
+	pixel_x = 7;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "vZm" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/roadsign/noturnback,
@@ -86612,12 +87568,14 @@
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/sabbat_lair)
 "vZF" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/chair/office/darkpack/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/blackgold,
+/area/vtm/interior/jazzclub)
 "vZI" = (
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
@@ -86797,10 +87755,6 @@
 	},
 /turf/open/floor/city/clinic,
 /area/vtm/interior/salubri)
-"wbT" = (
-/obj/structure/table,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/jazzclub)
 "wbU" = (
 /obj/warehouse_generator,
 /obj/machinery/light/directional/north,
@@ -86880,6 +87834,25 @@
 "wcT" = (
 /turf/open/openspace,
 /area/vtm/interior/laundromat)
+"wdn" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 4;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "wdp" = (
 /obj/structure/platform/lowwall/wood,
 /obj/structure/table/wood,
@@ -86942,12 +87915,6 @@
 /obj/structure/closet/body_bag,
 /turf/open/water,
 /area/vtm/interior/bianchiBank)
-"wed" = (
-/obj/structure/chair/office/darkpack/black{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/millennium_tower/ventrue)
 "wef" = (
 /obj/structure/closet/crate/dumpster,
 /turf/open/floor/plating/sidewalkalt,
@@ -86998,6 +87965,15 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf)
+"weE" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/support,
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "weI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -87015,7 +87991,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "weX" = (
 /obj/effect/turf_decal/bordur{
 	dir = 6
@@ -87026,8 +88002,19 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "wfa" = (
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/closet/secure_closet/freezer,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/cup/glass/baggie/meth/cocaine,
+/obj/item/reagent_containers/cup/glass/baggie/meth,
+/obj/item/reagent_containers/blood/a_plus,
+/obj/item/reagent_containers/blood/a_plus,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wfm" = (
 /obj/effect/landmark/npcbeacon/directed,
 /turf/open/floor/plating/sidewalk,
@@ -87063,17 +88050,16 @@
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
-"wfV" = (
-/obj/item/newspaper,
-/obj/structure/table/wood/fancy/green,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior/millennium_tower/ventrue)
 "wfW" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 6
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
 	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/decal/shadow,
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wfY" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -87102,16 +88088,6 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"wgf" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "wgg" = (
 /obj/structure/railing{
 	dir = 1;
@@ -87137,20 +88113,14 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/wood/old,
 /area/vtm/outside/northbeach)
+"wgL" = (
+/obj/effect/decal/wallpaper/paper/fancy/red,
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior/jazzclub)
 "wgQ" = (
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/shop/gunshop)
-"wgT" = (
-/obj/structure/table/wood,
-/obj/effect/decal/wallpaper/paper/darkred,
-/obj/item/rag{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "wgU" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/carpet/darkpack,
@@ -87456,6 +88426,12 @@
 /obj/structure/roadsign/parking,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
+"wlm" = (
+/obj/effect/decal/painting/third{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "wlq" = (
 /obj/machinery/light/directional/west,
 /obj/structure/bookcase/random/reference,
@@ -87712,6 +88688,18 @@
 /obj/effect/turf_decal/bordur/corner,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"wpA" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/plate/small{
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/obj/item/plate/small{
+	pixel_y = 9;
+	pixel_x = 5
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wpF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -87827,6 +88815,20 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
+"wrm" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wrw" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -87856,10 +88858,14 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
 "wrD" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/machinery/vending/cigarette{
+	pixel_y = 16;
+	density = 0
+	},
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 5
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "wrI" = (
 /obj/structure/vampstatue/angel,
@@ -87872,10 +88878,22 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf)
 "wsa" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
+/obj/structure/table/countertop/black,
+/obj/structure/sink/basin/directional/south,
+/obj/item/kitchen/rollingpin{
+	pixel_x = -8;
+	pixel_y = 11
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/item/knife/kitchen{
+	pixel_y = 9;
+	pixel_x = 11
+	},
+/obj/item/knife/kitchen{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/structure/coclock,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "wsb" = (
 /obj/machinery/iv_drip,
@@ -87949,6 +88967,10 @@
 	},
 /turf/open/indestructible/white/textured,
 /area/vtm/interior)
+"wsQ" = (
+/obj/structure/platform/lowwall/rich,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wsX" = (
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch)
@@ -87958,11 +88980,11 @@
 /turf/open/misc/grass,
 /area/vtm/outside/unionsquare)
 "wtb" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 6
+	},
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "wtd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -88001,6 +89023,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
+"wty" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
+	},
+/obj/machinery/light/prince/directional/east,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wtC" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/carpet/darkpack,
@@ -88144,7 +89176,7 @@
 	},
 /obj/effect/decal/pallet,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "wwj" = (
 /obj/effect/landmark/npcwall,
 /obj/effect/turf_decal/bordur{
@@ -88247,7 +89279,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "wxp" = (
 /obj/structure/table,
 /obj/item/gun/ballistic/revolver/darkpack/magnum,
@@ -88837,6 +89869,12 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic/haven)
+"wDM" = (
+/obj/effect/turf_decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/sidewalkalt,
+/area/vtm/outside/unionsquare)
 "wDV" = (
 /obj/structure/flora/rock/pile/darkpack,
 /turf/open/misc/grass,
@@ -88984,14 +90022,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower)
-"wGh" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "wGp" = (
 /obj/structure/table,
 /obj/item/emergency_bed,
@@ -89012,25 +90042,12 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "wGw" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/curtain/cloth/fancy/mechanical{
-	id = 2005
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood/old,
+/obj/effect/decal/wallpaper/red,
+/turf/closed/wall/vampwall/city,
 /area/vtm/interior/theatre)
-"wGC" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
 "wGI" = (
 /obj/effect/decal/coastline{
 	dir = 4
@@ -89091,9 +90108,6 @@
 /obj/structure/ladder/manhole/down,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
-"wHn" = (
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "wHu" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/light/directional/south,
@@ -89172,11 +90186,9 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
 "wIo" = (
-/obj/structure/railing{
-	pixel_y = -2
-	},
+/obj/structure/table/wood/fancy/red,
 /turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/ventrue)
+/area/vtm)
 "wIt" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -89190,11 +90202,10 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/theatre)
 "wIx" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 1
 	},
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/green,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "wIE" = (
 /obj/effect/turf_decal/bordur,
@@ -89258,6 +90269,9 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/police/upstairs)
+"wJH" = (
+/turf/open/floor/iron/stairs,
+/area/vtm)
 "wJN" = (
 /obj/effect/decal/cleanable/cardboard,
 /obj/structure/cable/layer1,
@@ -89360,12 +90374,14 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
 "wKO" = (
-/obj/structure/rack/food{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wKS" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 1
@@ -89609,12 +90625,17 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop)
 "wNY" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3;
-	pixel_x = 0
+/obj/structure/table/wood,
+/obj/structure/platform/lowwall/rich,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 10;
+	pixel_y = 10
 	},
-/turf/open/floor/carpet/red,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "wNZ" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -89634,6 +90655,12 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
+"wOp" = (
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "wOx" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -89666,7 +90693,7 @@
 /obj/structure/bed/maint,
 /obj/item/newspaper,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "wOF" = (
 /obj/effect/turf_decal/asphaltline,
 /turf/open/floor/plating/asphalt,
@@ -90009,6 +91036,10 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"wST" = (
+/obj/structure/closet/cardboard,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/jazzclub)
 "wSX" = (
 /turf/open/floor/black,
 /area/vtm/interior/mansion)
@@ -90098,6 +91129,12 @@
 	},
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/interior/setite)
+"wTQ" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm)
 "wUd" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/landmark/npcwall,
@@ -90228,6 +91265,10 @@
 "wVS" = (
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/tzimisce_sanctum)
+"wWb" = (
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "wWd" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/turf_decal/weather/dirt{
@@ -90423,14 +91464,27 @@
 	dir = 8
 	},
 /area/vtm/outside/ghetto)
+"wYM" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/machinery/light/prince/directional/east{
+	pixel_y = 8
+	},
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "wYX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/mop,
-/obj/structure/mop_bucket,
-/obj/machinery/light/directional/east,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/structure/railing/wooden_fence{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "wYY" = (
 /obj/effect/turf_decal/asphaltline{
 	dir = 8
@@ -90640,7 +91694,7 @@
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "xaf" = (
 /obj/structure/railing{
 	dir = 8;
@@ -90654,6 +91708,30 @@
 "xav" = (
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/sewer)
+"xaD" = (
+/obj/structure/coclock,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/storage/fancy/egg_box,
+/obj/item/food/burger/plain,
+/obj/item/food/burger/plain,
+/obj/item/food/burger/plain,
+/obj/item/food/burger/plain,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/rice,
+/obj/item/reagent_containers/condiment/rice,
+/obj/item/food/seaweedsheet,
+/obj/item/food/seaweedsheet,
+/obj/item/food/seaweedsheet,
+/obj/item/food/seaweedsheet,
+/obj/structure/closet/secure_closet/freezer{
+	locked = 0
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "xaF" = (
 /obj/structure/chair/darkpack,
 /turf/open/floor/city/plating_mono,
@@ -90850,12 +91928,6 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
-"xcw" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "xcJ" = (
 /obj/structure/chair/office/darkpack/black{
 	dir = 8
@@ -91165,6 +92237,13 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
+"xgz" = (
+/obj/machinery/light/prince/directional/east,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "xgK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -91252,7 +92331,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "xhL" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/smooth,
@@ -91824,29 +92903,8 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
 "xpv" = (
-/obj/structure/hedge{
-	pixel_y = 6
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_y = 10
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	pixel_y = -1
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/iron/stairs/black,
+/area/vtm/interior/jazzclub)
 "xpy" = (
 /obj/structure/vampfence/corner/rich{
 	dir = 1;
@@ -91855,10 +92913,10 @@
 /turf/open/misc/grass,
 /area/vtm/graveyard)
 "xpD" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 9
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood/old,
 /area/vtm/interior/jazzclub)
 "xpI" = (
 /obj/effect/turf_decal/siding/grey{
@@ -91874,14 +92932,15 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "xpQ" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/shower/directional/east,
-/obj/effect/turf_decal/siding/white{
+/obj/structure/curtain{
+	pixel_y = 8
+	},
+/obj/machinery/shower/directional/south,
+/obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/structure/curtain,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/city/factory,
+/area/vtm/interior/jazzclub)
 "xpR" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -91956,10 +93015,6 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
-"xqn" = (
-/obj/structure/stairs/north,
-/turf/open/floor/carpet/purple,
-/area/vtm/interior/jazzclub)
 "xqp" = (
 /obj/darkpack_car/retro/rand/anarch,
 /obj/effect/decal/pallet,
@@ -92015,15 +93070,6 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f3)
-"xqH" = (
-/obj/structure/curtain/cloth/fancy/mechanical/luxurious{
-	id = 2004
-	},
-/obj/effect/decal/wallpaper/gold/low,
-/obj/effect/decal/wallpaper/gold,
-/obj/structure/platform/lowwall/rich/window,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
 "xqJ" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south{
 	max_integrity = 1000000
@@ -92053,6 +93099,19 @@
 	dir = 4
 	},
 /area/vtm/interior/tzimisce_manor)
+"xrr" = (
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "xru" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -92158,16 +93217,6 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
-"xsI" = (
-/obj/machinery/light/prince/directional/north,
-/obj/structure/closet/secure_closet,
-/obj/item/wirecutters,
-/obj/item/storage/box/lights/mixed,
-/obj/item/reagent_containers/spray/pepper,
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/under/vampire/guard,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "xsJ" = (
 /obj/structure/roadsign/crosswalk,
 /obj/effect/landmark/npcability,
@@ -92220,7 +93269,7 @@
 "xtN" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/grass,
-/area/vtm/interior/library)
+/area/vtm/outside/unionsquare)
 "xtO" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
@@ -92321,12 +93370,6 @@
 /obj/structure/flora/tree/vamp,
 /turf/open/misc/dirt,
 /area/vtm/graveyard)
-"xvs" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/turf/open/floor/wood/old,
-/area/vtm/interior/jazzclub)
 "xvy" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/rough,
@@ -92412,6 +93455,12 @@
 /obj/structure/lattice/pentex,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/restricted)
+"xwG" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "xwJ" = (
 /obj/structure/curtain/cloth,
 /obj/effect/decal/rugs,
@@ -92444,6 +93493,10 @@
 /obj/effect/landmark/start/darkpack/voivode/bogatyr,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/tzimisce_manor)
+"xxB" = (
+/obj/machinery/light/prince/directional/south,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "xxD" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -92506,19 +93559,6 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm)
-"xyy" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/city/toilet,
-/area/vtm/interior/jazzclub)
 "xyB" = (
 /obj/effect/landmark/npcbeacon,
 /obj/effect/landmark/npcactivity,
@@ -92560,6 +93600,12 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
+"xza" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "xzb" = (
 /obj/effect/turf_decal/darkpack/grass{
 	dir = 4
@@ -92635,14 +93681,8 @@
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/millennium_tower)
 "xAx" = (
-/obj/structure/table/wood/fancy/black,
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/item/instrument/accordion,
-/obj/item/instrument/piano_synth,
-/obj/item/instrument/harmonica,
-/obj/machinery/light/prince/directional/south,
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/carpet/purple,
+/obj/structure/stairs/west,
+/turf/open/floor/carpet/darkpack/bluegold,
 /area/vtm/interior/jazzclub)
 "xAz" = (
 /obj/structure/closet,
@@ -92705,6 +93745,15 @@
 /obj/item/instrument/piano_synth,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
+"xBs" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/structure/railing/darkpack/metal,
+/turf/open/floor/wood/ornate,
+/area/vtm)
 "xBt" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/blood/a_minus,
@@ -92785,6 +93834,18 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/giovanni/courtyard)
+"xCj" = (
+/obj/effect/turf_decal/bordur{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/rough,
+/area/vtm)
 "xCp" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/railing/darkpack/metal{
@@ -92800,6 +93861,25 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating/granite,
 /area/vtm/interior/bianchiBank)
+"xCt" = (
+/obj/structure/platform/lowwall/rich,
+/obj/structure/vampstatue/angel{
+	pixel_y = 26
+	},
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/food/grown/flower/poppy/geranium{
+	pixel_x = 10;
+	pixel_y = 20
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/jazzclub)
 "xCz" = (
 /obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating/concrete,
@@ -92958,15 +94038,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/vtm/interior/endron_facility/restricted)
-"xEU" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
 "xFe" = (
 /obj/structure/chair/darkpack{
 	dir = 1
@@ -93407,7 +94478,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
 "xJZ" = (
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "xKa" = (
 /obj/structure/platform/lowwall/market/window,
@@ -93567,10 +94638,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"xLB" = (
-/obj/effect/landmark/npcactivity,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/interior/library)
 "xLD" = (
 /obj/structure/bed/maint,
 /turf/open/floor/carpet/darkpack,
@@ -93620,11 +94687,6 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/clothing_store)
-"xMa" = (
-/obj/structure/flora/tree/vamp,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/misc/grass,
-/area/vtm/interior/jazzclub)
 "xMb" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -93738,12 +94800,6 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/community)
-"xNo" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "xNq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/bush/sunny/style_random,
@@ -93879,6 +94935,16 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
+"xQE" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 5
+	},
+/obj/structure/chair/sofa/corp/right{
+	color = "#36454F";
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "xQM" = (
 /obj/structure/curtain/bounty{
 	pixel_y = 8
@@ -93940,11 +95006,15 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
 "xRL" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
 	},
-/turf/open/floor/plating/granite/black,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/decal/shadow,
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "xRN" = (
 /obj/structure/table,
 /obj/structure/platform/lowwall/rich/old,
@@ -94045,6 +95115,10 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/chinatown)
+"xTc" = (
+/obj/effect/decal/wallpaper/blue,
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior/jazzclub)
 "xTe" = (
 /obj/item/ritual_tome/arcane,
 /obj/machinery/light/small/red/directional/east,
@@ -94225,6 +95299,11 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"xUM" = (
+/obj/structure/sink/directional/west,
+/obj/machinery/light/prince/directional/east,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "xUN" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
@@ -94408,13 +95487,6 @@
 	},
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
-"xXm" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/vtm/interior/millennium_tower/ventrue)
 "xXn" = (
 /obj/structure/chair/comfy/beige{
 	pixel_y = 4
@@ -94423,15 +95495,15 @@
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/f3)
 "xXo" = (
-/obj/effect/turf_decal/siding/white{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/machinery/light/prince/directional/west,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/ventrue)
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "xXy" = (
 /obj/effect/turf_decal/siding/dark_blue/corner{
 	dir = 1
@@ -94439,9 +95511,12 @@
 /turf/open/floor/city/clinic,
 /area/vtm/interior/clinic)
 "xXz" = (
-/obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "xXB" = (
 /obj/structure/roadblock{
 	dir = 1
@@ -94628,12 +95703,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"ybq" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/millennium_tower/ventrue)
 "ybt" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/concrete,
@@ -94920,16 +95989,14 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
 "yeU" = (
-/obj/structure/table/wood,
-/obj/item/rag{
-	pixel_x = -4;
-	pixel_y = 5
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
-/obj/structure/curtain/bounty,
-/obj/effect/decal/wallpaper/paper/rich/low,
-/obj/structure/platform/lowwall/rich,
-/turf/open/floor/plating/rough,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "yeX" = (
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/shop/gunshop)
@@ -94939,6 +96006,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/techshop)
+"yfb" = (
+/obj/structure/vampdoor/wood,
+/obj/effect/mapping_helpers/door/access/primogen_ventrue,
+/obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/mapping_helpers/door/lock,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "yfe" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -95036,6 +96110,15 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
+"yfM" = (
+/obj/structure/roofstuff/vent_end{
+	dir = 8
+	},
+/obj/effect/turf_decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/roofwalk,
+/area/vtm)
 "yfN" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 1
@@ -95275,7 +96358,7 @@
 "yja" = (
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "yjs" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 4
@@ -95362,12 +96445,21 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
 "ykA" = (
-/obj/machinery/button/curtain{
-	id = "ventrueprim"
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/table/wood/fancy/red,
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/obj/structure/table/wood/fancy/royalblue,
-/turf/open/floor/carpet/royalblue,
-/area/vtm/interior/millennium_tower/ventrue)
+/obj/item/pen/fountain/captain{
+	name = "Golden fountain pen";
+	pixel_y = 8
+	},
+/obj/item/kirbyplants/darkpack/random{
+	pixel_x = -12;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "ykD" = (
 /obj/structure/bonfire/fire_barrel,
 /obj/effect/spawner/random/occult/artifact,
@@ -95383,7 +96475,7 @@
 "ykQ" = (
 /obj/structure/bonfire/fire_barrel,
 /turf/open/floor/plating/sidewalkalt,
-/area/vtm/interior/library)
+/area/vtm/outside/financialdistrict)
 "ykV" = (
 /obj/structure/table/wood{
 	density = 0
@@ -184829,7 +185921,7 @@ ujA
 ujA
 ujA
 ujA
-ujA
+gFf
 ujA
 ujA
 ujA
@@ -186358,21 +187450,21 @@ wbX
 xNC
 wcv
 eiL
-hKx
-hKx
-wsc
-hKx
-hKx
+pAr
+pAr
 eiL
-wsc
+pAr
+pAr
+eiL
+qGS
 sxM
 eiL
 eiL
-hKx
-hKx
+bdk
+bdk
 eiL
-hKx
-hKx
+bdk
+bdk
 eiL
 eiL
 hnz
@@ -186614,22 +187706,22 @@ wbX
 wbX
 xNC
 nXE
-wsc
+vgm
 tSq
-hnC
+frP
 qYQ
-pzZ
-fXp
+idO
+idO
 qqB
-wsa
+kSQ
 mQX
-wsc
+xTc
 oqC
 vns
-tXY
+xaD
 cUC
 tXY
-cdG
+qNH
 jus
 eiL
 hnz
@@ -186873,18 +187965,18 @@ xNC
 pES
 oqb
 irE
-hnC
-mIP
-hKq
+sII
+edY
 bLX
-jrs
+bLX
+idO
 ims
 pnH
-wsc
+xTc
 wsa
-tEg
-bvA
-bvA
+hnC
+hnC
+gEX
 bvA
 tEg
 cdG
@@ -187130,21 +188222,21 @@ kLG
 xEN
 bex
 dfu
-hnC
+hDY
 ree
-xMa
-idO
-ims
-cCY
-jus
-wsc
-ndq
-kWI
-mYc
+uXm
+pIE
+aIV
+rPo
+pnH
+pMk
+hnC
+hnC
+gEX
 tXb
 mYc
 iAj
-iIJ
+hnC
 aNn
 hnz
 gcj
@@ -187385,23 +188477,23 @@ wbX
 wbX
 wcJ
 jeC
-wsc
+qGS
 vjR
-hnC
+hDY
 hAj
 nMG
-idO
-ims
-cCY
+uXm
+iVz
+xJZ
 iYl
-gLY
+xTc
 fuP
-tEg
+hnC
 aGu
-aGu
-aGu
-tEg
-ceM
+gBs
+iAj
+hnC
+hnC
 aNn
 hnz
 gcj
@@ -187643,22 +188735,22 @@ wbX
 wcJ
 fzQ
 quI
-bJS
-hnC
+eWx
+hDY
 qgG
-nMG
-idO
-ims
-cCY
-jus
-wsc
-oqC
+ttI
+uXm
+vyt
+gEX
+vLL
+eiL
+xTc
 dPp
-tLz
+hnC
 mtR
 tLz
 ceM
-jus
+hnC
 eiL
 hnz
 gcj
@@ -187899,23 +188991,23 @@ wbX
 wbX
 wcJ
 fzQ
-oqb
-dfu
-hnC
-avM
-nMG
-idO
-ims
+qGS
+nZX
+neC
+ree
+uXm
+uXm
+ojH
 edF
 vfi
-eiL
-eiL
-eiL
-eiL
-eiL
-xPY
-xPY
-eiL
+kxk
+xTc
+jCX
+hnC
+buZ
+fYo
+apX
+xxB
 eiL
 hnz
 gcj
@@ -188156,23 +189248,23 @@ wbX
 wbX
 wcJ
 fzQ
-bex
-dfu
-hnC
+oqb
+lLN
+fgx
 ftr
-sjL
-idO
-ims
-qcm
+uXm
+uXm
+vyt
+edF
 voT
-eiL
-xqn
+vgo
+xTc
 kza
-fsB
+hnC
 hfC
+oWv
 eOW
-eOW
-eGa
+hnC
 eiL
 hnz
 gcj
@@ -188413,23 +189505,23 @@ wbX
 wbX
 wcJ
 fzQ
-wsc
+oqb
 uKH
-hnC
-avM
-nMG
-idO
-ims
-umW
+sII
+mIP
+uXm
+uXm
+vyt
+edF
 poI
-eiL
-xqn
-juB
-fsB
-eoc
-qiT
-qiT
-gmo
+vgo
+xTc
+hnC
+hnC
+hnC
+fdE
+hnC
+hnC
 aNn
 hnz
 gcj
@@ -188670,21 +189762,21 @@ wbX
 wbX
 wcJ
 fzQ
-wsc
-cwd
-hnC
-avM
+qGS
+nZX
+neC
+ree
 pFt
-idO
-ims
-cCY
-cCY
-eiL
-eiL
-eiL
-wsc
+uXm
+ojH
+edF
+tGt
+uNl
+xTc
+rts
+hnC
 wIx
-trt
+uSv
 trt
 fdE
 eiL
@@ -188927,21 +190019,21 @@ wbX
 wbX
 wcJ
 fzQ
-gbb
-rhF
-hnC
-ftr
-nMG
-idO
-ims
-edF
-vfi
-wsc
-rBR
+vgm
+eWx
+hDY
+qgG
+uXm
+ttI
+vyt
+aGu
+prQ
+eiL
+xTc
 pGK
-llz
+lxX
 wNY
-cCY
+lxX
 pDy
 lxX
 eiL
@@ -189184,24 +190276,24 @@ wbX
 wbX
 wcJ
 gge
-oqb
+qGS
 hBI
-hnC
+hDY
 pJs
-eoS
-idO
-ims
-cmk
+uXm
+uXm
+iVz
+xJZ
 ejP
-wsc
+xTc
 rBR
-pGK
-llz
-wNY
-cCY
+hWq
+rKg
+rcD
+rcD
 rcD
 hDv
-aNn
+eiL
 hnz
 gcj
 ujA
@@ -189441,23 +190533,23 @@ wbX
 wbX
 wcJ
 fzQ
-wsc
-nWO
-kwQ
-mIP
-hKq
-idO
-ims
+oqb
+dfu
+hDY
+ree
+pFt
+tyi
+aDd
 umW
-poI
-wsc
+pnH
+khR
 par
-fxs
-hWR
-rBR
-cCY
-bIz
-nrC
+vWT
+vWT
+vWT
+vWT
+vWT
+vWT
 eiL
 hnz
 gcj
@@ -189698,23 +190790,23 @@ wbX
 wbX
 wcJ
 fzQ
-wsc
+oqb
 tna
-oGl
+fgx
 uYB
-cCY
-cCY
-cCY
-cCY
-cCY
-wsc
+cIE
+cIE
+idO
+ims
+pnH
+xTc
 hJz
-rBR
-rBR
-rBR
-cCY
-bHE
-hDv
+vWT
+vWT
+vWT
+vWT
+nZd
+nZd
 aNn
 hnz
 gcj
@@ -189955,21 +191047,21 @@ wbX
 wbX
 wcJ
 fzQ
-wsc
+vgm
 uWo
-nLV
+frP
 oGl
-tLz
-tLz
-tLz
-mtR
+idO
+idO
+eBX
+uKP
 wtb
-oIy
+xTc
+vpo
+edR
 cCY
-cCY
-cCY
-cCY
-cCY
+vWT
+vWT
 aTd
 kxk
 eiL
@@ -190213,22 +191305,22 @@ wbX
 wcJ
 fzQ
 eiL
-eiL
-eiL
-eiL
-wsc
+coW
 coW
 eiL
+coW
+coW
 eiL
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
+qGS
+dOi
+xTc
+csI
+lnz
+utt
+vWT
+vWT
+wdn
+hsQ
 eiL
 hnz
 gcj
@@ -190469,23 +191561,23 @@ wbX
 wbX
 wcJ
 fzQ
-jYC
+mUh
 cXT
-hAs
+hYC
 ntk
-xJZ
-cCY
+bJS
+aop
 hYC
 xpD
 txK
-dKu
+xTc
 lao
 jxM
-jxM
-xvs
-aCi
+utt
+vWT
+vWT
 fQI
-aCi
+gIG
 eiL
 hnz
 gcj
@@ -190726,24 +191818,24 @@ wbX
 wbX
 wcJ
 gge
-jYC
+xTc
 gHb
 vUx
-hir
-xJZ
+tEg
+aCi
 tCE
 qZc
 mvX
 cSr
-wsc
+xTc
 mRK
-jxM
-wbT
-xvs
-fno
-oXC
-iUL
-xPY
+tSz
+iAj
+vWT
+vWT
+nZd
+nZd
+aNn
 hnz
 gcj
 ujA
@@ -190983,24 +192075,24 @@ wbX
 wbX
 wcJ
 fzQ
-wsc
+xTc
 nHO
 uwW
 oXD
-xJZ
-tCE
-bfs
+bJS
+aCi
+bJS
 qiT
 ruT
-wsc
-xyy
-jxM
-dkX
-jji
-fno
+lYz
+par
+vWT
+vWT
+vWT
+vWT
 oXC
 kIs
-xPY
+eiL
 hnz
 gcj
 ujA
@@ -191240,23 +192332,23 @@ wbX
 wbX
 wcJ
 fzQ
-jYC
-gHb
+xTc
+nHO
 qdo
-xJZ
-xJZ
-tCE
+iAj
+aCi
+jCx
 upf
 qiT
 rZj
-wsc
-uSa
-jxM
-vOe
-jRt
-aCi
+kRF
+par
+vWT
+vWT
+vWT
+vWT
 tCS
-aCi
+kqs
 eiL
 hnz
 gcj
@@ -191497,23 +192589,23 @@ wbX
 wbX
 wcJ
 fzQ
-jYC
-cXT
+mUh
+pXZ
 cwW
 bIJ
-xJZ
-tCE
+bJS
+rXI
 fyW
-mvX
+qiT
 uOc
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
+bkR
+uLA
+rLm
+qgh
+vWT
+vWT
+xQE
+uNl
 eiL
 hnz
 gcj
@@ -191754,23 +192846,23 @@ wbX
 wbX
 wcJ
 fzQ
-evP
-gHb
-dZm
-hdD
-xJZ
-tCE
-fyW
+eiL
+xPY
+xPY
+eiL
+eiL
+eiL
+xTc
 wrD
 foG
-wsc
+xTc
 qUB
-auB
+qjb
+fCn
 udf
-xJZ
 udf
-auB
-jus
+xrr
+xrr
 eiL
 hnz
 gcj
@@ -192011,24 +193103,24 @@ wbX
 wbX
 bwu
 fzQ
-eiL
-hZa
-xPY
-xPY
-wsc
+xfm
+fFj
+oVf
+dWa
+xTc
 geL
-wsc
-mwm
-oPU
-wsc
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
 auB
-xJZ
-xJZ
-wsc
-xJZ
-xJZ
-auB
-xPY
+aNn
 hnz
 gcj
 ujA
@@ -192268,24 +193360,24 @@ wbX
 wbX
 riW
 fzQ
-pPs
-fFj
-oVf
-dWa
-wsc
+xfm
+xuq
+hHf
+hHf
+mUh
 hzQ
-cCY
-tCE
-tCE
-wsc
-dXK
+uIm
 xJZ
-bJS
-dGb
-bJS
 xJZ
-rrh
-xPY
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+rUs
+auB
+aNn
 hnz
 gcj
 ujA
@@ -192529,19 +193621,19 @@ mrB
 cHW
 hHf
 hHf
-evP
-cCY
-kza
-kza
+mUh
+bvA
+bvA
+bvA
 all
-pdG
-rBR
-xJZ
-hnC
-bJS
-hnC
-xJZ
-tHd
+uYL
+uYL
+oaJ
+bvA
+bvA
+bvA
+eiL
+eiL
 eiL
 hnz
 gcj
@@ -192783,21 +193875,21 @@ wbX
 wcJ
 jeC
 hhB
-rBR
-rBR
-rBR
+hHf
+hHf
+hHf
 mrZ
-rBR
-kza
+eTI
+eTI
 tJu
-all
-wsc
-qUB
-xJZ
+mUX
 bJS
-hnC
-bJS
-bIJ
+rCt
+uKZ
+xCt
+eTI
+eTI
+xAx
 xAx
 eiL
 hnz
@@ -193043,18 +194135,18 @@ mrB
 sHF
 hHf
 hHf
-evP
-cCY
-kza
-kza
-all
-eDk
-rBR
-xJZ
-hnC
-bJS
-hnC
-hdD
+mUh
+gBs
+gBs
+gBs
+pRL
+uSv
+uSv
+jJW
+gBs
+gBs
+gBs
+gBs
 gBs
 eiL
 hnz
@@ -193300,20 +194392,20 @@ ssi
 xuq
 hHf
 hHf
-eiL
-wsc
-qAl
-eiL
-eiL
-wsc
-vUA
+mUh
+bRi
 xJZ
-bJS
-hnC
-bJS
 xJZ
-rrh
-xPY
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+xJZ
+auB
+aNn
 hnz
 oCx
 lNu
@@ -193557,20 +194649,20 @@ xfm
 kOO
 eAz
 qWr
-mIo
-hEe
-vWT
-vWT
-roo
-wsc
+xTc
+oum
+xJZ
+xJZ
+rfw
+rfw
+xJZ
+rfw
+rfw
+xJZ
+xJZ
+xJZ
 auB
-xJZ
-xJZ
-xJZ
-xJZ
-xJZ
-auB
-xPY
+aNn
 hnz
 gcj
 dEW
@@ -193814,19 +194906,19 @@ ssi
 kOO
 jOV
 qWr
-mIo
-vWT
-vWT
-uaD
-eGg
-wsc
-qUB
-auB
-pks
-ivu
-kVN
-auB
-jus
+eiL
+eiL
+vKN
+eiL
+eiL
+eiL
+qUF
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
 eiL
 hnz
 hgF
@@ -194072,17 +195164,17 @@ cLl
 cLl
 cLl
 bFO
-bFO
-vKN
+grt
+grt
 cLl
 cLl
 cLl
-eiL
-eiL
-eiL
-eiL
-eiL
-eiL
+bkd
+bkd
+hhD
+bkd
+bkd
+vuJ
 eiL
 eiL
 hnz
@@ -194328,15 +195420,15 @@ cLl
 aCS
 xFH
 ppW
-cLl
+bFO
 grt
 grt
 cLl
 slo
 cLl
+lYo
 bkd
-bkd
-bkd
+cLl
 bkd
 bkd
 cLl
@@ -195102,8 +196194,8 @@ bcr
 bFO
 mxc
 vop
+iPK
 vop
-ssN
 vop
 grt
 bFO
@@ -195359,10 +196451,10 @@ cLl
 bFO
 xEu
 vop
+iPK
 vop
-ssN
 vop
-grt
+qQp
 fAu
 bkd
 bkd
@@ -195616,10 +196708,10 @@ opq
 bFO
 buY
 vop
+iPK
 vop
-ssN
 vop
-grt
+qQp
 fAu
 bkd
 bkd
@@ -195873,11 +196965,11 @@ grt
 bFO
 grt
 vop
+iPK
 vop
-ssN
 vop
-grt
-ror
+qQp
+fAu
 bkd
 wIu
 bkd
@@ -196133,8 +197225,8 @@ grt
 grt
 grt
 grt
-grt
-ror
+qQp
+fAu
 bkd
 gUD
 bkd
@@ -196380,18 +197472,18 @@ wbX
 wbX
 wcJ
 fzQ
-bFO
+lNk
 grt
 fgT
 grt
 bFO
 grt
 vop
+iPK
 vop
-ssN
 vop
-grt
-ror
+qQp
+fAu
 bkd
 lfk
 bkd
@@ -196644,11 +197736,11 @@ cLl
 bFO
 xEu
 vop
+iPK
 vop
-ssN
 vop
-grt
-ror
+qQp
+fAu
 bkd
 bkd
 bkd
@@ -196901,11 +197993,11 @@ lXm
 bFO
 mxc
 vop
+iPK
 vop
-ssN
 vop
-grt
-ror
+qQp
+fAu
 bkd
 bkd
 vGJ
@@ -197158,8 +198250,8 @@ lXm
 bFO
 grt
 vop
+iPK
 vop
-ssN
 vop
 grt
 pup
@@ -200423,54 +201515,54 @@ kdy
 kdy
 kdy
 kdy
-kbX
-gNe
-gNe
+cfd
+cam
+cam
 dKv
-gNe
-gNe
-kbX
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-kbX
-gNe
-gNe
-gNe
-gNe
-gNe
-kbX
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
-gNe
+cam
+cam
+cfd
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cfd
+cam
+cam
+cam
+cam
+cam
+cfd
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
+cam
 cam
 cam
 cam
@@ -200681,53 +201773,53 @@ iog
 iog
 wOR
 vBx
-sUd
-wHn
-wHn
-wHn
-sUd
-xLB
-bgy
-aRe
-wHn
-wHn
-jvR
-wHn
-wHn
-wHn
-wHn
-wHn
+pNN
+nYX
+nYX
+nYX
+pNN
+uZu
+iwi
+eRU
+nYX
+nYX
+hNM
+nYX
+nYX
+nYX
+nYX
+nYX
 bAo
-xLB
-sUd
-wHn
-wHn
-wHn
-sUd
-xLB
-bgy
-aRe
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-dJy
-wHn
-jvR
-wHn
-wHn
-wHn
-wHn
-wHn
-dJy
-wHn
-wHn
-wHn
-wHn
-wHn
+uZu
+pNN
+nYX
+nYX
+nYX
+pNN
+uZu
+iwi
+eRU
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+ckf
+nYX
+hNM
+nYX
+nYX
+nYX
+nYX
+nYX
+ckf
+nYX
+nYX
+nYX
+nYX
+nYX
 nYX
 nYX
 ckf
@@ -200937,54 +202029,54 @@ iog
 iog
 iog
 iog
-wHn
-wHn
-gxo
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-gxo
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-jvR
-wHn
-wHn
-wHn
-gxo
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-gxo
-wHn
-wHn
-wHn
+nYX
+nYX
+jlq
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+jlq
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+hNM
+nYX
+nYX
+nYX
+jlq
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+jlq
+nYX
+nYX
+nYX
 hNM
 nYX
 nYX
@@ -201180,20 +202272,20 @@ iog
 iog
 iog
 iog
-wHn
-wHn
-wHn
-knn
-hfn
-hfn
-hfn
-hfn
-hfn
-hfn
-hfn
-hfn
-hfn
-hfn
+iog
+iog
+iog
+ntd
+ppt
+ppt
+ppt
+ppt
+ppt
+ppt
+ppt
+ppt
+ppt
+ppt
 hfn
 hfn
 hfn
@@ -201204,21 +202296,21 @@ hfn
 hfn
 hfn
 kZL
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
 pxc
 aPN
-wHn
-wHn
-wHn
-wHn
-wHn
-wHn
+nYX
+nYX
+nYX
+nYX
+nYX
+nYX
 knn
 hfn
 hfn
@@ -201240,8 +202332,8 @@ hfn
 hfn
 hfn
 kZL
-wHn
-wHn
+nYX
+nYX
 ppD
 ppD
 ppn
@@ -201437,29 +202529,29 @@ aIy
 iog
 iog
 iog
-wHn
-wHn
-wHn
+iog
+iog
+iog
 hJu
-nfF
-dBF
-dBF
-dBF
-jHq
-nfF
+oBA
+gWy
+gWy
+gWy
+qtG
+oBA
 qXB
-dBF
-bYm
-dBF
-dBF
-jHq
-dBF
-dBF
-dBF
-qXB
-nfF
-dBF
-dBF
+gWy
+jhd
+gWy
+fxx
+jjW
+fxx
+fxx
+fxx
+jxV
+ihd
+fxx
+fxx
 lcB
 jhO
 jhO
@@ -201477,25 +202569,25 @@ jHi
 jhO
 jhO
 ggw
-dBF
-dBF
-dBF
-dBF
-xtN
-dBF
-nfF
-dBF
-dBF
-dBF
-dBF
-dBF
-dBF
-dBF
-xtN
-qXB
-dBF
-nfF
-dBF
+fxx
+fxx
+fxx
+fxx
+wAM
+fxx
+ihd
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+fxx
+wAM
+jxV
+fxx
+ihd
+fxx
 lcB
 jhO
 jhO
@@ -201694,29 +202786,29 @@ iog
 iog
 pvm
 iog
-wHn
-wHn
-wHn
+iog
+iog
+iog
 hJu
 xtN
 qXB
-jHq
-dBF
-bYm
-dBF
-dBF
+qtG
+gWy
+jhd
+gWy
+gWy
 xtN
-dBF
-dBF
-qXB
-dBF
-nfF
-dBF
-dBF
-xtN
-dBF
-bYm
-jHq
+gWy
+gWy
+jxV
+fxx
+ihd
+fxx
+fxx
+wAM
+fxx
+vol
+jjW
 ovp
 hiy
 hiy
@@ -201734,25 +202826,25 @@ jHi
 irn
 hiy
 tRH
-bYm
-jHq
-dBF
-qXB
-dBF
-dBF
-dBF
-jHq
-dBF
-bYm
-dBF
-dBF
-xtN
-dBF
-dBF
-dBF
-jHq
-dBF
-xtN
+vol
+jjW
+fxx
+jxV
+fxx
+fxx
+fxx
+jjW
+fxx
+vol
+fxx
+fxx
+wAM
+fxx
+fxx
+fxx
+jjW
+fxx
+wAM
 ovp
 hiy
 hiy
@@ -201951,29 +203043,29 @@ lFi
 lFi
 auj
 iog
-wHn
-wHn
-wHn
+iog
+iog
+iog
 hJu
-dBF
-bYm
-nfF
-dBF
+gWy
+jhd
+oBA
+gWy
 qXB
-dBF
-dBF
-nfF
-dBF
-bYm
-dBF
-dBF
-xtN
-dBF
-dBF
-dBF
-dBF
-qXB
-dBF
+gWy
+gWy
+oBA
+gWy
+jhd
+fxx
+fxx
+wAM
+fxx
+fxx
+fxx
+fxx
+jxV
+fxx
 ovp
 hiy
 hiy
@@ -201991,25 +203083,25 @@ jHi
 irn
 hiy
 tRH
-dBF
-xtN
-dBF
-dBF
-jHq
-bYm
-dBF
-dBF
-dBF
+fxx
+wAM
+fxx
+fxx
+jjW
+vol
+fxx
+fxx
+fxx
 lLE
 pKZ
-dBF
-dBF
-dBF
-dBF
-dBF
-bYm
-dBF
-dBF
+fxx
+fxx
+fxx
+fxx
+fxx
+vol
+fxx
+fxx
 ovp
 hiy
 hiy
@@ -202208,29 +203300,29 @@ vWl
 lFi
 iog
 iog
-wHn
-wHn
-wHn
+iog
+iog
+iog
 hJu
 xtN
-dBF
-dBF
-dBF
-dBF
+gWy
+gWy
+gWy
+gWy
 xtN
-dBF
-dBF
-dBF
-dBF
-xtN
-dBF
-dBF
-nfF
-dBF
-dBF
-jHq
-dBF
-jHq
+gWy
+gWy
+gWy
+gWy
+wAM
+fxx
+fxx
+ihd
+fxx
+fxx
+jjW
+fxx
+jjW
 ovp
 hiy
 hiy
@@ -202248,25 +203340,25 @@ mmE
 hiy
 hiy
 tRH
-nfF
-dBF
-jHq
-jHq
-dBF
-dBF
-nfF
-qXB
-dBF
-xtN
-dBF
-dBF
-dBF
-nfF
-qXB
-jHq
-dBF
-qXB
-dBF
+ihd
+fxx
+jjW
+jjW
+fxx
+fxx
+ihd
+jxV
+fxx
+wAM
+fxx
+fxx
+fxx
+ihd
+jxV
+jjW
+fxx
+jxV
+fxx
 ovp
 hiy
 hiy
@@ -202465,29 +203557,29 @@ iHq
 lFi
 iog
 iog
-wHn
-wHn
-wHn
+iog
+iog
+iog
 hJu
-jHq
+qtG
 qXB
-dBF
-dBF
-dBF
-dBF
-bYm
-dBF
-jHq
+gWy
+gWy
+gWy
+gWy
+jhd
+gWy
+qtG
 qXB
-dBF
-jHq
-dBF
-qXB
-dBF
-bYm
-dBF
-dBF
-bYm
+fxx
+jjW
+fxx
+jxV
+fxx
+vol
+fxx
+fxx
+vol
 ovp
 hiy
 hiy
@@ -202505,25 +203597,25 @@ jHi
 irn
 hiy
 tRH
-dBF
-bYm
-qXB
-dBF
-xtN
-dBF
-jHq
-dBF
-dBF
-nfF
-dBF
-bYm
-jHq
-dBF
-dBF
-dBF
-dBF
-nfF
-jHq
+fxx
+vol
+jxV
+fxx
+wAM
+fxx
+jjW
+fxx
+fxx
+ihd
+fxx
+vol
+jjW
+fxx
+fxx
+fxx
+fxx
+ihd
+jjW
 ovp
 hiy
 hiy
@@ -202722,29 +203814,29 @@ iHq
 lFi
 xna
 iog
-wHn
-wHn
-wHn
+iog
+iog
+iog
 hJu
-bYm
-dBF
-dBF
+jhd
+gWy
+gWy
 xtN
 qXB
-nfF
-dBF
-dBF
-dBF
-dBF
-dBF
-dBF
-dBF
-dBF
-xtN
-dBF
-dBF
-xtN
-dBF
+oBA
+gWy
+gWy
+gWy
+gWy
+fxx
+fxx
+fxx
+fxx
+wAM
+fxx
+fxx
+wAM
+fxx
 ovp
 hiy
 hiy
@@ -202762,25 +203854,25 @@ jHi
 irn
 hiy
 tRH
-xtN
-dBF
-nfF
-dBF
-dBF
-dBF
-dBF
-dBF
-xtN
-dBF
-qXB
-dBF
-dBF
-dBF
-nfF
-dBF
-xtN
-dBF
-dBF
+wAM
+fxx
+ihd
+fxx
+fxx
+fxx
+fxx
+fxx
+wAM
+fxx
+jxV
+fxx
+fxx
+fxx
+ihd
+fxx
+wAM
+fxx
+fxx
 ovp
 hiy
 hiy
@@ -202980,19 +204072,19 @@ lFi
 iog
 iog
 jlH
-jhO
-jhO
+mPU
+mPU
 bjO
-oom
-oom
-oom
-oom
-oom
-oom
-oom
-oom
-oom
-oom
+rrD
+rrD
+rrD
+rrD
+rrD
+rrD
+rrD
+rrD
+rrD
+rrD
 oom
 oom
 oom
@@ -203236,20 +204328,20 @@ iHq
 lFi
 iog
 iog
-oNE
-hiy
-hiy
-hiy
-piU
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-piU
+wDM
+eDq
+eDq
+eDq
+oFb
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+oFb
 hiy
 hiy
 rXV
@@ -203493,20 +204585,20 @@ iHq
 lFi
 uLX
 iog
-oNE
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-rXV
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
+wDM
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+upC
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
 hiy
 hiy
 hiy
@@ -203750,20 +204842,20 @@ iHq
 lFi
 iog
 iog
-oNE
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
+wDM
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
+eDq
 hiy
 hiy
 hiy
@@ -204313,10 +205405,10 @@ yja
 yja
 sak
 qgz
-bYm
-dBF
-dBF
-dBF
+vol
+fxx
+fxx
+fxx
 oNE
 hiy
 hiy
@@ -204539,8 +205631,8 @@ mZy
 ijU
 xKy
 fFE
-hiy
-hiy
+sxJ
+sxJ
 jHi
 jHi
 jHi
@@ -204572,8 +205664,8 @@ xad
 jaB
 wOD
 wwa
-dBF
-dBF
+fxx
+fxx
 oNE
 hiy
 hiy
@@ -204796,8 +205888,8 @@ tXp
 qhA
 qhA
 fFE
-hiy
-hiy
+sxJ
+sxJ
 xtG
 hhF
 xvH
@@ -204829,8 +205921,8 @@ btA
 jHi
 jHi
 jHi
-nfF
-bYm
+ihd
+vol
 oNE
 hiy
 hiy
@@ -205054,7 +206146,7 @@ qRf
 qRf
 ufX
 vCD
-hiy
+sxJ
 xtG
 spk
 hoA
@@ -205086,8 +206178,8 @@ hoA
 hoA
 bkw
 jHi
-dBF
-dBF
+fxx
+fxx
 oNE
 hiy
 hiy
@@ -205310,8 +206402,8 @@ qRf
 vwF
 nSY
 ufX
-hiy
-hiy
+sxJ
+sxJ
 xtG
 spk
 hoA
@@ -205343,8 +206435,8 @@ hoA
 oPO
 qRY
 jHi
-dBF
-xtN
+fxx
+wAM
 oNE
 hiy
 hiy
@@ -205567,8 +206659,8 @@ qRf
 pse
 bUX
 fFE
-hiy
-hiy
+sxJ
+sxJ
 xtG
 pxB
 hoA
@@ -205824,8 +206916,8 @@ qRf
 pse
 bUX
 fFE
-hiy
-hiy
+sxJ
+sxJ
 xtG
 spk
 hoA
@@ -206081,8 +207173,8 @@ qRf
 lxt
 hfK
 ufX
-hiy
-hiy
+sxJ
+sxJ
 xtG
 spk
 hoA
@@ -206338,8 +207430,8 @@ qRf
 qRf
 qRf
 ufX
-hiy
-hiy
+sxJ
+sxJ
 xtG
 kqd
 hoA
@@ -206595,8 +207687,8 @@ aZZ
 knj
 knj
 fFE
-hiy
-hiy
+sxJ
+sxJ
 xtG
 spk
 hoA
@@ -206852,8 +207944,8 @@ oer
 jMG
 xKy
 fFE
-hiy
-wxn
+sxJ
+oGj
 xtG
 spk
 hoA
@@ -207109,8 +208201,8 @@ mZy
 bUX
 bUX
 fFE
-wxn
-kvw
+oGj
+nQA
 xtG
 wxN
 xYr
@@ -207366,8 +208458,8 @@ ufX
 ufX
 ufX
 ufX
-hiy
-hiy
+sxJ
+sxJ
 jHi
 jHi
 jHi
@@ -207611,20 +208703,20 @@ lHG
 lHG
 lHG
 hFy
-oNE
-hiy
-hiy
-kvw
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
-piU
-hiy
-hiy
+wDM
+eDq
+eDq
+nQA
+sxJ
+sxJ
+sxJ
+sxJ
+sxJ
+sxJ
+sxJ
+acl
+sxJ
+sxJ
 rAN
 gSx
 rAN
@@ -207869,19 +208961,19 @@ lHG
 lHG
 lHG
 xhK
-hiy
-hiy
-hiy
-hiy
-tru
-hiy
-rXV
-hiy
-hiy
-hiy
-hiy
-hiy
-hiy
+eDq
+eDq
+sxJ
+sxJ
+sRZ
+sxJ
+lsw
+sxJ
+sxJ
+sxJ
+sxJ
+sxJ
+sxJ
 lCm
 bCe
 bCe
@@ -208126,19 +209218,19 @@ qTP
 qTP
 qTP
 gHB
-pAo
+fXe
 qpx
-pAo
-pAo
-mUW
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
-pAo
+nKp
+nKp
+cGZ
+nKp
+nKp
+nKp
+nKp
+nKp
+nKp
+nKp
+nKp
 jHi
 jHi
 gZD
@@ -251893,24 +252985,24 @@ ntq
 ntq
 ntq
 ntq
-hVQ
-kmv
-kmv
-kmv
-kmv
-hVQ
-kmv
-kmv
-kmv
-kmv
-rtk
-rtk
-rtk
-kmv
-kmv
-kmv
-rtk
-rtk
+eiL
+eiL
+eiL
+eiL
+eiL
+xPY
+xPY
+eiL
+eiL
+mfU
+mfU
+mfU
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -252150,24 +253242,24 @@ ntq
 ntq
 ntq
 ntq
+wgL
+aiU
+vWT
+vWT
+wsc
 hVb
-sxC
-wed
-vCy
+vWT
+wgL
+sYw
 aRT
-hVb
-ecs
-wed
-vCy
-aRT
-iNI
+byA
 ljE
 lNl
-iNI
+wgL
 hlZ
 xXo
 jKA
-rtk
+eiL
 ntq
 ntq
 ntq
@@ -252407,24 +253499,24 @@ ntq
 ntq
 ntq
 ntq
-hVQ
+sow
 vZF
 gQi
-vCy
-vCy
+vWT
+eez
 hVQ
-vZF
-sZr
-vCy
-vCy
-iNI
+vWT
+wgL
+dVE
+coP
+nTN
 tEV
 cen
-iNI
+qcg
 xXz
 tlx
 qXE
-kmv
+eiL
 ntq
 ntq
 ntq
@@ -252664,23 +253756,23 @@ ntq
 ntq
 ntq
 ntq
-hVQ
+sow
 oCg
+mzX
+vWT
+nBM
+qoY
+vWT
 oXZ
-vCy
-vCy
-hVQ
-oCg
-oXZ
-vCy
-vCy
-iNI
+nxK
+dSi
+wKO
 wKO
 oxU
-fez
-qXE
-tlx
-vhw
+wgL
+pRH
+pft
+kRF
 kmv
 ntq
 ntq
@@ -252921,23 +254013,23 @@ ntq
 ntq
 ntq
 ntq
-hVQ
+wgL
 oFK
-cxJ
-ojk
+vWT
+vWT
+wsc
+vWT
+vWT
+pMk
+nxK
 dVo
-hVQ
-oFK
-cxJ
-ojk
-dVo
-iNI
-aHj
+llz
+llz
 lxS
-iNI
-xXz
-tlx
-kSl
+akV
+hnC
+hnC
+hnC
 kmv
 ntq
 ntq
@@ -253178,24 +254270,24 @@ ntq
 ntq
 ntq
 ntq
-rtk
-rtk
-iNI
-ieO
-rtk
-rtk
-rtk
-iNI
-ieO
-rtk
-iNI
+eiL
+eiL
+eiL
+eiL
+wsc
+aiU
+vWT
+oXZ
+nxK
+iNu
+wYX
 wYX
 gro
-iNI
-hlZ
-tlx
+wgL
+nVM
+onV
 jKA
-rtk
+kmv
 ntq
 ntq
 ntq
@@ -253435,24 +254527,24 @@ ntq
 ntq
 ntq
 ntq
-iNI
-kAh
-dsw
-dsw
-lus
-dsw
-dsw
-dsw
-dsw
-ezL
-rtk
-rtk
-rtk
-rtk
+wgL
+oFK
+vWT
+vWT
+wsc
+vWT
+vWT
+wgL
+bNB
+dsB
+bGL
+ohC
+dsB
+qcg
 iNI
 iQJ
-rtk
-rtk
+qXE
+eiL
 ntq
 ntq
 ntq
@@ -253692,24 +254784,24 @@ ntq
 ntq
 ntq
 ntq
-iNI
+sow
 paC
-gaV
-rtk
-rtk
-rtk
-iNI
-hQn
-dsw
+gQi
+vWT
+nBM
+tXG
+vWT
+wgL
+gxr
 cbJ
-fRj
-fRj
-rtk
-bAI
+wgL
+flW
+xUM
+wgL
 hHI
-tlx
-jKA
-rtk
+wYM
+kRF
+eiL
 ntq
 ntq
 ntq
@@ -253949,24 +255041,24 @@ ntq
 ntq
 ntq
 ntq
-jQM
-qXE
-dsw
-iNI
-ukB
-omV
-aQe
-nlw
-dsw
-cbJ
-fRj
-fRj
-rtk
-xXz
-dsw
-tlx
-mFl
-rtk
+sow
+bKi
+mzX
+vWT
+eez
+hVQ
+vWT
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -254206,23 +255298,23 @@ ntq
 ntq
 ntq
 ntq
-jQM
-dsw
-grI
-jjV
-dsw
-dsw
-jKJ
-mIi
-dsw
-dsw
-rtk
-rtk
-rtk
-rtk
-iNI
-iQJ
-rtk
+wgL
+aiU
+vWT
+vWT
+wsc
+qoY
+vWT
+vWT
+vTv
+vWT
+vWT
+vWT
+vTv
+vWT
+eiL
+eXs
+eXs
 rtk
 ntq
 ntq
@@ -254463,25 +255555,25 @@ ntq
 ntq
 ntq
 ntq
-jQM
-dsw
-dsw
-tBj
-xsI
-dsw
-dsw
-owH
-dsw
-dsw
-eye
-xcw
+eiL
+eiL
+eiL
+eiL
+wsc
+aiU
+vWT
+vWT
+vWT
+vWT
+vWT
+vWT
+vWT
+vWT
+eiL
 ogY
-ogY
-krS
-ogY
-bVs
-rtk
-ntq
+hlF
+rSi
+dMl
 ntq
 ntq
 ntq
@@ -254720,25 +255812,25 @@ ntq
 ntq
 ntq
 ntq
-iNI
+eiL
 sTy
-dsw
-rtk
-jeD
-qZA
-iNI
-val
-dsw
-dsw
+wST
+wsc
+tXG
+vWT
+vWT
+xwG
 iUJ
-tMT
-dsw
-jkS
-bwR
-dwS
+iUJ
+iUJ
+fRj
+vWT
+vWT
+eiL
+fiB
 dsw
 pFO
-ntq
+hDs
 ntq
 ntq
 ntq
@@ -254977,25 +256069,25 @@ ntq
 ntq
 ntq
 ntq
-iNI
-dsw
+eiL
+esk
 grI
 jjV
-dsw
-dsw
-qXE
-dsw
-dsw
-dsw
-iNI
+hVQ
+vWT
+vWT
+uEu
+wpA
+wpA
+wpA
 mSU
-dsw
-nAq
-daa
+vWT
+vWT
+eiL
 hye
-dsw
-pFO
-ntq
+rWN
+hlF
+hDs
 ntq
 ntq
 ntq
@@ -255234,25 +256326,25 @@ ntq
 ntq
 ntq
 ntq
-iNI
-sTy
-dsw
-gzE
-dsw
-dsw
-dsw
-dsw
-dsw
-dsw
-iNI
-tMT
-dsw
-nAq
-pMg
-hye
-dsw
-pFO
-ntq
+eiL
+ejL
+iWA
+wsc
+qoY
+vWT
+vWT
+uEu
+sDT
+sDT
+sDT
+mSU
+vWT
+vWT
+eiL
+ogY
+hlF
+hlF
+rXS
 ntq
 ntq
 ntq
@@ -255491,25 +256583,25 @@ ntq
 ntq
 ntq
 ntq
-jQM
-dsw
-dsw
-htZ
-ciA
-mLt
-kse
-pXA
-wgT
-dsw
+eiL
+eiL
+eiL
+eiL
+wsc
+aiU
+vWT
+rLu
 yeU
-ybq
-dsw
-nAq
+wty
+yeU
+xza
+vWT
+vWT
 bRs
-hye
-mwZ
-rtk
-ntq
+hlF
+hlF
+fiB
+ttZ
 ntq
 ntq
 ntq
@@ -255748,25 +256840,25 @@ ntq
 ntq
 ntq
 ntq
-jQM
-dsw
-dsw
-iNI
-sKZ
-wfV
-vQC
-gyX
-bow
-dsw
-hMn
-ixc
-dsw
-oFp
-rij
-eqz
-dsw
-rtk
-ntq
+vMH
+qMn
+lGk
+lyl
+fRj
+vWT
+vWT
+eiL
+eiL
+eiL
+eiL
+wsc
+aiU
+vWT
+bRs
+hlF
+hlF
+mPb
+xBs
 ntq
 ntq
 ntq
@@ -256005,25 +257097,25 @@ ntq
 ntq
 ntq
 ntq
-jQM
-qXE
-dsw
-iNI
-aHp
-tjp
-mwh
-xXm
+vMH
+qMn
+tSF
+tYZ
+qYL
+vWT
+vWT
+wsc
 fJy
 cAi
-iNI
-eKZ
-dsw
-dsw
-dsw
-dsw
-dsw
-pFO
-ntq
+gOj
+wsc
+vWT
+vWT
+eiL
+ogY
+hlF
+hlF
+mxR
 ntq
 ntq
 ntq
@@ -256262,25 +257354,25 @@ ntq
 ntq
 ntq
 ntq
-iNI
-vgC
-dsw
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
-iNI
+vMH
+eiL
+wsc
+aot
+rHd
+vWT
+vWT
+wsc
+iYr
+gOj
+gOj
 cGJ
-dsw
+vWT
+vWT
+eiL
 ieZ
-ieZ
-ieZ
-dsw
-pFO
-ntq
+mgs
+hlF
+hDs
 ntq
 ntq
 ntq
@@ -256519,25 +257611,25 @@ ntq
 ntq
 ntq
 ntq
-iNI
-xXz
-qXE
+vMH
+lTQ
+qMn
 mSr
 uWS
-vIq
-vIq
-ozt
-uzp
-leS
-iNI
-uYx
-dsw
-qtT
-qtT
-qtT
-dsw
+vWT
+vWT
+wsc
+tSa
+wsc
+tSa
+wsc
+vWT
+vWT
+eiL
+mPb
+udM
 pFO
-ntq
+hDs
 ntq
 ntq
 ntq
@@ -256776,25 +257868,25 @@ ntq
 ntq
 ntq
 ntq
-iNI
-dsw
-dsw
-mSr
-ojk
-vCy
-vCy
-vKp
-kha
-cbJ
+vMH
+lTQ
+qMn
+vIq
+oEL
+vWT
+vWT
+wsc
 eye
-rNZ
-vBM
-vBM
-vBM
-vBM
-vBM
-rtk
-ntq
+wsc
+eye
+wsc
+vWT
+vWT
+eiL
+ogY
+hlF
+rHW
+gJj
 ntq
 ntq
 ntq
@@ -257033,24 +258125,24 @@ ntq
 ntq
 ntq
 ntq
-rtk
-rtk
-rtk
-rtk
-jwG
-dCg
-vCy
-vCy
-vgy
-pYw
-rtk
-kmv
-kmv
-kmv
-kmv
-kmv
+vMH
+lTQ
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+wsc
+aiU
+vWT
+eiL
 fkR
-rtk
+fkR
+uqE
 ntq
 ntq
 ntq
@@ -257290,24 +258382,24 @@ ntq
 ntq
 ntq
 ntq
-iee
-lWG
-dax
-vIq
-uWS
-vCy
-vCy
-vCy
-vCy
-vKp
-iNI
-jST
-mNC
-qIW
-xEU
-oiK
-vYs
-rtk
+vMH
+lTQ
+wgL
+mBK
+iTO
+vWT
+vWT
+vWT
+eSI
+kfY
+uzS
+wsc
+vWT
+vWT
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -257547,24 +258639,24 @@ ntq
 ntq
 ntq
 ntq
-dUS
-dax
-vCy
+eiL
+eiL
+wgL
+tFS
+vWT
 ojk
-ojk
-ojk
-ojk
-ojk
-ojk
-vKp
+mpz
+vWT
+vWT
+rLu
 foo
-fRj
-pHq
-eQk
-kZM
-kZM
+wsc
+vWT
+vWT
+eiL
 fzA
-rtk
+fzA
+eiL
 ntq
 ntq
 ntq
@@ -257804,24 +258896,24 @@ ntq
 ntq
 ntq
 ntq
-dUS
+wgL
 ntz
 cot
+vWT
+ojk
+qtW
+hGK
 mpz
-qYL
-mpz
-qYL
-mpz
-qYL
-eMz
-foo
+vWT
+vWT
+vWT
+wsc
+vWT
+xwG
+auQ
 fRj
-fRj
-fRj
-fRj
-fRj
-wGh
-pFO
+vWT
+kmv
 ntq
 ntq
 ntq
@@ -258062,23 +259154,23 @@ ntq
 ntq
 ntq
 dUS
-pmo
-qYL
+tXG
+vWT
+xwG
+qtW
+vJa
+vJa
 hGK
-hGK
-hGK
-hGK
-hGK
-qYL
-eMz
-foo
 fRj
-fRj
-fRj
-fRj
-fRj
-wGh
-pFO
+vWT
+tXG
+wsc
+aiU
+rLu
+hCR
+xza
+vWT
+kmv
 ntq
 ntq
 ntq
@@ -258318,24 +259410,24 @@ ntq
 ntq
 ntq
 ntq
-xqH
+dUS
 jnd
-gYM
-hGK
-hGK
-hGK
-hGK
-hGK
+vWT
+jVa
+vJa
+wsQ
+oPP
+vJa
 qYL
-eMz
-foo
-fRj
-fRj
-fRj
-fRj
-fRj
-wGh
-pFO
+vWT
+muK
+yfb
+vWT
+vWT
+eiL
+mUA
+llz
+kmv
 ntq
 ntq
 ntq
@@ -258577,22 +259669,22 @@ ntq
 ntq
 dUS
 pmo
-qYL
-vwj
-hGK
-hGK
-hGK
-hGK
-qYL
-eMz
-foo
-fRj
-fRj
-fRj
-fRj
-fRj
-wGh
-pFO
+vWT
+rLu
+jqY
+vJa
+vJa
+mrp
+xza
+vWT
+qoY
+wsc
+aiU
+vWT
+eiL
+llz
+llz
+eiL
 ntq
 ntq
 ntq
@@ -258832,24 +259924,24 @@ ntq
 ntq
 ntq
 ntq
-dUS
-ntz
+wgL
+qBC
 laW
+vWT
+vIq
+jqY
+mrp
 oEL
-qYL
-oEL
-qYL
-oEL
-qYL
-eMz
-foo
-fRj
-fRj
-fRj
-fRj
-fRj
-wGh
-pFO
+vWT
+vWT
+vWT
+wsc
+moN
+vWT
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -259089,24 +260181,24 @@ ntq
 ntq
 ntq
 ntq
-dUS
-sms
-vCy
+eiL
+eiL
+wgL
+tBg
+vWT
 vIq
-vIq
-vIq
-vIq
-vIq
-vIq
-vKp
-foo
-fRj
-wgf
-ebg
-ebg
-ebg
-fzA
-rtk
+oEL
+vWT
+vWT
+xwG
+uzS
+wsc
+vWT
+vWT
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -259346,24 +260438,24 @@ ntq
 ntq
 ntq
 ntq
-iee
-lWG
-sms
-ojk
-fah
-ojk
-fah
-ojk
+eiL
+eiL
+wgL
+huY
+iTO
+vWT
+vWT
+vWT
 uWA
-jKA
-iNI
-jST
-tvv
-aeX
-sku
-bRF
-trh
-rtk
+rVe
+rIs
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -259603,24 +260695,24 @@ ntq
 ntq
 ntq
 ntq
-rtk
-rtk
-eNE
-eNE
-iee
+eiL
+eiL
+eiL
+eiL
+vgm
 vkm
-rtk
-eNE
-eNE
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eIo
+dSS
+dSS
+dSS
+dSS
+rhr
 ntq
 ntq
 ntq
@@ -259860,24 +260952,24 @@ ntq
 ntq
 ntq
 ntq
-gpI
+vgm
 tXQ
 uVM
 xpv
+vWT
+vWT
 ezL
-dsw
-ezL
-dsw
-jKA
-eNE
+xJZ
+eiL
+eiL
 nJA
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
-ntq
+hzq
+hlF
+hlF
+hlF
+hlF
+hlF
+aeB
 ntq
 ntq
 ntq
@@ -260117,24 +261209,24 @@ ntq
 ntq
 ntq
 ntq
-gpI
-vCy
-vCy
-vCy
-vCy
-vCy
-dsw
-dsw
-hlM
+eNE
+xJZ
+vTb
+kdN
+kaP
+vWT
+vYY
+xJZ
+xJZ
 eNE
 nJA
-txe
-avo
-avo
-avo
-ouf
-ntq
-ntq
+hzq
+hlF
+hlF
+hlF
+hlF
+hlF
+scN
 ntq
 ntq
 ntq
@@ -260374,24 +261466,24 @@ ntq
 ntq
 ntq
 ntq
-gpI
-mgT
-boe
+eNE
+xJZ
+xJZ
 ovK
 xRL
-vCy
-vCy
-dsw
-jKA
+vWT
+vYY
+xJZ
+xJZ
 eNE
-gqU
+nJA
 vlu
 dpu
 rYY
 hzq
-wIo
-ntq
-ntq
+hlF
+hlF
+aeB
 ntq
 ntq
 ntq
@@ -260633,22 +261725,22 @@ ntq
 ntq
 iee
 qTD
-wfa
+xJZ
 ckF
-qYL
-xRL
-ojk
-vCy
-pJH
-rtk
-iWU
+aSm
+fRj
+vYY
+xJZ
+xJZ
+eiL
+hEe
 mwB
 jAQ
 uwt
-hzq
-wIo
-ntq
-ntq
+cCB
+hlF
+hlF
+scN
 ntq
 ntq
 ntq
@@ -260888,24 +261980,24 @@ ntq
 ntq
 ntq
 ntq
-vLo
+qGS
 isx
 sDv
 kFk
 ahy
-hEK
-vZk
-ntz
-vCy
+qYL
+vYY
+xJZ
+xJZ
 aZW
-vCy
+vWT
 vCy
 vKp
 sCV
-hzq
-ouf
-ntq
-ntq
+cCB
+hlF
+hlF
+aeB
 ntq
 ntq
 ntq
@@ -261145,24 +262237,24 @@ ntq
 ntq
 ntq
 ntq
-iee
-qTD
-wfa
+vgm
+dLQ
+xJZ
 ykA
-qYL
-wfW
-vIq
-vCy
-qpk
-rtk
-iWU
-bRs
-jAQ
-uwt
-hzq
-wIo
-ntq
-ntq
+wrm
+xza
+vYY
+xJZ
+xJZ
+eiL
+hEe
+vWT
+vWT
+bqC
+wJH
+hlF
+hlF
+scN
 ntq
 ntq
 ntq
@@ -261402,24 +262494,24 @@ ntq
 ntq
 ntq
 ntq
-gpI
-joQ
-hDi
+eNE
+xJZ
+xJZ
 cjp
 wfW
-vCy
-vCy
-pFX
-omW
+vWT
+vYY
+xJZ
+xJZ
 eNE
 kUO
 jHS
 mdQ
-rYY
-hDZ
-wIo
-ntq
-ntq
+sNU
+hzq
+hlF
+hlF
+aeB
 ntq
 ntq
 ntq
@@ -261659,24 +262751,24 @@ ntq
 ntq
 ntq
 ntq
-gpI
-vCy
-vCy
-vCy
-vCy
-vCy
-dsw
-rVw
-lkL
+eNE
+xJZ
+rzA
+eIB
+kaP
+vWT
+vYY
+xJZ
+xJZ
 eNE
 nJA
-rYY
 hzq
-hzq
-nYH
-ouf
-ntq
-ntq
+hlF
+hlF
+hlF
+hlF
+hlF
+scN
 ntq
 ntq
 ntq
@@ -261916,24 +263008,24 @@ ntq
 ntq
 ntq
 ntq
-gpI
+vgm
 vXc
-swG
-iit
+uVM
+xpv
+vWT
+vWT
 ewc
-dsw
-ewc
-kWa
-lUz
-eNE
+xJZ
+eiL
+eiL
 nJA
-rYY
 hzq
-hzq
-wGC
-wIo
-ntq
-ntq
+hlF
+hlF
+hlF
+hlF
+hlF
+aeB
 ntq
 ntq
 ntq
@@ -262173,24 +263265,24 @@ ntq
 ntq
 ntq
 ntq
-rtk
-rtk
-rtk
-rtk
-rtk
-ggM
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
-rtk
-rYY
-hDZ
-wIo
-ntq
-ntq
+eiL
+eiL
+eiL
+eiL
+vgm
+vkm
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+hzq
+hlF
+hlF
+hlF
+scN
 ntq
 ntq
 ntq
@@ -262430,24 +263522,24 @@ ntq
 ntq
 ntq
 ntq
-oTm
-quz
+eiL
+wgL
 vZk
-dsw
-cbJ
-vCy
-vCy
-vCy
-jtC
-rtk
+vWT
+vWT
+vWT
+vWT
+vWT
+eiL
+eiL
 xpQ
 gOj
-rtk
-uwt
-nYH
+eiL
+cCB
+hlF
 ouf
-ntq
-ntq
+hlF
+aeB
 ntq
 ntq
 ntq
@@ -262687,24 +263779,24 @@ ntq
 ntq
 ntq
 ntq
-oTm
+wgL
 hVz
-dsw
-xNo
-kZE
+qYL
+vWT
+vWT
 qsP
-cUv
-vCy
-vCy
+vWT
+vWT
+vWT
 cIB
 ooV
 gOj
-coY
-rYY
-wGC
+hKx
+hzq
+hlF
 wIo
-ntq
-ntq
+hlF
+scN
 ntq
 ntq
 ntq
@@ -262944,24 +264036,24 @@ ntq
 ntq
 ntq
 ntq
-iee
+wgL
 lcY
 lil
-lil
-emm
-wfa
+vWT
+eiL
+wgL
 vVW
-ebT
+vWT
 iCG
-atA
+eiL
 vMa
 hdi
-rtk
+eiL
 hzo
-hzq
-wIo
-ntq
-ntq
+hlF
+nvH
+hlF
+aeB
 ntq
 ntq
 ntq
@@ -263201,24 +264293,24 @@ ntq
 ntq
 ntq
 ntq
-iee
+wgL
 mKD
+qYL
+vWT
+wgL
 wfa
-wfa
-tqz
-wfa
-vVW
-gVg
-vCy
-rtk
-rtk
-rtk
-rtk
+fRj
+vWT
+hcu
+eiL
+eiL
+eiL
+eiL
 dLD
-ehi
-ouf
-ntq
-ntq
+xNb
+xNb
+xNb
+hVI
 ntq
 ntq
 ntq
@@ -263458,16 +264550,16 @@ ntq
 ntq
 ntq
 ntq
-iee
-lyp
-wfa
-wfa
-tqz
-wfa
-vVW
+eiL
+wgL
+jFc
+vWT
+wgL
+uyQ
+xza
 alq
-cuS
-rtk
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -263715,16 +264807,16 @@ ntq
 ntq
 ntq
 ntq
-rtk
-rtk
-rtk
-rtk
-uvV
-uvV
-uvV
-rtk
-rtk
-rtk
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -268083,7 +269175,7 @@ ntq
 ntq
 ntq
 ntq
-ntq
+lxu
 ntq
 vMH
 lTQ
@@ -317429,24 +318521,24 @@ ntq
 ntq
 ntq
 ntq
-lvw
+bLQ
+rqx
+rqx
+rqx
+dTI
+hGQ
 jPj
 jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-jPj
-wpx
+fjt
+jps
+jps
+jps
+jps
+jps
+jps
+jps
+jps
+iex
 ntq
 ntq
 ntq
@@ -317686,24 +318778,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
+fDc
+vOr
+vOr
+vOr
+lHN
+ldB
 kno
 kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -317943,24 +319035,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
+fDc
+abo
+vOr
+abo
+lSB
+wJH
 kno
 kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+fDv
+lTQ
+lTQ
+fDv
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -318200,24 +319292,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
+fDc
+vOr
+vOr
+vOr
+lHN
+ldB
 kno
 kno
-kno
-kno
-fuh
-kno
-fuh
-kno
-fuh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -318457,24 +319549,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
+cwH
+meW
+xCj
+meW
+tRJ
+qiW
 kno
 kno
-kno
-kno
-bgM
-kno
-bgM
-kno
-bgM
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+fDv
+lTQ
+lTQ
+fDv
+lTQ
+lTQ
+fDv
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -318714,24 +319806,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
+icl
+ctC
+wTQ
 kno
 kno
 kno
 kno
 kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -318971,24 +320063,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-fuh
-kno
-fuh
-kno
-fuh
+lGq
+ctC
+wTQ
 kno
 kno
 kno
 kno
 kno
-kno
-kno
-sqA
+vMH
+lTQ
+fDv
+lTQ
+lTQ
+fDv
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -319228,24 +320320,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
+lGq
+ctC
+wTQ
 kno
-kno
-kno
-kno
-bgM
-kno
-bgM
-kno
-bgM
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+eiL
+ryz
+ryz
+eiL
+aOT
+lbr
+lbr
+lbr
+lbr
+lbr
+lbr
+rbp
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -319485,24 +320577,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+lGq
+ctC
+wTQ
+eiL
+eiL
+xJZ
+xJZ
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+aOT
+lbr
+bSw
 ntq
 ntq
 ntq
@@ -319742,24 +320834,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+lGq
+ctC
+wTQ
+eiL
+bbi
+xJZ
+xJZ
+usL
+eiL
+eiL
+qGS
+olu
+hnC
+hnC
+eiL
+ntq
+ntq
+ntq
 ntq
 ntq
 ntq
@@ -319999,24 +321091,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+yfM
+ctC
+wTQ
+eiL
+jMQ
+wWb
+xJZ
+mrT
+eiL
+eiL
+vgm
+oCW
+hnC
+hnC
+eiL
+ntq
+ntq
+ntq
 ntq
 ntq
 ntq
@@ -320256,24 +321348,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-fuh
-kno
-fuh
-kno
-fuh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+ctC
+wTQ
+eiL
+muh
+xJZ
+xJZ
+kVf
+eiL
+eiL
+qGS
+olu
+hnC
+hnC
+eiL
+ntq
+ntq
+ntq
 ntq
 ntq
 ntq
@@ -320513,24 +321605,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-bgM
-kno
-bgM
-kno
-bgM
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+eiL
+eiL
+eiL
+eiL
+eiL
+ett
+ett
+eiL
+eiL
+eiL
+eiL
+qGS
+mmZ
+rhy
+eiL
+ntq
+ntq
+ntq
 ntq
 ntq
 ntq
@@ -320770,24 +321862,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vgm
+kEs
+cen
+cen
+cbS
+bJS
+bJS
+tGu
+dup
+muD
+hBT
+qGS
+iOM
+hnC
+eiL
+ntq
+ntq
+ntq
 ntq
 ntq
 ntq
@@ -321027,24 +322119,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-fuh
-kno
-fuh
-kno
-fuh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+xPY
+jPt
+bJS
+bJS
+bJS
+bJS
+bJS
+bJS
+bJS
+bJS
+bJS
+vgm
+rts
+hnC
+eiL
+ntq
+ntq
+ntq
 ntq
 ntq
 ntq
@@ -321284,24 +322376,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-bgM
-kno
-bgM
-kno
-bgM
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+xPY
+isj
+uqK
+dsB
+dsB
+dsB
+dsB
+dsB
+dsB
+dQi
+bJS
+qGS
+hnC
+hnC
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -321541,24 +322633,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+xPY
+qoF
+jYF
+hnC
+hnC
+hnC
+hnC
+hnC
+hnC
+qXE
+bJS
+jYF
+hnC
+hnC
+eiL
+rts
+hnC
+eiL
 ntq
 ntq
 ntq
@@ -321798,24 +322890,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vgm
+sdx
+jYF
+rhy
+hnC
+hnC
+hnC
+hnC
+hnC
+fgw
+bJS
+jYF
+hnC
+gzA
+iVt
+voi
+txK
+eiL
 ntq
 ntq
 ntq
@@ -322055,24 +323147,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vgm
+weE
+jYF
+hnC
+hnC
+hnC
+hnC
+hnC
+hnC
+qXE
+bJS
+jYF
+hnC
+kfR
+sUG
+wOp
+uOc
+eiL
 ntq
 ntq
 ntq
@@ -322312,24 +323404,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+xPY
+qoF
+jYF
+hnC
+hnC
+hnC
+hnC
+hnC
+hnC
+qXE
+bJS
+jYF
+hnC
+hnC
+eiL
+kfR
+eny
+eiL
 ntq
 ntq
 ntq
@@ -322569,24 +323661,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+xPY
+mjW
+ior
+cen
+cen
+cen
+cen
+cen
+cen
+vgX
+bJS
+qGS
+hnC
+hnC
+eiL
+rts
+hnC
+eiL
 ntq
 ntq
 ntq
@@ -322826,24 +323918,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+xPY
+isj
+bJS
+bJS
+bJS
+bJS
+bJS
+bJS
+bJS
+bJS
+gJA
+vgm
+rts
+hnC
+eiL
+cen
+cen
+eiL
 ntq
 ntq
 ntq
@@ -323083,24 +324175,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vgm
+fam
+dsB
+pgx
+dvO
+bJS
+bJS
+xgz
+gGD
+ckh
+dQi
+qGS
+wlm
+hnC
+eiL
+llz
+llz
+eiL
 ntq
 ntq
 ntq
@@ -323340,24 +324432,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+eiL
+eiL
+eiL
+eiL
+qGS
+kkz
+kkz
+eiL
+eiL
+eiL
+eiL
+qGS
+hnC
+rhy
+eiL
+llz
+llz
+eiL
 ntq
 ntq
 ntq
@@ -323597,24 +324689,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+szW
+xJZ
+xJZ
+xJZ
+dkZ
+xJZ
+xJZ
+eiL
+qGS
+olu
+hnC
+hnC
+eiL
+eiL
+eiL
+eiL
 ntq
 ntq
 ntq
@@ -323854,24 +324946,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+szW
+aKb
+xJZ
+iqw
+dkZ
+xJZ
+xJZ
+eiL
+vgm
+hUz
+hnC
+hnC
+eiL
+jps
+jps
+iex
 ntq
 ntq
 ntq
@@ -324111,24 +325203,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+szW
+mTu
+xJZ
+dkZ
+peJ
+xJZ
+mTu
+eiL
+qGS
+olu
+hnC
+hnC
+eiL
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -324368,24 +325460,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+szW
+kGn
+mTu
+xJZ
+xJZ
+dkZ
+kGn
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -324625,24 +325717,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+eiL
+szW
+mTu
+dkZ
+dkZ
+mTu
+eiL
+eiL
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -324882,24 +325974,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+eiL
+eiL
+eiL
+eiL
+eiL
+eiL
+lTQ
+lTQ
+lTQ
+lbr
+lbr
+lbr
+lbr
+lbr
+bSw
 ntq
 ntq
 ntq
@@ -325139,24 +326231,24 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-tUd
-cvt
-cvt
-cvt
-cvt
-cvt
-cvt
-cvt
-lmH
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+bSw
+ntq
+ntq
+ntq
+ntq
+ntq
+ntq
 ntq
 ntq
 ntq
@@ -325396,17 +326488,17 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
-ntq
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -325653,17 +326745,17 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
-ntq
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -325910,20 +327002,20 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-taq
-jPj
-jPj
-wpx
-ntq
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+jps
+jps
+iex
 ntq
 ntq
 ntq
@@ -326167,20 +327259,20 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
-ntq
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+hjR
+jiL
+pmV
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -326424,20 +327516,20 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
-ntq
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+eOI
+lDx
+pmV
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -326681,20 +327773,20 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
-ntq
+vMH
+lTQ
+hjR
+jiL
+pmV
+lTQ
+kEP
+cnm
+pmV
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -326938,20 +328030,20 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-tUd
-cvt
-cvt
-lmH
-ntq
+vMH
+lTQ
+eOI
+lDx
+pmV
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lbr
+lbr
+bSw
 ntq
 ntq
 ntq
@@ -327195,17 +328287,17 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
-ntq
+vMH
+lTQ
+kEP
+cnm
+pmV
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -327452,17 +328544,17 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
-ntq
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+hjR
+jiL
+pmV
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -327709,19 +328801,19 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-taq
-jPj
-jPj
-wpx
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+eOI
+nEh
+pmV
+lTQ
+lTQ
+jps
+iex
 ntq
 ntq
 ntq
@@ -327966,19 +329058,19 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+hjR
+jiL
+pmV
+lTQ
+kEP
+cnm
+pmV
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -328223,19 +329315,19 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+eOI
+nEh
+pmV
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -328480,19 +329572,19 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+kEP
+cnm
+pmV
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -328737,19 +329829,19 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-tUd
-cvt
-cvt
-lmH
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lbr
+lbr
+bSw
 ntq
 ntq
 ntq
@@ -328994,16 +330086,16 @@ ntq
 ntq
 ntq
 ntq
-kTh
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-kno
-sqA
+vMH
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+lTQ
+ctC
 ntq
 ntq
 ntq
@@ -329251,16 +330343,16 @@ ntq
 ntq
 ntq
 ntq
-gjN
-cvt
-cvt
-cvt
-cvt
-cvt
-cvt
-cvt
-cvt
-lmH
+aOT
+lbr
+lbr
+lbr
+lbr
+lbr
+lbr
+lbr
+lbr
+bSw
 ntq
 ntq
 ntq
@@ -332590,7 +333682,7 @@ ntq
 ntq
 ntq
 ntq
-ntq
+lxu
 ntq
 ntq
 ntq

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -830,7 +830,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/obj/structure/chair/office/light{
+/obj/structure/chair/office/darkpack{
 	dir = 1
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -3953,7 +3953,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/oldchurch)
 "aVV" = (
-/obj/item/chair/stool/bar,
+/obj/item/chair/stool/bar/darkpack/red,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "aVW" = (
@@ -9692,6 +9692,12 @@
 /obj/item/melee/vamp/tire,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
+"cnY" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/anarch)
 "cob" = (
 /obj/structure/railing{
 	pixel_y = -1
@@ -11172,7 +11178,7 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f3)
 "cHS" = (
-/obj/item/chair/stool/bar,
+/obj/item/chair/stool/bar/darkpack/red,
 /obj/machinery/light/small/pink/directional/north,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
@@ -15247,7 +15253,7 @@
 /area/vtm/interior/shop/bubway)
 "dLx" = (
 /obj/structure/table,
-/obj/item/chair/stool/bar,
+/obj/item/chair/stool/bar/darkpack/red,
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic/haven)
 "dLA" = (
@@ -26774,7 +26780,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/anarch)
 "gGw" = (
-/obj/structure/chair/office/light,
+/obj/structure/chair/office/darkpack,
 /obj/effect/decal/carpet{
 	icon_state = "rug_blue";
 	pixel_x = 1;
@@ -33841,7 +33847,7 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
 "iwq" = (
-/obj/structure/chair/office/light,
+/obj/structure/chair/office/darkpack,
 /obj/effect/landmark/start/darkpack/hospital/doctor,
 /obj/effect/turf_decal/siding/grey/corner{
 	dir = 1
@@ -35420,9 +35426,8 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
 "iSs" = (
-/obj/structure/chair/plastic{
-	dir = 8;
-	pixel_y = 4
+/obj/structure/chair/plastic/darkpack{
+	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
@@ -38721,7 +38726,6 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry)
 "jKx" = (
-/obj/machinery/light/directional/south,
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
@@ -67720,7 +67724,9 @@
 /turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/jazzclub)
 "qYS" = (
-/obj/structure/toilet,
+/obj/structure/toilet{
+	pixel_y = 16
+	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/church/staff)
 "qZa" = (
@@ -70276,7 +70282,7 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/shop/pharmacy)
 "rDR" = (
-/obj/item/chair/stool/bar,
+/obj/item/chair/stool/bar/darkpack/red,
 /obj/effect/decal/cleanable/greenglow/ecto,
 /turf/open/floor/plating/rust,
 /area/vtm/interior/strip)
@@ -83369,7 +83375,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
 "uVp" = (
-/obj/structure/chair/office/light{
+/obj/structure/chair/office/darkpack{
 	dir = 4
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -90038,7 +90044,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
 "wGu" = (
-/obj/item/chair/stool/bar,
+/obj/item/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "wGw" = (
@@ -94698,7 +94704,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
 "xMh" = (
-/obj/structure/chair/office/light,
+/obj/structure/chair/office/darkpack,
 /obj/effect/landmark/start/darkpack/hospital/doctor,
 /obj/effect/turf_decal/siding/grey/corner{
 	dir = 4
@@ -183776,7 +183782,7 @@ qjr
 qLB
 qLB
 pDs
-ugF
+cnY
 giR
 kFn
 iTQ
@@ -184290,7 +184296,7 @@ dsa
 qLB
 qLB
 nAW
-pMC
+ugF
 giR
 eJa
 eJa

--- a/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
+++ b/_maps/map_files/Vampire/san_fangsisco/sanfangsisco.dmm
@@ -78,6 +78,15 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/bianchiBank)
+"aaX" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "aaY" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -141,7 +150,7 @@
 /area/vtm/interior)
 "abG" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
 "abQ" = (
@@ -1738,6 +1747,7 @@
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/access/federal,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/mapping_helpers/door/bash_difficulty/seven,
 /turf/open/misc/dirt,
 /area/vtm/interior/police/fed)
 "ava" = (
@@ -1813,11 +1823,6 @@
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/ghetto)
-"avQ" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "avT" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -1916,10 +1921,11 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic)
 "awR" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
+/obj/structure/chair/sofa/corp/right{
+	color = "#CD5C5C";
+	dir = 4
 	},
-/turf/open/floor/wood/smooth,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "awV" = (
 /obj/structure/hedge,
@@ -2413,7 +2419,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "aDz" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/city/bacotell,
@@ -2694,11 +2700,6 @@
 /obj/structure/sink/directional/west,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
-"aHn" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "aHq" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -2927,17 +2928,6 @@
 /obj/machinery/light/prince/directional/east,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
-"aKn" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/ammo_box/darkpack/arrows,
-/obj/item/ammo_box/darkpack/arrows,
-/obj/item/ammo_box/darkpack/arrows,
-/obj/item/ammo_box/darkpack/arrows,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/museum)
 "aKu" = (
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/city,
@@ -2952,9 +2942,8 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
 "aKy" = (
-/obj/structure/chair/plastic{
-	dir = 8;
-	pixel_y = 4
+/obj/structure/chair/plastic/darkpack{
+	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
@@ -3149,7 +3138,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/hotel)
 "aNi" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
 "aNj" = (
@@ -3245,7 +3234,7 @@
 /area/vtm/interior/clinic)
 "aOz" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/carpet/blue,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "aOC" = (
 /obj/structure/chair/wood/darkpack/red{
@@ -3405,6 +3394,16 @@
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/iron/small,
 /area/vtm/interior/endron_facility/restricted)
+"aQM" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24;
+	pixel_x = 0
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 16
+	},
+/turf/open/umbra,
+/area/vtm/interior)
 "aQO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3878,13 +3877,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"aUU" = (
-/mob/living/carbon/human/npc/bouncer/elysium/theatre,
-/obj/structure/chair/wood/darkpack/red{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/theatre)
 "aUX" = (
 /obj/structure/platform/lowwall/rich/old/window,
 /turf/open/floor/plating/rough,
@@ -3902,14 +3894,6 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
-"aVi" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/south,
-/obj/structure/railing{
-	dir = 8;
-	pixel_x = -3
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior)
 "aVk" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/smooth/old,
@@ -4106,7 +4090,8 @@
 "aYj" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
-/turf/open/floor/carpet/darkpack,
+/obj/effect/turf_decal/siding/wood/light/corner,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "aYr" = (
 /obj/machinery/oven/range,
@@ -4117,7 +4102,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "aYA" = (
-/obj/structure/table/wood/fancy/royalblue,
+/obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "aYG" = (
@@ -4394,6 +4379,18 @@
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
+"bcv" = (
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/unlock,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "bcw" = (
 /obj/structure/vampdoor/simple{
 	dir = 4;
@@ -5084,6 +5081,13 @@
 /obj/effect/decal/wallpaper/blue/low,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/jazzclub)
+"bkS" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
+/mob/living/carbon/human/npc/bouncer/elysium/theatre,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/theatre)
 "bkT" = (
 /obj/structure/platform/lowwall/painted/window/reinforced,
 /turf/open/floor/plating/rough,
@@ -5128,7 +5132,7 @@
 /area/vtm/interior/shop/antiques)
 "blP" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "blQ" = (
@@ -5305,6 +5309,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/shop/bubway)
+"bnz" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24;
+	pixel_x = 0
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior)
 "bnA" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/city/plating_mono,
@@ -5521,6 +5532,16 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"bqd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "bqk" = (
 /obj/structure/table,
 /obj/structure/microscope,
@@ -6372,19 +6393,6 @@
 /obj/item/storage/box/aquarium_props,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
-"bzU" = (
-/obj/structure/vampdoor/simple{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/door/access/strip,
-/obj/effect/mapping_helpers/door/lock,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/door/lock_difficulty/eight,
-/obj/effect/mapping_helpers/door/bash_difficulty/eight,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "bzV" = (
 /obj/machinery/light/floor/lamppost/one{
 	dir = 8
@@ -6417,7 +6425,8 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/prince/directional/north,
 /obj/item/reagent_containers/cup/glass/baggie/meth/cocaine,
-/turf/open/floor/carpet/darkpack,
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "bAi" = (
 /obj/structure/chair/sofa/left/brown,
@@ -6436,6 +6445,13 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/financialdistrict)
+"bAp" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "bAq" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/toilet{
@@ -6597,12 +6613,6 @@
 /obj/structure/vampdoor,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"bCc" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "bCe" = (
 /turf/open/floor/city/toilet,
 /area/vtm/interior/chantry)
@@ -6724,6 +6734,12 @@
 /obj/structure/roadsign,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"bDH" = (
+/obj/structure/curtain/cloth/fancy{
+	pixel_y = 8
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior)
 "bDN" = (
 /mob/living/carbon/human/npc/bouncer/elysium/elysium_2,
 /turf/open/floor/city/plating_mono,
@@ -6752,24 +6768,10 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/misc/grass,
 /area/vtm/outside/giovanni/courtyard)
-"bEh" = (
-/obj/structure/easel,
-/obj/item/canvas/twentythree_twentythree{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
 "bEr" = (
 /obj/structure/platform/lowwall/bar/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/shop/gunshop)
-"bEu" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "bEv" = (
 /obj/structure/ladder/manhole/up,
 /obj/machinery/light/small/directional/north,
@@ -7080,12 +7082,6 @@
 /obj/structure/bed,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
-"bIV" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "bIY" = (
 /obj/structure/stairs/west,
 /turf/open/floor/wood/smooth/old,
@@ -7509,13 +7505,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
-"bOo" = (
-/obj/structure/chair/plastic{
-	dir = 4;
-	pixel_y = 7
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/sewer/nosferatu_town)
 "bOt" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -7589,6 +7578,12 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm/interior/oldchurch)
+"bPS" = (
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "bPX" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/city/church,
@@ -8131,6 +8126,14 @@
 /obj/machinery/light/directional/west,
 /turf/open/misc/dirt,
 /area/vtm/outside/pacificheights/forest)
+"bVT" = (
+/obj/machinery/light/directional/south,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "bWd" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/concrete,
@@ -8255,6 +8258,10 @@
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/museum)
+"bXz" = (
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/jazzclub)
 "bXC" = (
 /obj/structure/rack/tall/store_shelf_metal,
 /obj/item/clothing/suit/vampire/vest{
@@ -8326,7 +8333,9 @@
 /obj/item/reagent_containers/cup/glass/bottle/wine,
 /obj/item/reagent_containers/cup/glass/bottle/wine,
 /obj/item/storage/box/drinkingglasses,
-/turf/open/floor/carpet/darkpack,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "bYc" = (
 /obj/effect/decal/pallet{
@@ -8507,6 +8516,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic)
+"cas" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "cat" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -8647,16 +8663,6 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
-"ccX" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/musician/piano{
-	icon_state = "piano"
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior)
 "ccZ" = (
 /obj/structure/railing{
 	dir = 8
@@ -9071,10 +9077,6 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
-"cgg" = (
-/obj/structure/chair/greyscale,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
 "cgt" = (
 /obj/structure/closet/cabinet,
 /obj/item/scythe/vamp{
@@ -9118,9 +9120,8 @@
 /area/vtm/interior/techshop)
 "cgz" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/chair/plastic{
-	dir = 8;
-	pixel_y = 4
+/obj/structure/chair/plastic/darkpack{
+	dir = 8
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
@@ -9394,7 +9395,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/banu/haven)
 "ckz" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
 "ckE" = (
@@ -9924,6 +9925,20 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/clinic/haven)
+"crv" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 2;
+	color = "#CD5C5C"
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "crx" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -10082,7 +10097,7 @@
 /area/vtm/interior/church/haven)
 "cth" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "ctk" = (
@@ -10174,7 +10189,6 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
 "cum" = (
-/obj/structure/table/wood/fancy/orange,
 /obj/item/storage/pill_bottle/estrogen{
 	pixel_y = 6
 	},
@@ -10182,7 +10196,8 @@
 /obj/item/storage/pill_bottle/psicodine,
 /obj/item/storage/pill_bottle/lsd,
 /obj/item/storage/pill_bottle/epinephrine,
-/turf/open/floor/carpet/orange,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "cuo" = (
 /turf/open/misc/grass,
@@ -10206,6 +10221,18 @@
 	},
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/chantry)
+"cuI" = (
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/railing{
+	dir = 8;
+	pixel_y = 9
+	},
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "cuJ" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -10580,12 +10607,9 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
 "cAr" = (
-/obj/structure/railing{
-	dir = 8;
-	pixel_y = 9
-	},
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "cAs" = (
 /obj/structure/railing{
 	dir = 5
@@ -10738,9 +10762,8 @@
 /turf/open/water,
 /area/vtm/interior/millennium_tower)
 "cCs" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/sewer/nosferatu_town)
@@ -10868,10 +10891,6 @@
 /obj/item/ammo_box/darkpack/c44/silver,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
-"cEg" = (
-/obj/machinery/light/small/red/directional/south,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "cEl" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -11231,10 +11250,10 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "cIk" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 8
 	},
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /turf/open/floor/wood/ornate,
@@ -11499,36 +11518,8 @@
 /area/vtm/interior/clinic)
 "cLI" = (
 /obj/machinery/light/prince/directional/north,
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_y = 5;
-	pixel_x = 11
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_y = 5;
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_y = 5;
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_y = 5;
-	pixel_x = -9
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
-	pixel_x = -11
-	},
-/obj/structure/table/wood/fancy,
-/turf/open/floor/wood/smooth,
+/obj/structure/bookcase/random,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "cLJ" = (
 /obj/machinery/light/prince/directional/east,
@@ -11804,10 +11795,10 @@
 /turf/open/misc/dirt,
 /area/vtm/interior/glasswalker)
 "cPZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
 	},
-/turf/open/floor/wood/ornate,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "cQg" = (
 /obj/structure/barrels/rand,
@@ -11959,6 +11950,10 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"cSH" = (
+/obj/effect/decal/wallpaper/blue,
+/turf/closed/wall/vampwall/rich,
+/area/vtm/interior)
 "cSN" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 1
@@ -12075,7 +12070,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
 "cUk" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /obj/effect/landmark/start/darkpack/hecata/capo,
@@ -12181,6 +12176,10 @@
 	color = "#483C32"
 	},
 /area/vtm/interior/giovanni/basement)
+"cVx" = (
+/obj/structure/chair/stool/bar/darkpack/red,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior)
 "cVy" = (
 /obj/structure/railing{
 	dir = 8
@@ -12463,6 +12462,38 @@
 /obj/item/food/grown/cannabis,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/police)
+"dba" = (
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_y = 5;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
+	pixel_x = -11
+	},
+/obj/structure/table/wood/fancy/royalblack,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "dbm" = (
 /obj/structure/hedge,
 /obj/machinery/light/directional/east,
@@ -12687,11 +12718,10 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "dej" = (
-/obj/structure/chair/comfy{
-	color = "#0066ff";
+/obj/effect/landmark/start/darkpack/primogen/toreador,
+/obj/structure/chair/comfy/darkpack/darkblue{
 	dir = 1
 	},
-/obj/effect/landmark/start/darkpack/primogen/toreador,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "dek" = (
@@ -12907,6 +12937,12 @@
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/tzimisce_sanctum)
+"dgq" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "dgt" = (
 /obj/structure/sign/city/chinese/directional/east,
 /turf/open/floor/plating/sidewalkalt,
@@ -14240,15 +14276,6 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
-"dxv" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire,
-/obj/item/gun/ballistic/shotgun/toy/crossbow/vampire,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/museum)
 "dxy" = (
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/baali)
@@ -14281,16 +14308,12 @@
 /obj/structure/closet/crate/coffin,
 /obj/item/clothing/under/vampire/primogen_toreador,
 /obj/item/clothing/under/vampire/primogen_toreador/female,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "dxU" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer/nosferatu_town)
-"dxZ" = (
-/obj/structure/chair/wood/darkpack/red,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "dya" = (
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
@@ -14594,6 +14617,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/industrial,
 /area/vtm/interior/shop/hardware_store)
+"dCI" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 16
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24;
+	pixel_x = 0
+	},
+/turf/open/umbra,
+/area/vtm/interior)
 "dCN" = (
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk,
@@ -14637,7 +14670,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
 "dDl" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood/dark{
@@ -15414,10 +15447,10 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/wyrm_corrupted)
 "dNi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "dNj" = (
 /turf/open/openspace,
@@ -15664,6 +15697,10 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/grass,
 /area/vtm/interior/bianchiBank)
+"dQp" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "dQz" = (
 /obj/structure/table/countertop/bacotell,
 /obj/structure/platform/lowwall/painted,
@@ -16240,17 +16277,6 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"dXY" = (
-/obj/structure/railing{
-	pixel_y = -2
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
 "dXZ" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/vampfence/rich,
@@ -16269,7 +16295,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/haven)
 "dYj" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
@@ -16283,6 +16309,10 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/setite)
+"dYs" = (
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "dYt" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -16296,10 +16326,10 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f2)
 "dYG" = (
-/obj/effect/turf_decal/siding/purple{
+/obj/structure/railing/wooden_fence{
 	dir = 6
 	},
-/turf/open/floor/light,
+/turf/open/floor/wood/old,
 /area/vtm/interior)
 "dYK" = (
 /obj/effect/landmark/npcwall,
@@ -16364,10 +16394,6 @@
 /obj/structure/vampfence/corner,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
-"dZz" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "dZB" = (
 /obj/structure/table/wood,
 /obj/item/vamp/keys/children_of_gaia,
@@ -16403,12 +16429,6 @@
 /obj/machinery/vending/cola/blue,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
-"eaA" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 1
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/f4)
 "eaB" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/vampirewater,
@@ -17084,8 +17104,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "eiK" = (
-/obj/structure/chair/sofa/corp/left,
-/obj/structure/coclock,
+/obj/machinery/jukebox{
+	pixel_y = 15;
+	density = 0
+	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "eiL" = (
@@ -17104,12 +17126,6 @@
 /obj/item/clothing/mask/gas/vampire,
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
-"ejg" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "ejm" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -17474,8 +17490,10 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "enA" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
+/obj/effect/landmark/start/darkpack/camarilla/harpy,
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "#CD5C5C"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
@@ -17498,7 +17516,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "enM" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /turf/open/misc/dirt,
@@ -17863,6 +17881,13 @@
 /obj/item/ammo_box/darkpack/c50ae,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
+"etF" = (
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/fax/camarilla{
+	pixel_y = 7
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "etL" = (
 /obj/structure/chair/office/darkpack/black,
 /obj/machinery/light/directional/north,
@@ -17952,6 +17977,18 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"euY" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/paper_bin{
+	pixel_y = 14;
+	pixel_x = 12
+	},
+/obj/item/pen/fountain{
+	pixel_x = 10;
+	pixel_y = 15
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "euZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -18190,22 +18227,6 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/city/factory,
 /area/vtm/interior/jazzclub)
-"eyh" = (
-/obj/structure/railing{
-	dir = 8;
-	pixel_y = 9
-	},
-/obj/structure/table/wood,
-/obj/item/canvas/twentythree_twentythree{
-	pixel_x = 7;
-	pixel_y = 19
-	},
-/obj/item/canvas/twentythree_nineteen,
-/obj/item/canvas/nineteen_nineteen{
-	pixel_x = 21
-	},
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
 "eyp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing{
@@ -18523,8 +18544,10 @@
 "eDn" = (
 /obj/machinery/light/prince/directional/north,
 /obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
+/obj/machinery/bitcoin_miner{
+	name = "money printer";
+	desc = "A machine that is designed to print counterfeit currency with impeccable accuracy, with a monitor connected to it.\nIt has an output for withdrawing the cash obtained from printing, somehow."
+	},
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "eDq" = (
@@ -18859,6 +18882,15 @@
 /obj/item/smartphone/payphone,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/fishermanswharf/lower)
+"eHk" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "eHs" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/grass,
@@ -18869,6 +18901,10 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"eHx" = (
+/obj/structure/chair/stool/bar/darkpack/black,
+/turf/open/floor/carpet/darkpack/purplegold,
+/area/vtm/interior/jazzclub)
 "eHy" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 9
@@ -18883,7 +18919,7 @@
 /area/vtm)
 "eHD" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair/greyscale,
+/obj/structure/chair/darkpack,
 /obj/effect/turf_decal/siding/grey{
 	dir = 9
 	},
@@ -19782,10 +19818,10 @@
 /area/vtm/interior/jazzclub)
 "eSN" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/spawner/random/occult/artifact,
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/effect/spawner/random/occult/artifact,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "eST" = (
@@ -19794,7 +19830,7 @@
 /area/vtm/interior/millennium_tower)
 "eSU" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/hotel)
 "eSV" = (
@@ -19946,12 +19982,13 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/setite)
 "eVp" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/obj/structure/chair/sofa/corp/left{
+	color = "#CD5C5C";
+	dir = 1
 	},
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "eVz" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/secure_closet/freezer,
@@ -20037,9 +20074,6 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "eWK" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
 /obj/machinery/light/prince/directional/east,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
@@ -20162,6 +20196,15 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/techshop)
+"eYv" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "eYF" = (
 /obj/effect/turf_decal/siding/grey{
 	dir = 4
@@ -20423,7 +20466,7 @@
 /area/vtm/outside/forest)
 "fbj" = (
 /obj/machinery/light/warm/directional/east,
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/plating/rough/cave,
@@ -20489,8 +20532,10 @@
 /area/vtm/interior/clinic)
 "fbY" = (
 /obj/effect/decal/wallpaper/gold/low,
-/obj/structure/curtain/bounty,
 /obj/structure/platform/lowwall/rich/window/reinforced,
+/obj/structure/curtain/cloth/fancy{
+	pixel_y = 8
+	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f4)
 "fbZ" = (
@@ -20925,7 +20970,7 @@
 /area/vtm/outside/fishermanswharf)
 "fhf" = (
 /obj/effect/decal/pallet,
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /turf/open/misc/dirt,
@@ -21026,8 +21071,18 @@
 /area/vtm/interior/vjanitor)
 "fih" = (
 /obj/structure/hedge,
-/turf/open/floor/carpet/darkpack/blacksilver,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/misc/grass,
 /area/vtm/interior/millennium_tower/f4)
+"fip" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing/corner/end{
+	pixel_y = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "fir" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -21050,6 +21105,10 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/necropolis/air,
 /area/vtm/interior/tzimisce_sanctum)
+"fjh" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "fjk" = (
 /obj/effect/decal/wallpaper/stone,
 /obj/effect/decal/wallpaper/stone,
@@ -21278,9 +21337,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
 "fmw" = (
-/obj/structure/chair/comfy/beige{
-	pixel_y = 4
-	},
+/obj/structure/chair/comfy/darkpack,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
 "fmx" = (
@@ -21480,8 +21537,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/community)
 "foM" = (
-/obj/effect/turf_decal/siding/purple,
-/turf/open/floor/light,
+/turf/open/floor/iron/stairs/black,
 /area/vtm/interior)
 "foR" = (
 /obj/structure/railing{
@@ -21541,11 +21597,10 @@
 /turf/open/misc/grass,
 /area/vtm/interior/church)
 "fpB" = (
-/obj/structure/chair/plastic{
-	dir = 4;
-	pixel_y = 7
-	},
 /obj/machinery/light/small/directional/west,
+/obj/structure/chair/plastic/darkpack{
+	dir = 4
+	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
 "fpR" = (
@@ -21583,6 +21638,12 @@
 /obj/structure/rack,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/cog/caern)
+"fqg" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 6
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior)
 "fqo" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -22148,9 +22209,8 @@
 /turf/open/misc/grass,
 /area/vtm/outside/forest)
 "fym" = (
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	pixel_x = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
@@ -22427,9 +22487,8 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "fBh" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1;
-	color = "#50C878"
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
 	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/glasswalker)
@@ -22597,9 +22656,8 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/chantry)
 "fCS" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
@@ -22723,12 +22781,6 @@
 /obj/fusebox,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/giovanni)
-"fEN" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 9
-	},
-/turf/open/floor/light,
-/area/vtm/interior)
 "fEX" = (
 /obj/structure/table,
 /turf/open/floor/wood/smooth/old,
@@ -23289,10 +23341,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf)
 "fLJ" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 4
 	},
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
 /turf/open/floor/wood/ornate,
@@ -23314,12 +23366,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /turf/open/floor/wood/old,
 /area/vtm/interior/chantry)
-"fLN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/f4)
 "fLO" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -23363,6 +23409,10 @@
 "fMQ" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/outside/pacificheights)
+"fMS" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "fMU" = (
 /obj/machinery/light/prince/directional/west,
 /obj/effect/turf_decal/siding/white{
@@ -23477,9 +23527,8 @@
 /obj/item/stack/dollar/hundred,
 /obj/item/stack/dollar/hundred,
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
@@ -23544,7 +23593,6 @@
 /turf/open/floor/iron/white/textured,
 /area/vtm/interior/endron_facility/restricted)
 "fPn" = (
-/obj/effect/turf_decal/siding/white,
 /obj/structure/vampdoor/reinf{
 	lock_id = "primToreador";
 	locked = 1;
@@ -23554,6 +23602,10 @@
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/bash_difficulty/ten,
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "fPs" = (
@@ -23573,12 +23625,18 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
 "fPy" = (
-/obj/structure/chair/comfy/brown{
+/obj/effect/landmark/start/darkpack/anarch/emissary,
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start/darkpack/anarch/emissary,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch)
+"fPC" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "fPD" = (
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/city/toilet,
@@ -24041,15 +24099,6 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/baali)
-"fUC" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/vtm/interior/millennium_tower/f4)
 "fUJ" = (
 /obj/structure/mop_bucket,
 /obj/item/mop,
@@ -24145,10 +24194,6 @@
 /obj/effect/decal/rugs,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/supply)
-"fWC" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/plating/rough,
-/area/vtm)
 "fWI" = (
 /obj/item/trash/popcorn,
 /turf/open/floor/plating/rough,
@@ -24262,6 +24307,8 @@
 /area/vtm/interior/shop/otolleys)
 "fYo" = (
 /obj/structure/hedge,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
 "fYz" = (
@@ -24270,9 +24317,9 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer)
 "fYC" = (
-/obj/structure/chair/comfy/beige,
 /obj/effect/decal/pallet,
 /obj/effect/landmark/start/darkpack/primogen/malkavian,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/clinic/haven)
 "fYH" = (
@@ -24320,7 +24367,7 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "fYY" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/haven)
 "fZa" = (
@@ -24416,7 +24463,6 @@
 /area/vtm/interior/millennium_tower)
 "gaB" = (
 /obj/structure/coclock,
-/obj/structure/rack/clothing_hanger,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "gaJ" = (
@@ -24612,6 +24658,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/clinic)
+"gdy" = (
+/obj/effect/turf_decal/siding/wood/dark,
+/obj/structure/chair/darkpack/blue,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior)
 "gdA" = (
 /obj/machinery/button/door{
 	id = "pentexhq_exec";
@@ -24752,6 +24803,16 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/shop/bacotell)
+"gfR" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "gfV" = (
 /obj/effect/turf_decal/bordur{
 	dir = 9
@@ -24856,8 +24917,9 @@
 /area/vtm/interior/shop/bacotell)
 "ggU" = (
 /obj/effect/landmark/start/darkpack/camarilla/prince,
-/obj/structure/chair/comfy/brown{
-	color = "#FFECD5"
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 2;
+	color = "#CD5C5C"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
@@ -25120,8 +25182,8 @@
 /area/vtm/interior/setite/basement)
 "gjE" = (
 /obj/structure/coclock,
-/obj/structure/chair/sofa/corp/corner,
 /obj/machinery/light/prince/directional/east,
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "gjJ" = (
@@ -25368,6 +25430,9 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/fed)
+"gnd" = (
+/turf/open/floor/iron/stairs/black,
+/area/vtm/interior/millennium_tower/f4)
 "gng" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -26307,7 +26372,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "gAx" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /turf/open/floor/carpet/darkpack/old,
@@ -26618,11 +26683,6 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/salubri)
-"gEu" = (
-/obj/structure/vampstatue/angel,
-/obj/machinery/sprinkler/area_managed,
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/f4)
 "gEx" = (
 /obj/structure/ladder/manhole/down,
 /turf/open/floor/plating/sidewalk/poor,
@@ -27210,7 +27270,7 @@
 /turf/open/misc/grass,
 /area/vtm/interior/chantry)
 "gKO" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/setite)
 "gKQ" = (
@@ -27448,10 +27508,6 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
-"gOQ" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior/millennium_tower/f4)
 "gOV" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/city/plating_mono,
@@ -28047,14 +28103,6 @@
 /obj/structure/table,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/sewer)
-"gVS" = (
-/obj/effect/decal/wallpaper/red,
-/obj/machinery/light/small/pink{
-	dir = 1;
-	pixel_y = -17
-	},
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior)
 "gVZ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -28425,7 +28473,7 @@
 /area/vtm/interior)
 "haZ" = (
 /obj/structure/chair/wood/darkpack/red,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "hbc" = (
 /obj/effect/turf_decal/bordur{
@@ -28581,10 +28629,8 @@
 /area/vtm/interior/jazzclub)
 "hcA" = (
 /obj/structure/bed,
-/obj/item/bedsheet/qm{
-	name = "bedsheet"
-	},
-/turf/open/floor/carpet/orange,
+/obj/item/bedsheet/black,
+/turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "hcH" = (
 /obj/machinery/light/directional/north,
@@ -28686,6 +28732,22 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower)
+"hdQ" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/paper_bin{
+	pixel_y = 19;
+	pixel_x = -11
+	},
+/obj/item/clipboard{
+	pixel_x = -3;
+	pixel_y = 11
+	},
+/obj/item/pen/fountain{
+	pixel_x = -14;
+	pixel_y = 20
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "hdT" = (
 /obj/effect/decal/pallet,
 /turf/open/water/vamp_sewer,
@@ -28887,20 +28949,15 @@
 /area/vtm/interior/hotel)
 "hgT" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 14;
-	pixel_x = 19
-	},
 /obj/item/pen/fountain/captain{
 	name = "director's fountain pen";
 	desc = "It's an expensive Oak fountain pen. The nib is quite sharp. The letter V is embossed."
 	},
 /obj/item/paper_bin{
 	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
@@ -29022,8 +29079,10 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
 "hio" = (
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/cup/glass/bottle/champagne,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "hiu" = (
@@ -29243,6 +29302,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/northbeach)
+"hlA" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior)
 "hlF" = (
 /turf/open/floor/wood/smooth,
 /area/vtm)
@@ -29356,11 +29419,6 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/arts)
-"hnx" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table/wood,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
 "hnz" = (
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk/old,
@@ -29395,10 +29453,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/glasswalker)
-"hnU" = (
-/obj/effect/decal/shadow,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior)
 "hnV" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/machinery/light/small/directional/east,
@@ -29915,6 +29969,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
+"hup" = (
+/obj/structure/curtain/cloth/fancy{
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "hur" = (
 /obj/structure/vampdoor/prison{
 	lockpick_difficulty = 15
@@ -29959,6 +30019,10 @@
 /obj/item/radio,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/clinic/haven)
+"huV" = (
+/obj/structure/table/wood/fancy/royalblack,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "huY" = (
 /obj/structure/table/wood/fancy/red,
 /obj/effect/decal/painting/second{
@@ -30032,9 +30096,6 @@
 	},
 /turf/closed/wall/vampwall/market,
 /area/vtm/interior/shop/bacotell)
-"hwb" = (
-/turf/open/floor/iron/stairs,
-/area/vtm/interior/millennium_tower/f4)
 "hwe" = (
 /obj/effect/decal/rugs{
 	pixel_x = 2;
@@ -30334,6 +30395,13 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop/bacotell)
+"hAN" = (
+/obj/effect/landmark/start/darkpack/camarilla/harpy,
+/obj/structure/chair/sofa/corp/right{
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/vtm/interior/millennium_tower/f4)
 "hAX" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/grass,
@@ -30744,6 +30812,12 @@
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/ten,
 /obj/effect/mapping_helpers/door/bash_difficulty/ten,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "hEQ" = (
@@ -30779,11 +30853,14 @@
 /area/vtm/interior/clinic)
 "hGg" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/wood/ornate,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "hGi" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/hotel)
 "hGm" = (
@@ -30862,7 +30939,7 @@
 	desc = "A silver Football Association Challenge Cup, this one is engraved with the year 1976."
 	},
 /obj/structure/table/wood/fancy,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "hHc" = (
 /obj/structure/barrels,
@@ -30955,7 +31032,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
 "hIs" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /turf/open/floor/city/church,
@@ -30981,7 +31058,7 @@
 /turf/closed/wall/vampwall/brick,
 /area/vtm/interior/shop)
 "hJb" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/effect/turf_decal/siding/grey/end{
 	dir = 1
 	},
@@ -31652,7 +31729,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
 "hRD" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -31932,13 +32009,6 @@
 	pixel_y = -2
 	},
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/railing{
 	dir = 8
 	},
 /obj/structure/flora/bush/flowers_yw/style_random{
@@ -31946,6 +32016,10 @@
 	},
 /obj/structure/flora/bush/lavendergrass/style_random{
 	pixel_y = 13
+	},
+/obj/structure/railing{
+	dir = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm)
@@ -32270,10 +32344,6 @@
 /obj/structure/sink/directional/west,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
-"iay" = (
-/obj/structure/rack/clothing_hanger,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "iaE" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -32500,10 +32570,6 @@
 "idO" = (
 /turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/interior/jazzclub)
-"idX" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "ieb" = (
 /obj/fusebox,
 /turf/open/floor/wood/herring,
@@ -32512,13 +32578,6 @@
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/community)
-"iee" = (
-/obj/effect/decal/wallpaper/gold,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/jazzclub)
 "ieg" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -32733,6 +32792,12 @@
 /obj/structure/vampstatue,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni/basement)
+"igV" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "iha" = (
 /obj/structure/roofstuff/vent/autotiling,
 /turf/open/floor/plating/sidewalk/poor,
@@ -32832,15 +32897,6 @@
 /obj/item/clothing/head/vampire/beanie/black,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch)
-"iiA" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/obj/machinery/light/small/pink{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "iiD" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/chair/sofa/corp/corner{
@@ -32875,12 +32931,6 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
-"ijw" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "ijA" = (
 /obj/effect/landmark/npcbeacon,
 /obj/effect/landmark/npcactivity,
@@ -32918,6 +32968,9 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/ghetto)
+"ikA" = (
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "ikB" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 5
@@ -33000,7 +33053,7 @@
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
 "ilC" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/carpet/darkpack,
@@ -33359,7 +33412,9 @@
 /turf/open/floor/wood/herring,
 /area/vtm/interior/shop/clothing_store)
 "iqw" = (
-/obj/structure/musician/piano,
+/obj/structure/musician/piano{
+	desc = "an elegant piano"
+	},
 /turf/open/floor/carpet/darkpack/purplegold,
 /area/vtm/interior/jazzclub)
 "iqx" = (
@@ -33446,27 +33501,23 @@
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/tzimisce_manor)
 "irM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/hedge,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
 /obj/machinery/sprinkler/area_managed,
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "irU" = (
 /obj/effect/mapping_helpers/door/lock,
 /obj/structure/vampdoor/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/door/lock_difficulty/ten,
 /obj/effect/mapping_helpers/door/access/federal,
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/door/bash_difficulty/ten,
+/obj/effect/mapping_helpers/door/bash_difficulty/seven,
+/obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/fed)
 "irW" = (
@@ -33670,11 +33721,6 @@
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
-"iuc" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/red,
-/area/vtm/interior)
 "iud" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -33803,8 +33849,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
 "ivI" = (
-/obj/structure/curtain/bounty,
 /obj/structure/platform/lowwall/rich/window,
+/obj/structure/curtain/bounty{
+	pixel_y = 15
+	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f4)
 "ivN" = (
@@ -34042,6 +34090,12 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/red,
 /area/vtm/interior)
+"izU" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "izV" = (
 /obj/structure/hydrant{
 	pixel_y = 5
@@ -34055,6 +34109,15 @@
 /obj/structure/vampfence/rich,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/community)
+"iAg" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/vampire_computer{
+	icon_state = "computerprince";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "iAj" = (
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 6
@@ -34115,7 +34178,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/outside/financialdistrict)
 "iAV" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /turf/open/floor/carpet/green,
@@ -34535,7 +34598,9 @@
 /obj/effect/decal/painting/third{
 	pixel_y = 32
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/instrument/violin,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "iGa" = (
 /turf/open/floor/iron/stairs/right,
@@ -34868,10 +34933,6 @@
 "iKo" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/interior/setite)
-"iKt" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/carpet/red,
-/area/vtm/interior)
 "iKD" = (
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sabbat_lair)
@@ -34884,7 +34945,7 @@
 /area/vtm/interior/shop)
 "iKR" = (
 /mob/living/carbon/human/npc/guard,
-/obj/structure/chair/greyscale,
+/obj/structure/chair/darkpack,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
 "iKX" = (
@@ -35141,10 +35202,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/northbeach)
-"iOE" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/light,
-/area/vtm/interior)
 "iOF" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/storage/fancy/egg_box,
@@ -35204,7 +35261,7 @@
 /area/vtm/interior/strip)
 "iPK" = (
 /obj/structure/chair/wood/darkpack/red,
-/obj/structure/railing/darkpack/metal,
+/obj/structure/railing/wooden_fence,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/theatre)
 "iPO" = (
@@ -35418,11 +35475,10 @@
 /turf/open/floor/city/clinic,
 /area/vtm/interior/clinic)
 "iSr" = (
-/obj/structure/chair/plastic{
-	dir = 8;
-	pixel_y = 4
-	},
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
+/obj/structure/chair/plastic/darkpack{
+	dir = 8
+	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
 "iSs" = (
@@ -35723,6 +35779,7 @@
 /obj/effect/turf_decal/siding/wood/light{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "iVz" = (
@@ -36162,10 +36219,12 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
 "jbr" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
+/obj/structure/chair/sofa/corp/left{
+	alpha = 225;
+	dir = 4;
+	color = "#CD5C5C"
 	},
-/turf/open/floor/wood/smooth,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "jbu" = (
 /obj/structure/closet/secure_closet/freezer,
@@ -36399,6 +36458,23 @@
 "jfa" = (
 /turf/open/floor/iron/stairs/black/right,
 /area/vtm/interior/endron_facility/restricted)
+"jff" = (
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
+"jfi" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "jfj" = (
 /obj/structure/railing/darkpack/metal/industrial/solo{
 	dir = 1
@@ -36574,7 +36650,7 @@
 /area/vtm/interior)
 "jhz" = (
 /obj/effect/decal/cleanable/litter,
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -37107,6 +37183,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"jpf" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "jps" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -37131,12 +37213,22 @@
 /obj/item/lighter,
 /turf/open/floor/plating/roofwalk,
 /area/vtm/interior/oldchurch)
+"jpJ" = (
+/obj/machinery/sprinkler/area_managed,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "jpK" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/church)
+"jpL" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 10
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "jpM" = (
 /obj/effect/decal/cleanable/litter,
 /turf/open/floor/plating/sidewalk/poor,
@@ -37430,6 +37522,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/shop/otolleys)
+"jtT" = (
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "jua" = (
 /obj/structure/vampdoor/wood{
 	dir = 4;
@@ -37474,19 +37575,14 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
 "jup" = (
-/obj/structure/hedge{
-	pixel_x = 3
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/railing/wooden_fence{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 8
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/lavendergrass/style_random{
-	pixel_y = 13
-	},
-/turf/open/floor/wood/smooth,
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior/theatre)
 "juq" = (
 /obj/effect/turf_decal/siding/white{
@@ -38323,6 +38419,14 @@
 /obj/structure/lattice/pentex,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/wyrm_corrupted)
+"jEb" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/reagent_containers/cup/glass/trophy{
+	pixel_y = 11
+	},
+/obj/item/knife/vamp,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "jEh" = (
 /obj/machinery/light/floor/lamppost/one{
 	dir = 8
@@ -38368,6 +38472,13 @@
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry/basement)
+"jEX" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "jFc" = (
 /obj/effect/turf_decal/siding/wood/dark,
 /obj/structure/dresser{
@@ -38402,6 +38513,13 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
+"jFo" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/obj/structure/chair/sofa/corp/corner{
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "jFq" = (
 /obj/effect/turf_decal/stock{
 	dir = 8
@@ -38501,6 +38619,12 @@
 	density = 0
 	},
 /turf/open/floor/plating/rough,
+/area/vtm/interior)
+"jGG" = (
+/obj/structure/railing/wooden_fence{
+	dir = 8
+	},
+/turf/open/floor/wood/old,
 /area/vtm/interior)
 "jGR" = (
 /turf/open/floor/city/plating_mono,
@@ -38664,15 +38788,6 @@
 /obj/effect/turf_decal/darkpack/dirt/corner,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm)
-"jJQ" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/obj/machinery/light/small/pink{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "jJS" = (
 /obj/structure/closet/crate/large,
 /obj/effect/decal/pallet,
@@ -38932,10 +39047,8 @@
 /area/vtm/interior/church/haven)
 "jMM" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/item/blood_hunt,
+/obj/effect/turf_decal/siding/dark/corner,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "jMN" = (
@@ -39618,15 +39731,15 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/salubri)
 "jWy" = (
-/obj/structure/chair/comfy/teal{
+/obj/effect/landmark/start/darkpack/primogen/banu,
+/obj/structure/chair/comfy/darkpack/green{
 	dir = 8
 	},
-/obj/effect/landmark/start/darkpack/primogen/banu,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
 "jWz" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "jWC" = (
@@ -39915,12 +40028,6 @@
 /obj/effect/decal/shadow,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
-"kaQ" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "kaV" = (
 /obj/structure/coclock,
 /turf/open/floor/carpet/red,
@@ -40096,16 +40203,9 @@
 /area/vtm/interior/museum)
 "kdd" = (
 /obj/structure/hedge,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/prince/directional/west,
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/smooth,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/misc/grass,
 /area/vtm/interior/millennium_tower/f4)
 "kde" = (
 /obj/effect/turf_decal/siding/wood/dark{
@@ -40333,7 +40433,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/police/morgue)
 "kfT" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -40820,11 +40920,7 @@
 /obj/effect/decal/painting/second{
 	pixel_y = 32
 	},
-/obj/structure/chair/sofa/corp/right,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/landmark/start/darkpack/camarilla/clerk,
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "kmD" = (
@@ -41072,12 +41168,6 @@
 /obj/item/chair/wood,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
-"kpJ" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/turf/open/floor/light,
-/area/vtm/interior)
 "kpM" = (
 /obj/structure/table/wood,
 /obj/underplate/stuff{
@@ -41114,6 +41204,15 @@
 	},
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
+"kqy" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/clipboard,
+/obj/item/clipboard{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/jazzclub)
 "kqF" = (
 /obj/item/kirbyplants/random,
@@ -41261,9 +41360,8 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
@@ -41335,7 +41433,7 @@
 /turf/open/floor/iron/stairs/medium,
 /area/vtm/interior/church/haven)
 "ktJ" = (
-/obj/structure/chair/greyscale,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
 "ktO" = (
@@ -41374,7 +41472,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/shop/pawnshop)
 "kum" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
 /turf/open/floor/city/bacotell,
@@ -41525,7 +41623,7 @@
 /turf/open/floor/wood,
 /area/vtm/interior/church/haven)
 "kwy" = (
-/obj/structure/chair/sofa/corp{
+/obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
 /turf/open/floor/carpet/darkpack,
@@ -41724,6 +41822,10 @@
 /obj/structure/vampfence/corner/rich,
 /turf/open/misc/grass,
 /area/vtm/outside/forest)
+"kzx" = (
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior)
 "kzH" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/railing,
@@ -41911,6 +42013,12 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/bianchiBank)
+"kCy" = (
+/obj/structure/railing/corner/end{
+	pixel_y = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "kCB" = (
 /obj/darkpack_car/track/volkswagen{
 	access = "triad"
@@ -42157,7 +42265,7 @@
 /turf/open/misc/grass,
 /area/vtm)
 "kFx" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/wood/smooth/old,
@@ -42393,6 +42501,21 @@
 	},
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
+"kIB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/hedge,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/decal/shadow,
+/turf/open/misc/grass,
+/area/vtm/interior/millennium_tower/f4)
 "kIJ" = (
 /mob/living/carbon/human/npc/bubway,
 /obj/effect/mapping_helpers/mob_buckler,
@@ -42401,6 +42524,14 @@
 	},
 /turf/open/floor/city/circled,
 /area/vtm/interior/shop/bubway)
+"kIL" = (
+/obj/effect/decal/kopatich{
+	pixel_x = 18;
+	pixel_y = 18
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "kIM" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -42538,7 +42669,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "kKO" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood/dark{
@@ -42593,6 +42724,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/stairs/black/right,
 /area/vtm/interior/endron_facility/restricted)
+"kLj" = (
+/obj/structure/platform/lowwall/rich/window/reinforced,
+/obj/structure/curtain/cloth/fancy{
+	pixel_y = 15
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "kLq" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior/shop/camping_store)
@@ -42725,11 +42863,12 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/church)
 "kNs" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/structure/railing{
+	pixel_y = -2
 	},
-/turf/open/floor/plating/rough,
-/area/vtm)
+/obj/machinery/light/floor,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "kNt" = (
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior)
@@ -43005,6 +43144,10 @@
 	},
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"kQl" = (
+/obj/machinery/light/prince/directional/south,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "kQr" = (
 /obj/effect/decal/graffiti/large,
 /obj/effect/decal/cleanable/litter,
@@ -43444,10 +43587,6 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
-"kVm" = (
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/plating/rough,
-/area/vtm)
 "kVv" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/dollar/five,
@@ -43463,7 +43602,7 @@
 /area/vtm/interior/anarch)
 "kVA" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/hotel)
 "kVB" = (
@@ -43516,10 +43655,6 @@
 /obj/machinery/sprinkler/area_managed,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/chantry/basement)
-"kWl" = (
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "kWn" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth/old,
@@ -43540,7 +43675,7 @@
 /obj/structure/dresser,
 /obj/item/instrument/violin/golden,
 /obj/item/clothing/suit/vampire/trench/alt/armored,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "kWs" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -43877,16 +44012,9 @@
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
 "laI" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/canvas/nineteen_nineteen{
-	pixel_x = 21
-	},
-/obj/item/canvas/twentythree_nineteen,
+/obj/structure/chair/sofa/corp/right,
 /turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
+/area/vtm/interior)
 "laN" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
@@ -44225,11 +44353,6 @@
 /obj/fusebox,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
-"leG" = (
-/obj/structure/chair/sofa/corp/left,
-/obj/structure/coclock,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "leK" = (
 /obj/effect/turf_decal/asphaltline/alt{
 	dir = 8;
@@ -44293,6 +44416,22 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm/interior/theatre)
+"lfp" = (
+/obj/structure/railing{
+	dir = 8;
+	pixel_y = 9
+	},
+/obj/structure/table/wood,
+/obj/item/canvas/twentythree_twentythree{
+	pixel_x = 7;
+	pixel_y = 19
+	},
+/obj/item/canvas/twentythree_nineteen,
+/obj/item/canvas/nineteen_nineteen{
+	pixel_x = 21
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "lfr" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/sprinkler/area_managed,
@@ -44326,7 +44465,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
 "lfQ" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -44389,6 +44528,10 @@
 /obj/structure/trafficlight,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/financialdistrict)
+"lgE" = (
+/obj/structure/chair/stool/bar/darkpack/red,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "lgJ" = (
 /obj/effect/decal/cleanable/cardboard,
 /obj/structure/barrels/rand,
@@ -44735,12 +44878,6 @@
 /obj/structure/platform/lowwall/painted/window/reinforced,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/bianchiBank)
-"lmo" = (
-/obj/structure/chair/sofa/corp/corner,
-/mob/living/carbon/human/npc/incel,
-/obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "lmu" = (
 /obj/structure/platform/lowwall/market/window,
 /turf/open/floor/plating/rough,
@@ -44826,8 +44963,11 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/church/haven)
 "lnC" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/turf/open/floor/wood/smooth,
+/obj/structure/chair/sofa/corp/right{
+	dir = 8;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "lnH" = (
 /obj/structure/chair/wood/darkpack/red{
@@ -44869,8 +45009,6 @@
 /turf/open/misc/grass,
 /area/vtm)
 "loq" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/instrument/violin,
 /obj/machinery/light/prince/directional/west,
 /obj/effect/decal/painting{
 	pixel_y = 32
@@ -45034,6 +45172,17 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
+"lqt" = (
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "lqu" = (
 /obj/effect/decal/cleanable/trash{
 	icon_state = "trash7"
@@ -45438,10 +45587,6 @@
 /obj/darkpack_car/police,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/police)
-"lxr" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior)
 "lxs" = (
 /obj/structure/stairs/east,
 /turf/open/floor/plating/rough,
@@ -45508,22 +45653,6 @@
 	},
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/jazzclub)
-"lxT" = (
-/obj/structure/railing{
-	pixel_y = -2
-	},
-/obj/effect/decal/shadow{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior/tzimisce_manor)
 "lxX" = (
 /obj/structure/table/wood,
 /obj/structure/platform/lowwall/rich,
@@ -45625,12 +45754,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
-"lzw" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "lzB" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/church/staff)
@@ -45708,10 +45831,6 @@
 /obj/item/clothing/gloves/vampire/latex,
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/plating/concrete,
-/area/vtm/interior)
-"lAZ" = (
-/obj/effect/decal/wallpaper/light,
-/turf/closed/wall/vampwall/rich,
 /area/vtm/interior)
 "lBk" = (
 /obj/effect/turf_decal/siding/red{
@@ -45796,7 +45915,10 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
 "lCq" = (
-/turf/open/floor/carpet/orange,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "lCr" = (
 /obj/item/vamp/keys/malkav{
@@ -45813,6 +45935,16 @@
 "lCv" = (
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
+"lCw" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner,
+/obj/vampire_computer{
+	icon_state = "computerprince";
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "lCy" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/rough,
@@ -46068,11 +46200,12 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/bianchiBank)
 "lFK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/vampstatue/angel{
+	pixel_y = 11
 	},
-/obj/structure/chair/comfy/black,
-/turf/open/floor/wood/ornate,
+/obj/effect/decal/wallpaper/gold/low,
+/obj/structure/platform/lowwall/rich,
+/turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f4)
 "lFM" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -46127,9 +46260,6 @@
 /area/vtm/outside/forest)
 "lGk" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/computer/stockexchange{
-	name = "Luxurious stock exchange computer"
-	},
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 9
 	},
@@ -46156,10 +46286,6 @@
 	},
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/salubri)
-"lGB" = (
-/obj/machinery/jukebox,
-/turf/open/floor/light,
-/area/vtm/interior)
 "lGE" = (
 /obj/structure/rack/food{
 	dir = 4;
@@ -46708,10 +46834,10 @@
 /turf/open/floor/light,
 /area/vtm/interior/strip)
 "lND" = (
-/obj/effect/turf_decal/siding/purple{
+/obj/structure/railing/wooden_fence{
 	dir = 4
 	},
-/turf/open/floor/light,
+/turf/open/floor/wood/old,
 /area/vtm/interior)
 "lNZ" = (
 /obj/effect/turf_decal/darkpack/dirt{
@@ -46924,7 +47050,7 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/police/upstairs)
 "lRB" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/effect/landmark/start/darkpack/camarilla/sheriff,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f3)
@@ -47548,7 +47674,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "lYQ" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /turf/open/floor/plating/sidewalk/poor,
@@ -47924,7 +48050,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/lower)
 "mej" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/darkpack/dark,
 /obj/effect/landmark/start/darkpack/society_of_leopold/abbe,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
@@ -47945,14 +48071,9 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
 "meT" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "meV" = (
 /turf/open/floor/carpet/darkpack/blacksilver,
@@ -47968,13 +48089,6 @@
 /area/vtm)
 "mfd" = (
 /turf/closed/wall/vampwall/junk,
-/area/vtm/interior)
-"mfm" = (
-/obj/structure/hedge,
-/obj/machinery/light/small/pink{
-	dir = 4
-	},
-/turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "mfn" = (
 /obj/structure/toilet{
@@ -48423,6 +48537,12 @@
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"mko" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "mkp" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -48441,10 +48561,26 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
+"mkF" = (
+/obj/structure/chair/sofa/corp{
+	color = "#CD5C5C";
+	dir = 8
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "mkH" = (
 /obj/effect/decal/carpet,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
+"mla" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 16
+	},
+/turf/open/umbra,
+/area/vtm)
 "mle" = (
 /obj/structure/railing/corner/end{
 	dir = 8;
@@ -48486,7 +48622,10 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/graveyard)
 "mlK" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/light,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1
+	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "mlM" = (
@@ -48568,7 +48707,7 @@
 /area/vtm/interior/bianchiBank)
 "mmx" = (
 /obj/machinery/light/directional/east,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "mmD" = (
@@ -48579,6 +48718,13 @@
 /obj/structure/platform/lowwall/rich/old/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/chantry)
+"mmJ" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "mmV" = (
 /obj/structure/toilet{
 	dir = 4
@@ -48723,13 +48869,6 @@
 	},
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
-"moJ" = (
-/obj/structure/railing{
-	dir = 8;
-	pixel_x = -3
-	},
-/turf/open/floor/iron/stairs,
-/area/vtm/interior)
 "moN" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -49003,6 +49142,14 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
+"msY" = (
+/obj/effect/decal/wallpaper/gold/low,
+/obj/structure/platform/lowwall/rich/window/reinforced,
+/obj/structure/curtain/bounty{
+	pixel_y = 8
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior/millennium_tower/f4)
 "mtk" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/small/directional/north,
@@ -49158,11 +49305,15 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
 "muW" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/carpet/royalblack,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/misc/grass,
 /area/vtm/interior/millennium_tower/f4)
 "muZ" = (
 /obj/structure/transport/linear/public,
@@ -49371,7 +49522,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/fishermanswharf/ghetto)
 "mxT" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /obj/item/bong,
@@ -49556,12 +49707,12 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
 "mAd" = (
-/obj/structure/table/wood/fancy/orange,
 /obj/item/storage/pill_bottle/estrogen{
 	pixel_y = 6
 	},
 /obj/item/toy/crayon/spraycan/infinite,
-/turf/open/floor/carpet/orange,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "mAq" = (
 /obj/effect/landmark/start/darkpack/law_enforcement/officer,
@@ -49672,9 +49823,6 @@
 /area/vtm/interior/setite/basement)
 "mBK" = (
 /obj/structure/table/wood/fancy/red,
-/obj/machinery/computer/stockexchange{
-	name = "Luxurious stock exchange computer"
-	},
 /obj/effect/decal/painting/third{
 	pixel_y = 32
 	},
@@ -49701,11 +49849,6 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/tzimisce_manor)
-"mCj" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "mCk" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/vjanitor)
@@ -49940,7 +50083,6 @@
 	},
 /area/vtm/interior/sewer)
 "mFf" = (
-/obj/structure/table/wood/fancy/orange,
 /obj/item/storage/pill_bottle/happy,
 /obj/item/storage/pill_bottle/happinesspsych,
 /obj/item/storage/pill_bottle/stimulant,
@@ -49950,7 +50092,8 @@
 /obj/item/vamp/keys/strip,
 /obj/item/vamp/keys/strip,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/carpet/orange,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "mFk" = (
 /obj/effect/turf_decal/siding/wood,
@@ -50952,10 +51095,15 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior)
 "mRH" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/structure/vampstatue/cloaked{
+	name = "worn statue"
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/misc/grass,
 /area/vtm/interior/millennium_tower/f4)
 "mRJ" = (
 /obj/effect/turf_decal/siding/white{
@@ -51117,6 +51265,12 @@
 /obj/item/trash/candle,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
+"mTi" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "mTj" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior)
@@ -51666,9 +51820,12 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/ghetto)
 "mZI" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/obj/structure/curtain/cloth/fancy{
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "mZU" = (
 /obj/effect/landmark/npcbeacon/directed{
 	dir = 4
@@ -52027,6 +52184,13 @@
 /obj/vampire_computer,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/banu/haven)
+"neJ" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "neK" = (
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/concrete,
@@ -52555,7 +52719,7 @@
 /area/vtm/interior/chantry/basement)
 "nlP" = (
 /obj/effect/turf_decal/siding/white,
-/obj/effect/decal/wallpaper/paper/darkgreen,
+/obj/effect/decal/wallpaper/paper/fancy/red,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f4)
 "nlY" = (
@@ -52754,6 +52918,15 @@
 "noM" = (
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower)
+"noW" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/folder/red,
+/obj/item/folder/red{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "npf" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/decal/cleanable/trash,
@@ -53587,6 +53760,17 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"nBi" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 4
+	},
+/obj/item/smartphone/clean{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "nBj" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -53721,8 +53905,8 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "nCx" = (
-/obj/structure/table/wood/fancy/orange,
-/turf/open/floor/carpet/orange,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "nCH" = (
 /obj/structure/curtain/bounty{
@@ -53799,11 +53983,19 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/tzimisce_manor)
 "nDz" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 10
-	},
-/turf/open/floor/light,
+/obj/structure/railing/wooden_fence,
+/turf/open/floor/wood/old,
 /area/vtm/interior)
+"nDF" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "nDI" = (
 /obj/structure/vampfence/rich{
 	pixel_y = 7
@@ -54023,7 +54215,7 @@
 	pixel_y = 5;
 	anchored = 1
 	},
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "nGr" = (
 /obj/item/bouquet/sunflower{
@@ -54076,6 +54268,12 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/supply)
+"nHh" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "nHi" = (
 /obj/item/smartphone/payphone,
 /turf/open/floor/plating/sidewalk,
@@ -54170,7 +54368,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/shop/bacotell)
 "nIG" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "nIQ" = (
@@ -54259,16 +54457,8 @@
 	pixel_y = 10
 	},
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	pixel_y = -2
+	dir = 6;
+	pixel_y = 2
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
@@ -54278,9 +54468,8 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "nJG" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/oldchurch)
@@ -54327,6 +54516,15 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
+"nKn" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "nKp" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -55029,7 +55227,9 @@
 /turf/open/misc/dirt,
 /area/vtm/interior/supply)
 "nRK" = (
-/obj/structure/toilet,
+/obj/structure/toilet{
+	pixel_y = 16
+	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f4)
 "nRM" = (
@@ -55120,9 +55320,8 @@
 /turf/open/floor/city/clinic,
 /area/vtm/interior/clinic)
 "nSp" = (
-/obj/structure/pole,
-/mob/living/carbon/human/npc/stripper,
-/turf/open/floor/carpet/darkpack,
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "nSq" = (
 /obj/structure/vampipe{
@@ -55163,7 +55362,9 @@
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
 "nSO" = (
-/obj/structure/chair/stool/bar/darkpack/red,
+/obj/structure/curtain/cloth/fancy{
+	pixel_y = 8
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "nSY" = (
@@ -55180,6 +55381,16 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f2)
+"nTi" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "nTj" = (
 /obj/structure/rack/food/rand{
 	dir = 4;
@@ -55590,6 +55801,16 @@
 /obj/structure/bricks,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/sewer)
+"nYT" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "nYV" = (
 /obj/structure/vampdoor/wood{
 	lockpick_difficulty = 6
@@ -55828,11 +56049,6 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/fishermanswharf/lower)
-"obQ" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "obT" = (
 /turf/open/water/beach/vamp/deep,
 /area/vtm/outside/northbeach)
@@ -55903,6 +56119,11 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
+"ocB" = (
+/obj/item/toy/cards/deck,
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "ocL" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/rods,
@@ -55935,7 +56156,9 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
 "odN" = (
-/obj/structure/curtain/bounty,
+/obj/structure/curtain/bounty{
+	pixel_y = 15
+	},
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
@@ -56345,7 +56568,7 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/chinatown)
 "oiF" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
 /turf/open/floor/city/church,
@@ -56385,14 +56608,6 @@
 /obj/structure/coclock,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
-"ojm" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/gun/ballistic/automatic/darkpack/ar15,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/museum)
 "ojw" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/vampfence/rich{
@@ -56451,11 +56666,12 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "okh" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/structure/railing{
+	dir = 8;
+	pixel_y = 9
 	},
-/turf/open/floor/plating/rough,
-/area/vtm)
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "okm" = (
 /obj/effect/turf_decal/bordur{
 	dir = 10
@@ -56633,7 +56849,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/oldchurch)
 "omE" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/city/church,
@@ -57228,8 +57444,9 @@
 /area/vtm/interior)
 "oum" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/structure/table/wood,
 /obj/machinery/light/prince/directional/east,
+/obj/structure/chair/wood/darkpack/red,
+/mob/living/carbon/human/npc/bouncer/elysium/theatre_backdoor,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/jazzclub)
 "oun" = (
@@ -57621,7 +57838,7 @@
 	},
 /area/vtm)
 "ozn" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
 "ozs" = (
@@ -57780,9 +57997,8 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/laundromat)
 "oAX" = (
-/obj/structure/chair/plastic{
-	dir = 8;
-	pixel_y = 4
+/obj/structure/chair/plastic/darkpack{
+	dir = 8
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm)
@@ -58627,6 +58843,11 @@
 	},
 /turf/closed/wall/vampwall/redbrick,
 /area/vtm/interior/museum)
+"oLb" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/wood,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "oLm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
@@ -58726,12 +58947,20 @@
 /obj/structure/chair/wood/darkpack/red{
 	dir = 8
 	},
-/turf/open/floor/wood/smooth,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "oMt" = (
 /obj/structure/sink/directional/south,
 /turf/open/floor/city/church,
 /area/vtm/interior/church/staff)
+"oMx" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fourcolor,
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "oMH" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/green,
@@ -59111,9 +59340,6 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/police/upstairs)
 "oQZ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
 /obj/structure/vampdoor/wood{
 	lock_id = "primogen";
 	locked = 1;
@@ -59123,6 +59349,10 @@
 /obj/effect/mapping_helpers/door/access/camarilla,
 /obj/effect/mapping_helpers/door/bash_difficulty/nine,
 /obj/effect/mapping_helpers/door/lock_difficulty/seven,
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "oRc" = (
@@ -59192,12 +59422,6 @@
 /obj/structure/platform/lowwall/brick,
 /turf/open/floor/city/industrial,
 /area/vtm/interior/shop/hardware_store)
-"oRz" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/vtm/interior)
 "oRA" = (
 /obj/machinery/light/directional/north,
 /obj/structure/closet/crate/large,
@@ -59432,13 +59656,6 @@
 /obj/item/newspaper,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/jazzclub)
-"oVh" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/comfy/darkpack/dark{
-	dir = 1
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/f4)
 "oVl" = (
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/canalplating,
@@ -59709,14 +59926,14 @@
 /turf/open/water/bloodwave,
 /area/vtm/interior/chantry/basement)
 "oZc" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/landmark/start/darkpack/camarilla/harpy,
-/turf/open/floor/carpet/royalblack,
+/obj/effect/decal/shadow,
+/turf/open/misc/grass,
 /area/vtm/interior/millennium_tower/f4)
 "oZm" = (
 /obj/effect/decal/wallpaper/blue,
@@ -59750,6 +59967,16 @@
 /obj/structure/vampdoor/simple,
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower/f2)
+"oZy" = (
+/obj/structure/chair/wood/darkpack/red{
+	dir = 1
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "oZz" = (
 /obj/effect/landmark/npcability,
 /obj/effect/turf_decal/bordur{
@@ -59758,6 +59985,15 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
+"oZL" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/structure/hedge,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/decal/shadow,
+/turf/open/misc/grass,
+/area/vtm/interior/millennium_tower/f4)
 "oZP" = (
 /obj/structure/chair/sofa/middle/brown,
 /turf/open/floor/wood/smooth/old,
@@ -59937,9 +60173,8 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/techshop)
 "pco" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
+/obj/item/reagent_containers/cup/glass/bottle/champagne,
+/obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "pcu" = (
@@ -60113,6 +60348,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured_large,
 /area/vtm/interior/endron_facility/restricted)
+"pfk" = (
+/turf/open/floor/wood/ornate,
+/area/vtm/interior)
 "pfo" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/vampire/graveyard,
@@ -60169,7 +60407,7 @@
 /turf/open/misc/grass,
 /area/vtm/outside/northbeach)
 "pfT" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
 "pgl" = (
@@ -60288,9 +60526,7 @@
 /turf/open/floor/city/toilet,
 /area/vtm/interior/millennium_tower)
 "phy" = (
-/obj/structure/chair/comfy/beige{
-	pixel_y = 4
-	},
+/obj/structure/chair/comfy/darkpack,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/f3)
 "phB" = (
@@ -61262,7 +61498,8 @@
 /area/vtm/interior/shop/gasstation)
 "puc" = (
 /obj/machinery/light/prince/directional/north,
-/turf/open/floor/carpet/royalblack,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "pui" = (
 /obj/effect/turf_decal/asphaltline/xing{
@@ -61276,7 +61513,9 @@
 /obj/structure/curtain/cloth/fancy/mechanical{
 	id = 2005
 	},
-/turf/open/floor/iron/stairs/old,
+/turf/open/floor/iron/stairs/old{
+	dir = 1
+	},
 /area/vtm/interior/theatre)
 "puv" = (
 /obj/effect/decal/cleanable/trash,
@@ -61311,6 +61550,13 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm)
+"puB" = (
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "puG" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/sidewalk/poor,
@@ -62198,6 +62444,10 @@
 /obj/item/food/grown/flower/rose,
 /turf/open/water/hot_spring,
 /area/vtm/interior/jazzclub)
+"pFv" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior)
 "pFF" = (
 /obj/structure/vampfence/rich{
 	dir = 4;
@@ -62301,18 +62551,6 @@
 /obj/item/tape,
 /turf/open/floor/city/circled,
 /area/vtm/interior/setite/basement)
-"pHc" = (
-/obj/structure/railing{
-	pixel_y = -2
-	},
-/obj/structure/railing{
-	dir = 8;
-	pixel_y = 9
-	},
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
 "pHe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -62507,7 +62745,7 @@
 	icon_state = "shadow-alt";
 	pixel_y = 32
 	},
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -62671,12 +62909,6 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/chinatown)
-"pLj" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "pLl" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating/canalplating,
@@ -62722,6 +62954,9 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
+"pLJ" = (
+/turf/open/umbra,
+/area/vtm/interior)
 "pLL" = (
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/junk/alt,
@@ -62788,9 +63023,8 @@
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "pMW" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -62959,8 +63193,13 @@
 /turf/open/floor/plating/canal,
 /area/vtm/interior/sewer)
 "pPa" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/south,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas,
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "pPi" = (
 /obj/effect/turf_decal/bordur/end,
@@ -63005,6 +63244,13 @@
 	},
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/police/upstairs)
+"pPV" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "pQl" = (
 /obj/effect/turf_decal/bordur{
 	dir = 4
@@ -63258,7 +63504,7 @@
 /area/vtm/interior/shop/gasstation)
 "pTe" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "pTu" = (
@@ -63384,6 +63630,16 @@
 /obj/structure/platform/lowwall/city,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/salubri)
+"pUV" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "pUY" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/sidewalk,
@@ -63463,11 +63719,6 @@
 	dir = 8
 	},
 /area/vtm/interior/endron_facility/restricted)
-"pWf" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/south,
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "pWl" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/city/toilet,
@@ -63744,6 +63995,13 @@
 /obj/item/vamp/keys/nosferatu,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
+"qaf" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 1;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "qah" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/shower/directional/south,
@@ -64079,6 +64337,12 @@
 /obj/item/clothing/mask/gas/vampire,
 /turf/open/floor/city/industrial,
 /area/vtm/interior/shop/hardware_store)
+"qfo" = (
+/obj/structure/hedge,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/railing/wooden_fence,
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/theatre)
 "qfv" = (
 /obj/structure/vampdoor/simple,
 /obj/effect/mapping_helpers/door/access/coggie,
@@ -64304,6 +64568,10 @@
 	},
 /turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/museum)
+"qhB" = (
+/obj/effect/turf_decal/siding/wood/light,
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "qhO" = (
 /obj/structure/platform/lowwall/market/window,
 /obj/effect/decal/wallpaper/paper/green/low,
@@ -64327,14 +64595,10 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
 "qin" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 1
 	},
-/obj/structure/vampstatue/cloaked{
-	name = "worn statue"
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "qip" = (
 /obj/structure/vampdoor/simple{
@@ -64541,12 +64805,6 @@
 	},
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/salubri)
-"qkX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/f4)
 "qla" = (
 /obj/structure/toilet{
 	dir = 8
@@ -64596,11 +64854,10 @@
 /turf/open/misc/dirt,
 /area/vtm/interior/cog/caern)
 "qlG" = (
-/obj/structure/chair/plastic{
-	dir = 4;
-	pixel_y = 7
-	},
 /obj/effect/landmark/start/darkpack/anarch/bruiser,
+/obj/structure/chair/plastic/darkpack{
+	dir = 4
+	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
 "qlH" = (
@@ -64781,6 +65038,9 @@
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/museum)
 "qoe" = (
@@ -64796,6 +65056,17 @@
 /obj/structure/flora/rock/darkpack_big,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/outside/forest)
+"qom" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "qos" = (
 /obj/structure/vampdoor{
 	dir = 4
@@ -64894,10 +65165,8 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
 "qpV" = (
-/obj/item/knife/vamp,
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/siding/wood,
-/obj/item/reagent_containers/cup/glass/trophy,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "qqa" = (
@@ -65625,6 +65894,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f2)
+"qyf" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "qyh" = (
 /obj/machinery/camera/directional/north{
 	network = list("Endron");
@@ -65751,9 +66027,11 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights/community)
 "qzi" = (
-/obj/structure/rack/clothing_hanger,
 /obj/machinery/light/prince/directional/south,
-/turf/open/floor/carpet/darkpack,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "qzk" = (
 /obj/effect/spawner/random/occult/artifact,
@@ -66251,10 +66529,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
-"qHd" = (
-/obj/structure/hedge,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "qHg" = (
 /obj/effect/decal/graffiti,
 /turf/open/misc/grass,
@@ -66391,7 +66665,8 @@
 	dir = 8
 	},
 /obj/structure/hedge,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/misc/grass,
 /area/vtm/interior/millennium_tower/f4)
 "qIs" = (
 /mob/living/basic/pet/cat/darkpack,
@@ -66656,11 +66931,6 @@
 /obj/item/assembly/timer,
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/techshop)
-"qLv" = (
-/obj/machinery/light/directional/west,
-/obj/structure/table/wood,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "qLA" = (
 /obj/structure/chair/sofa/middle/brown{
 	dir = 4
@@ -66987,9 +67257,7 @@
 /turf/open/floor/wood/old,
 /area/vtm/outside/pacificheights/forest)
 "qQp" = (
-/obj/structure/railing/darkpack/metal{
-	pixel_y = -2
-	},
+/obj/structure/railing/wooden_fence,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/theatre)
 "qQr" = (
@@ -67021,11 +67289,6 @@
 /obj/structure/roadsign/speedlimit25,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights)
-"qQX" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/obj/structure/sign/city/strip_club/directional/north,
-/turf/open/floor/carpet/red,
-/area/vtm/interior)
 "qQY" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -67106,6 +67369,10 @@
 /area/vtm/interior/glasswalker)
 "qRF" = (
 /obj/machinery/light/small/directional/east,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
+"qRI" = (
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "qRL" = (
@@ -67499,6 +67766,12 @@
 /obj/machinery/light/prince/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"qVH" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "qVJ" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/graffiti,
@@ -67628,7 +67901,11 @@
 /area/vtm/interior/endron_facility/restricted)
 "qXV" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/dark,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 14;
+	pixel_x = 19
+	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "qYb" = (
@@ -68022,9 +68299,8 @@
 /turf/open/floor/iron/large,
 /area/vtm/interior/endron_facility/restricted)
 "rcM" = (
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	pixel_x = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
@@ -68178,14 +68454,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
-"rej" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/ammo_box/magazine/darkpack556,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/museum)
 "rek" = (
 /obj/effect/turf_decal/bordur,
 /obj/structure/roadsign/warningdeer,
@@ -68233,7 +68501,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "rfh" = (
-/obj/structure/chair/comfy/beige{
+/obj/structure/chair/comfy/darkpack{
 	dir = 8
 	},
 /obj/effect/landmark/start/darkpack/pentex/lead,
@@ -68332,12 +68600,6 @@
 	},
 /turf/open/misc/beach/vamp,
 /area/vtm/outside/northbeach)
-"rgX" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "rhf" = (
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
@@ -68350,10 +68612,6 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
 "rhr" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
 /obj/structure/hedge{
 	pixel_y = 6
 	},
@@ -68364,13 +68622,14 @@
 	pixel_y = 10
 	},
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
 	dir = 8
 	},
 /obj/structure/railing{
 	pixel_y = -2
+	},
+/obj/structure/railing{
+	dir = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/wood/old,
 /area/vtm)
@@ -69067,7 +69326,8 @@
 /area/vtm/interior/anarch/basement)
 "rpU" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/fax/camarilla,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "rpW" = (
@@ -69320,6 +69580,12 @@
 	},
 /turf/open/water,
 /area/vtm/interior/bianchiBank)
+"rsv" = (
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 10
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior)
 "rsx" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/sidewalk/poor,
@@ -69464,6 +69730,16 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/hotel)
+"rtI" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "rtO" = (
 /obj/structure/vampipe{
 	icon_state = "piping6";
@@ -69543,10 +69819,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/laundromat)
-"rux" = (
-/obj/structure/chair/darkpack,
-/turf/open/floor/carpet/blue,
-/area/vtm/interior)
 "ruz" = (
 /mob/living/carbon/human/npc/guard,
 /obj/machinery/light/directional/east,
@@ -69871,6 +70143,13 @@
 	},
 /turf/open/floor/city/toilet,
 /area/vtm/interior/hotel)
+"rxK" = (
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "rxW" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -70359,6 +70638,11 @@
 /obj/structure/flora/darkpack_flower/yerba,
 /turf/open/misc/grass,
 /area/vtm/outside/unionsquare)
+"rFt" = (
+/obj/structure/platform/lowwall/market/window,
+/obj/effect/decal/wallpaper/paper/fancy/stripe/low,
+/turf/open/floor/plating/rough,
+/area/vtm/interior/museum)
 "rFv" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/vampfence/rich{
@@ -70728,13 +71012,6 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
-"rKg" = (
-/obj/structure/chair/stool/bar/darkpack/blue,
-/obj/effect/turf_decal/siding/wood/dark/end{
-	dir = 1
-	},
-/turf/open/floor/carpet/darkpack/bluegold,
-/area/vtm/interior/jazzclub)
 "rKm" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -70907,6 +71184,18 @@
 /obj/item/chainsaw/vamp,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower)
+"rLM" = (
+/obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/structure/vampdoor/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/door/unlock,
+/obj/effect/turf_decal/siding/wood/dark{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/jazzclub)
 "rLN" = (
 /obj/structure/vampdoor/glass,
 /obj/effect/turf_decal/bordur,
@@ -71344,13 +71633,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm)
-"rSp" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/vtm/interior/church/haven)
 "rSq" = (
 /obj/effect/decal/cleanable/trash,
 /obj/effect/decal/cleanable/trash,
@@ -71437,7 +71719,7 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "rTs" = (
-/obj/effect/decal/wallpaper/paper/darkgreen,
+/obj/effect/decal/wallpaper/paper/fancy/red,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f4)
 "rTw" = (
@@ -71569,7 +71851,7 @@
 /turf/closed/wall/vampwall/junk,
 /area/vtm/interior/banu/haven)
 "rVU" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/church/staff)
 "rWc" = (
@@ -71582,6 +71864,19 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/financialdistrict)
+"rWn" = (
+/obj/effect/decal/wallpaper/stone/low{
+	pixel_y = 24
+	},
+/obj/effect/decal/shadow,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "rWp" = (
 /obj/effect/decal/carpet,
 /turf/open/floor/wood/smooth/old,
@@ -71717,7 +72012,7 @@
 	desc = "An Ascot Gold Cup with the year 1896 engraved in it."
 	},
 /obj/structure/table/wood/fancy,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "rXI" = (
 /obj/structure/chair/comfy/darkpack/darkblue{
@@ -71836,16 +72131,6 @@
 /obj/item/vampire_stake,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
-"rYP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/hedge,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/misc/grass,
-/area/vtm/interior/millennium_tower/f4)
 "rYR" = (
 /obj/machinery/hydroponics/simple/plastic,
 /turf/open/floor/carpet/darkpack,
@@ -71876,15 +72161,12 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	pixel_y = -2
-	},
 /obj/structure/chair/sofa/corp/corner{
 	color = "#36454F";
 	dir = 1
+	},
+/obj/structure/railing{
+	dir = 10
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
@@ -71978,13 +72260,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/cog/pantry)
-"rZV" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/light/small/pink{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "rZZ" = (
 /obj/structure/closet/secure_closet/freezer,
 /turf/open/floor/city/toilet,
@@ -72200,12 +72475,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop/gunshop)
-"sbT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/f4)
 "sbV" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 8
@@ -72257,16 +72526,13 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/oldchurch)
 "scE" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plating/rough,
-/area/vtm)
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "scN" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 3
-	},
 /obj/structure/hedge{
 	pixel_y = 6
 	},
@@ -72277,13 +72543,14 @@
 	pixel_y = 10
 	},
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
 	dir = 8
 	},
 /obj/structure/railing{
 	pixel_y = -2
+	},
+/obj/structure/railing{
+	dir = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm)
@@ -72450,7 +72717,7 @@
 /area/vtm/interior/ghetto)
 "seB" = (
 /obj/effect/decal/cleanable/trash,
-/obj/structure/chair/greyscale,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
 "seN" = (
@@ -73095,7 +73362,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch/basement)
 "snZ" = (
-/obj/structure/chair/sofa/corp{
+/obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /turf/open/floor/carpet/darkpack,
@@ -73214,10 +73481,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/sewer/nosferatu_town)
 "spt" = (
-/obj/structure/chair/comfy/brown{
+/obj/effect/landmark/start/darkpack/anarch/baron,
+/obj/structure/chair/comfy/darkpack/darkblue{
 	dir = 1
 	},
-/obj/effect/landmark/start/darkpack/anarch/baron,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/anarch/basement)
 "spy" = (
@@ -73257,7 +73524,7 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower)
 "sqa" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/supply)
 "sqf" = (
@@ -73820,13 +74087,6 @@
 /obj/structure/vampfence,
 /turf/open/misc/dirt,
 /area/vtm/outside/fishermanswharf/ghetto)
-"sxp" = (
-/obj/effect/decal/wallpaper/red,
-/obj/machinery/light/small/pink{
-	pixel_y = 32
-	},
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior)
 "sxw" = (
 /obj/structure/vampdoor/glass{
 	name = "Hospital Entrance"
@@ -73995,6 +74255,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm)
+"syQ" = (
+/obj/structure/railing/wooden_fence,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior)
 "syU" = (
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/garbage,
@@ -74263,9 +74527,6 @@
 /area/vtm/interior/millennium_tower)
 "sCV" = (
 /obj/effect/turf_decal/siding/white,
-/obj/structure/railing{
-	pixel_y = -2
-	},
 /obj/structure/chair/sofa/corp/right{
 	color = "#36454F";
 	dir = 1
@@ -74273,6 +74534,7 @@
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 4
 	},
+/obj/structure/railing,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
 "sCW" = (
@@ -74348,7 +74610,7 @@
 /area/vtm/interior/cog/caern)
 "sDD" = (
 /obj/machinery/light/prince/directional/north,
-/turf/open/floor/wood/smooth,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "sDJ" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -74568,7 +74830,7 @@
 /area/vtm/outside/giovanni/courtyard)
 "sGX" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "sGY" = (
@@ -75040,16 +75302,10 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 6
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	pixel_y = -2
-	},
 /obj/structure/table/wood/fancy/red,
+/obj/structure/railing{
+	dir = 6
+	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/jazzclub)
 "sNW" = (
@@ -75203,6 +75459,12 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f3)
+"sQA" = (
+/obj/structure/chair/sofa/corp/corner{
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/vtm/interior/millennium_tower/f4)
 "sQC" = (
 /obj/effect/decal/wallpaper/paper/darkred,
 /obj/machinery/light/small/directional/north,
@@ -75395,6 +75657,7 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
+/mob/living/basic/cockroach,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/jazzclub)
 "sTB" = (
@@ -75476,7 +75739,7 @@
 /area/vtm/outside/pacificheights/forest)
 "sUm" = (
 /obj/machinery/sprinkler/area_managed,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/blue,
 /area/vtm/interior)
 "sUp" = (
 /obj/item/kirbyplants/darkpack/random,
@@ -75500,6 +75763,7 @@
 /obj/structure/vampdoor/woodglass,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /obj/effect/mapping_helpers/door/access/jazz_club,
+/obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
 "sUH" = (
@@ -75724,9 +75988,12 @@
 /obj/structure/vampdoor/woodglass,
 /obj/effect/mapping_helpers/door/access/prince,
 /obj/effect/mapping_helpers/door/lock,
-/obj/effect/turf_decal/siding/white,
 /obj/effect/mapping_helpers/door/bash_difficulty/eight,
 /obj/effect/mapping_helpers/door/lock_difficulty/ten,
+/obj/effect/turf_decal/siding/wood/light,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "sXv" = (
@@ -76235,8 +76502,10 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/bianchiBank)
 "tef" = (
-/obj/structure/chair/stool/bar/darkpack/red,
-/turf/open/floor/carpet/lone,
+/obj/structure/railing/wooden_fence{
+	dir = 10
+	},
+/turf/open/floor/wood/old,
 /area/vtm/interior)
 "tei" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -76274,7 +76543,6 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/park)
 "tew" = (
-/obj/structure/table/wood/fancy/orange,
 /obj/item/vamp/keys/toreador,
 /obj/item/vamp/keys/toreador,
 /obj/item/vamp/keys/toreador,
@@ -76284,7 +76552,8 @@
 	accesslocks = list("toreador","toreador1","toreador2","toreador3","toreador4");
 	name = "Master key"
 	},
-/turf/open/floor/carpet/orange,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior)
 "teA" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -76319,7 +76588,7 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "teH" = (
-/obj/structure/chair/greyscale,
+/obj/structure/chair/darkpack,
 /obj/item/reagent_containers/cup/glass/bottle/beer/vampire,
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
@@ -77141,12 +77410,6 @@
 /obj/effect/turf_decal/asphaltline/alt,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
-"tqH" = (
-/obj/structure/pole{
-	pixel_w = -16
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "tqK" = (
 /obj/structure/toilet{
 	dir = 1
@@ -77278,10 +77541,6 @@
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/giovanni)
-"tsb" = (
-/obj/item/restraints/handcuffs/fake,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "tsf" = (
 /obj/structure/railing{
 	dir = 8
@@ -77380,7 +77639,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/bianchiBank)
 "ttp" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 10
 	},
 /turf/open/floor/wood/ornate,
@@ -77877,15 +78136,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/endron_facility/restricted)
-"tAX" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/obj/machinery/light/small/pink{
-	dir = 8
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "tBg" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/siding/wood/dark/end{
@@ -77971,6 +78221,11 @@
 /obj/item/toy/plush/argemia,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
+"tCu" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/clipboard,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "tCy" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/curtain/bounty,
@@ -78285,6 +78540,12 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/jazzclub)
+"tFc" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 5
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "tFl" = (
 /obj/structure/platform/lowwall/painted/window,
 /turf/open/floor/plating/rough,
@@ -78299,6 +78560,10 @@
 "tFB" = (
 /turf/open/umbra,
 /area/vtm)
+"tFH" = (
+/obj/structure/platform/lowwall/rich,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "tFI" = (
 /obj/structure/chair/pew/right,
 /turf/open/floor/carpet/darkpack/redsilver,
@@ -78630,6 +78895,23 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/graveyard)
+"tJS" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/folder/blue,
+/obj/item/folder/blue{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/folder/documents{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/folder/documents{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "tJT" = (
 /obj/machinery/light/small/pink/directional/west,
 /turf/open/floor/wood/smooth,
@@ -78873,7 +79155,7 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass/wine_glass{
 	pixel_x = -11
 	},
-/turf/open/floor/carpet/darkpack,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "tNK" = (
 /obj/machinery/light/small/red/directional/east,
@@ -78888,12 +79170,6 @@
 /mob/living/carbon/human/npc/hobo,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
-"tNW" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/open/floor/light,
-/area/vtm/interior)
 "tOa" = (
 /obj/structure/table/wood,
 /obj/item/plate,
@@ -79358,7 +79634,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
 "tUY" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/anarch)
 "tVa" = (
@@ -79714,7 +79990,7 @@
 /obj/structure/musician/piano{
 	icon_state = "piano"
 	},
-/turf/open/floor/wood/smooth,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "tZR" = (
 /turf/closed/wall/vampwall/metal,
@@ -79873,10 +80149,10 @@
 /area/vtm/interior/supply)
 "ucK" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "uda" = (
 /obj/structure/table/wood,
@@ -80054,7 +80330,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
 "ufK" = (
-/obj/structure/chair/greyscale,
+/obj/structure/chair/darkpack,
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
@@ -80142,6 +80418,12 @@
 	dir = 8
 	},
 /area/vtm/interior/clinic)
+"uhn" = (
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior)
 "uhp" = (
 /obj/structure/table/modern,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -80160,7 +80442,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/outside/pacificheights/forest)
 "uhH" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/light{
 	dir = 6
 	},
 /turf/open/floor/wood/ornate,
@@ -80266,6 +80548,13 @@
 /obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/bianchiBank)
+"ujf" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "ujg" = (
 /obj/effect/turf_decal/bordur,
 /turf/cordon/secret,
@@ -80302,7 +80591,7 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/outside/park)
 "ujD" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/ghetto)
 "ujE" = (
@@ -80318,8 +80607,9 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights)
 "ujL" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/drinkingglass,
+/obj/structure/table/wood/fancy/black,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "ujN" = (
@@ -80334,10 +80624,11 @@
 /area/vtm/interior/giovanni)
 "ujU" = (
 /obj/machinery/light/prince/directional/north,
-/obj/structure/chair/wood/darkpack/red{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
-/turf/open/floor/wood/smooth,
+/obj/structure/bookcase/random,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "uka" = (
 /obj/structure/table/wood,
@@ -80442,6 +80733,13 @@
 /obj/structure/table,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
+"ulN" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "ulR" = (
 /obj/structure/railing{
 	dir = 1;
@@ -80564,9 +80862,12 @@
 /area/vtm/interior/bianchiBank)
 "umV" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/siding/wood,
 /obj/item/newspaper,
-/obj/item/smartphone/clean,
+/obj/item/smartphone/clean{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
 "umW" = (
@@ -80620,7 +80921,7 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/unionsquare)
 "unF" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
@@ -80679,6 +80980,13 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
+"uor" = (
+/obj/structure/rack/clothing_hanger,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "uot" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/vampipe{
@@ -80962,7 +81270,7 @@
 /area/vtm/interior/clinic)
 "uqT" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/hotel)
 "uqU" = (
@@ -81147,6 +81455,15 @@
 /obj/structure/flora/rock/pile/darkpack,
 /turf/open/misc/grass,
 /area/vtm/outside/pacificheights/forest)
+"utq" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/mob/living/carbon/human/npc/incel,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "uts" = (
 /obj/structure/railing{
 	dir = 4
@@ -81318,6 +81635,18 @@
 	},
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/techshop)
+"uvA" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 8
+	},
+/obj/vampire_computer{
+	icon_state = "computerprince";
+	pixel_x = -6;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/darkpack/redsilver,
+/area/vtm/interior/jazzclub)
 "uvB" = (
 /obj/structure/vampfence/corner{
 	dir = 4
@@ -81376,9 +81705,7 @@
 /area/vtm/interior/sewer)
 "uwt" = (
 /obj/effect/turf_decal/siding/white,
-/obj/structure/railing{
-	pixel_y = -2
-	},
+/obj/structure/railing,
 /obj/structure/chair/sofa/corp{
 	color = "#36454F";
 	dir = 1
@@ -81830,6 +82157,15 @@
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/setite)
+"uBk" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "uBn" = (
 /obj/structure/table/wood,
 /obj/underplate,
@@ -82268,11 +82604,6 @@
 /obj/keypad/panic_room,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
-"uGG" = (
-/obj/machinery/light/prince/directional/north,
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/wood/ornate,
-/area/vtm/interior/millennium_tower/f4)
 "uGN" = (
 /obj/machinery/light/floor/lamppost/one,
 /turf/open/floor/plating/sidewalk,
@@ -82595,12 +82926,6 @@
 /obj/machinery/light/prince/broken/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/mansion)
-"uKz" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 5
-	},
-/turf/open/floor/light,
-/area/vtm/interior)
 "uKE" = (
 /obj/structure/vampstatue{
 	name = "statue to the Del'Roh"
@@ -82747,10 +83072,11 @@
 /turf/open/floor/cult,
 /area/vtm/interior/chantry/basement)
 "uMw" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
 /mob/living/carbon/human/npc/incel,
+/obj/structure/chair/sofa/corp/right{
+	color = "#CD5C5C"
+	},
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "uME" = (
@@ -82782,6 +83108,13 @@
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/city/gummaguts,
 /area/vtm/interior/shop/otolleys)
+"uNk" = (
+/obj/effect/turf_decal/siding/wood/dark/end{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/darkpack/blue,
+/turf/open/floor/carpet/darkpack/bluegold,
+/area/vtm/interior/jazzclub)
 "uNl" = (
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 6
@@ -82817,12 +83150,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/openspace,
 /area/vtm)
-"uNR" = (
-/obj/structure/chair/wood/darkpack/red{
-	dir = 8
-	},
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "uNS" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/decal/cleanable/cardboard,
@@ -82915,7 +83242,7 @@
 /obj/effect/turf_decal/bordur{
 	dir = 4
 	},
-/obj/structure/chair/greyscale,
+/obj/structure/chair/darkpack,
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "uPu" = (
@@ -82975,6 +83302,10 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/upstairs)
+"uPK" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "uPP" = (
 /obj/structure/stairs/north,
 /obj/structure/railing{
@@ -82982,19 +83313,18 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
-"uPV" = (
-/obj/structure/easel,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
 "uPZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
-/turf/open/floor/wood/ornate,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "uQc" = (
 /obj/machinery/light/prince/directional/east,
-/turf/open/floor/wood/ornate,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "uQy" = (
 /obj/structure/chair/sofa/city_bench/metal/left/black,
@@ -83085,6 +83415,13 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/shop/grocery)
+"uRW" = (
+/obj/effect/turf_decal/siding/wood/light/corner,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 9
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "uRY" = (
 /obj/effect/turf_decal/bordur{
 	dir = 1
@@ -83267,6 +83604,13 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/clinic/haven)
+"uTG" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 2;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "uTJ" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	pixel_y = -6
@@ -83636,6 +83980,13 @@
 	},
 /turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/museum)
+"uYc" = (
+/obj/machinery/light/prince/directional/north,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "uYe" = (
 /obj/structure/table,
 /obj/effect/decal/graffiti/large{
@@ -83767,7 +84118,7 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/tzimisce_manor)
 "uZG" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /turf/open/floor/city/bacotell,
@@ -83929,6 +84280,22 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry/basement)
+"vbY" = (
+/obj/structure/hedge{
+	pixel_y = 6
+	},
+/obj/structure/flora/bush/lavendergrass/style_random{
+	pixel_y = 13
+	},
+/obj/structure/flora/bush/flowers_yw/style_random{
+	pixel_y = 10
+	},
+/obj/structure/railing{
+	dir = 10;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/jazzclub)
 "vci" = (
 /obj/structure/barrels/rand,
 /turf/open/floor/plating/sidewalk,
@@ -84414,7 +84781,7 @@
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/clinic/haven)
 "vhN" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/banu/haven)
 "vhU" = (
@@ -84504,6 +84871,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/baali)
+"vjl" = (
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/theatre)
 "vjp" = (
 /obj/structure/chair/wood/darkpack/red{
 	dir = 4
@@ -84844,7 +85217,7 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights/old)
 "vod" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood/dark,
@@ -85053,6 +85426,15 @@
 	},
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/hotel)
+"vqw" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing/corner/end{
+	pixel_y = 6
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm)
 "vqy" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet/any,
@@ -85070,6 +85452,7 @@
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/nine,
 /obj/effect/mapping_helpers/door/access/federal,
+/obj/effect/mapping_helpers/door/bash_difficulty/seven,
 /turf/open/floor/wood/rough,
 /area/vtm/interior/police/fed)
 "vqG" = (
@@ -85354,11 +85737,6 @@
 /obj/effect/turf_decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/supply)
-"vuH" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "vuJ" = (
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/theatre)
@@ -85928,7 +86306,11 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
 "vDQ" = (
-/turf/open/floor/city/plating_mono,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 4;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "vDU" = (
 /obj/machinery/light/directional/north,
@@ -86117,10 +86499,6 @@
 /obj/structure/stairs/east,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
-"vGq" = (
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/wood/smooth,
-/area/vtm/interior)
 "vGr" = (
 /obj/effect/landmark/ert_spawn,
 /turf/open/floor/plating/asphalt,
@@ -86167,10 +86545,10 @@
 /turf/open/floor/wood/old,
 /area/vtm/interior/theatre)
 "vGK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 6
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "vGO" = (
 /obj/structure/statue/bone/rib{
@@ -86332,10 +86710,8 @@
 /area/vtm/interior/jazzclub)
 "vJb" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/effect/turf_decal/siding/wideplating/dark/corner,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "vJc" = (
 /obj/effect/decal/shadow,
@@ -86925,7 +87301,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/wood/ornate,
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "vSn" = (
 /turf/open/floor/plating/granite/black,
@@ -86968,6 +87346,15 @@
 /obj/structure/coclock,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/bianchiBank)
+"vSX" = (
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
+/turf/open/floor/wood/ornate,
+/area/vtm/interior/millennium_tower/f4)
 "vSZ" = (
 /obj/structure/vampipe{
 	icon_state = "piping31"
@@ -86997,6 +87384,13 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"vTn" = (
+/obj/structure/pole{
+	pixel_w = -16
+	},
+/mob/living/carbon/human/npc/stripper,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "vTv" = (
 /obj/machinery/light/prince/directional/west,
 /turf/open/floor/wood/smooth/old,
@@ -87204,6 +87598,12 @@
 /obj/machinery/griddle,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
+"vVE" = (
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "vVV" = (
 /obj/item/kirbyplants/darkpack/random,
 /turf/open/floor/city/bacotell,
@@ -87679,6 +88079,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/chinatown)
+"waN" = (
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "waS" = (
 /obj/structure/table/wood,
 /obj/item/detective_scanner,
@@ -88220,7 +88624,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/gasstation)
 "wih" = (
-/obj/structure/tank_holder/extinguisher,
+/obj/structure/rack/clothing_hanger,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/millennium_tower/f4)
 "wii" = (
@@ -88246,6 +88650,10 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/strip)
+"wiG" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "wiJ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -88312,6 +88720,20 @@
 	},
 /turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/police/fed)
+"wjL" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "wjM" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -88501,7 +88923,7 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/outside/fishermanswharf/lower)
 "wmq" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair/darkpack{
 	dir = 1
 	},
 /turf/open/floor/plating/rough,
@@ -88607,6 +89029,11 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/fishermanswharf/lower)
+"wnW" = (
+/obj/structure/railing/wooden_fence,
+/obj/structure/chair/stool/bar/darkpack/red,
+/turf/open/floor/wood/ornate,
+/area/vtm/interior)
 "wnZ" = (
 /obj/effect/turf_decal/siding/wood/dark{
 	dir = 1
@@ -88796,6 +89223,12 @@
 	lockpick_difficulty = 16;
 	name = "backroom"
 	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 4
+	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/millennium_tower/f4)
 "wqP" = (
@@ -88873,6 +89306,16 @@
 	},
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/jazzclub)
+"wrE" = (
+/obj/structure/railing{
+	dir = 8;
+	pixel_y = 9
+	},
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "wrI" = (
 /obj/structure/vampstatue/angel,
 /turf/open/floor/wood/smooth/old,
@@ -89091,6 +89534,12 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"wuz" = (
+/obj/effect/turf_decal/siding/wood/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/smooth/old,
+/area/vtm/interior/museum)
 "wuI" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/smooth/old,
@@ -89359,7 +89808,7 @@
 /area/vtm/interior/tzimisce_manor)
 "wya" = (
 /obj/structure/ladder/manhole/down,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/fed)
@@ -89801,16 +90250,6 @@
 	},
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/pantry)
-"wDg" = (
-/obj/structure/railing{
-	dir = 8;
-	pixel_y = 9
-	},
-/obj/structure/railing{
-	pixel_y = -2
-	},
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm)
 "wDh" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 4
@@ -89860,10 +90299,6 @@
 "wDG" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/church)
-"wDJ" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "wDL" = (
 /obj/structure/table,
 /obj/structure/vampfence/rich{
@@ -90114,11 +90549,6 @@
 /obj/structure/ladder/manhole/down,
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/ghetto)
-"wHu" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "wHB" = (
 /obj/structure/sign/flag/britain{
 	pixel_y = 29;
@@ -90193,6 +90623,11 @@
 /area/vtm/interior/bianchiBank)
 "wIo" = (
 /obj/structure/table/wood/fancy/red,
+/obj/effect/decal/carpet{
+	icon_state = "rug_red";
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /turf/open/floor/wood/smooth,
 /area/vtm)
 "wIt" = (
@@ -90272,7 +90707,7 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/outside/forest)
 "wJy" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/darkpack/dark,
 /turf/open/floor/carpet/darkpack/old,
 /area/vtm/interior/police/upstairs)
 "wJH" = (
@@ -90397,7 +90832,7 @@
 /area/vtm/interior/sewer/nosferatu_town)
 "wLg" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack,
 /area/vtm/interior/cog/caern)
 "wLh" = (
@@ -90445,6 +90880,17 @@
 /obj/effect/decal/cleanable/cardboard,
 /turf/open/floor/plating/canal,
 /area/vtm/interior/glasswalker)
+"wLt" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/canvas/nineteen_nineteen{
+	pixel_x = 21
+	},
+/obj/item/canvas/twentythree_nineteen,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "wLu" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -90485,7 +90931,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/oldchurch)
 "wLI" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 4
 	},
 /obj/item/vamp/keys/nosferatu,
@@ -90823,7 +91269,7 @@
 /area/vtm/interior/police/upstairs)
 "wPZ" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/darkpack/hotel,
 /area/vtm/interior/hotel)
 "wQc" = (
@@ -90915,9 +91361,8 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/outside/forest)
 "wRp" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
 /obj/structure/railing{
 	dir = 1;
@@ -91438,12 +91883,6 @@
 /obj/structure/roadsign/warningpedestrian,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/outside/pacificheights)
-"wYs" = (
-/obj/structure/pole{
-	pixel_w = -16
-	},
-/turf/open/floor/light,
-/area/vtm/interior)
 "wYw" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -92003,6 +92442,12 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop/pawnshop)
+"xdK" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "xdQ" = (
 /obj/structure/chair/sofa/corp/corner{
 	color = "#CD5C5C"
@@ -92066,13 +92511,6 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/dirt,
 /area/vtm/outside/forest)
-"xeL" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/wood/smooth/old,
-/area/vtm/interior/banu/haven)
 "xeN" = (
 /obj/structure/hydrant,
 /obj/effect/landmark/npcability,
@@ -92698,7 +93136,9 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/pacificheights/old)
 "xmJ" = (
-/turf/open/floor/light,
+/obj/structure/chair/stool/bar/darkpack/red,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/darkpack,
 /area/vtm/interior)
 "xmP" = (
 /obj/effect/turf_decal/bordur{
@@ -92930,13 +93370,6 @@
 	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
-"xpK" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/obj/machinery/light/small/red/directional/south,
-/turf/open/floor/carpet/darkpack,
-/area/vtm/interior)
 "xpQ" = (
 /obj/structure/curtain{
 	pixel_y = 8
@@ -93059,11 +93492,17 @@
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police)
 "xqC" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 6
+/obj/structure/easel,
+/obj/item/canvas/twentythree_twentythree{
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/turf/open/floor/plating/rough,
-/area/vtm)
+/obj/structure/railing{
+	pixel_y = -2
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "xqD" = (
 /obj/structure/ladder/manhole/down,
 /turf/open/misc/grass,
@@ -93945,6 +94384,12 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/ghetto)
+"xDe" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/granite/black,
+/area/vtm/interior/millennium_tower/f4)
 "xDg" = (
 /turf/open/floor/city/saint,
 /area/vtm/interior/church/staff)
@@ -94070,7 +94515,8 @@
 /obj/item/reagent_containers/blood/vitae,
 /obj/item/reagent_containers/blood/vitae,
 /obj/structure/closet/crate/freezer,
-/turf/open/floor/carpet/darkpack,
+/obj/effect/turf_decal/siding/wood/light/corner,
+/turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "xFt" = (
 /obj/effect/turf_decal/siding/white{
@@ -94120,14 +94566,6 @@
 	},
 /turf/open/floor/wood/old,
 /area/vtm)
-"xFR" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/vtm/interior/millennium_tower/f4)
 "xFV" = (
 /obj/effect/turf_decal/bordur{
 	dir = 8
@@ -94229,7 +94667,7 @@
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/setite/basement)
 "xHj" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/chair/comfy/darkpack/dark{
 	dir = 8
 	},
 /turf/open/floor/wood/smooth/old,
@@ -94333,6 +94771,13 @@
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry/basement)
+"xIy" = (
+/obj/machinery/light/prince/directional/north,
+/obj/effect/turf_decal/siding/wood/light{
+	dir = 8
+	},
+/turf/open/floor/wood/smooth,
+/area/vtm/interior/millennium_tower/f4)
 "xIC" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/wood,
@@ -94598,6 +95043,7 @@
 /obj/effect/mapping_helpers/door/access/federal,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/door/bash_difficulty/seven,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/police/fed)
 "xKZ" = (
@@ -94773,14 +95219,6 @@
 /obj/structure/curtain/bounty,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/sewer/nosferatu_town)
-"xNa" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/blood/b_plus,
-/obj/item/reagent_containers/blood/b_plus,
-/obj/item/reagent_containers/blood/a_plus,
-/obj/item/reagent_containers/blood/a_plus,
-/turf/open/floor/plating/concrete,
-/area/vtm/interior/museum)
 "xNb" = (
 /obj/structure/railing{
 	dir = 4
@@ -94864,7 +95302,7 @@
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/tzimisce_manor)
 "xOG" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/hotel)
 "xOJ" = (
@@ -95494,9 +95932,7 @@
 /turf/open/floor/plating/canalplating,
 /area/vtm/interior/sewer)
 "xXn" = (
-/obj/structure/chair/comfy/beige{
-	pixel_y = 4
-	},
+/obj/structure/chair/comfy/darkpack,
 /obj/effect/landmark/start/darkpack/camarilla/hound,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/f3)
@@ -95539,11 +95975,6 @@
 /obj/structure/platform/lowwall/bar/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/anarch/basement)
-"xXP" = (
-/obj/effect/decal/shadow,
-/obj/structure/chair/stool/bar/darkpack/red,
-/turf/open/floor/carpet/lone,
-/area/vtm/interior)
 "xXV" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/roofwalk,
@@ -95627,6 +96058,14 @@
 /obj/vampire_computer,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower)
+"xZC" = (
+/obj/machinery/light/directional/south,
+/obj/structure/chair/comfy/darkpack/dark{
+	dir = 8;
+	color = "#CD5C5C"
+	},
+/turf/open/floor/carpet/darkpack,
+/area/vtm/interior)
 "xZU" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium,
@@ -95731,7 +96170,8 @@
 /area/vtm/outside/northbeach)
 "ybV" = (
 /obj/structure/fireplace,
-/turf/open/floor/carpet/royalblack,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f4)
 "ybX" = (
 /turf/closed/wall/vampwall/brick_old{
@@ -96102,12 +96542,6 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/clinic)
-"yfG" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior)
 "yfI" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/landmark/npcwall,
@@ -96443,9 +96877,8 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/giovanni/basement)
 "ykv" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
+/obj/structure/chair/wood/darkpack/red{
+	dir = 8
 	},
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/wood/smooth/old,
@@ -103794,7 +104227,7 @@ byn
 cvP
 qRA
 dQT
-bOo
+rLy
 uuF
 cSf
 cSf
@@ -172736,9 +173169,9 @@ piZ
 bMn
 dar
 dar
-jDF
+rFt
 vkz
-jDF
+rFt
 vkz
 jDF
 dar
@@ -190037,7 +190470,7 @@ prQ
 eiL
 xTc
 pGK
-lxX
+xTc
 wNY
 lxX
 pDy
@@ -190294,8 +190727,8 @@ ejP
 xTc
 rBR
 hWq
-rKg
-rcD
+hWq
+uNk
 rcD
 rcD
 hDv
@@ -191362,7 +191795,7 @@ fMQ
 fMQ
 fMQ
 dRG
-lxr
+xxL
 cJu
 iHq
 gEh
@@ -195177,7 +195610,7 @@ cLl
 cLl
 bkd
 bkd
-hhD
+uIA
 bkd
 bkd
 vuJ
@@ -196708,7 +197141,7 @@ wbX
 wcJ
 fzQ
 bFO
-aUU
+grt
 qwe
 opq
 bFO
@@ -196967,7 +197400,7 @@ fzQ
 bFO
 grt
 grt
-grt
+bkS
 bFO
 grt
 vop
@@ -198768,10 +199201,10 @@ bcX
 aea
 lXm
 oVF
+vjl
 grt
 grt
-grt
-grt
+vjl
 cLl
 cLl
 cLl
@@ -199025,7 +199458,7 @@ eYp
 dzh
 wkI
 bFO
-jup
+qfo
 iqn
 xvU
 jup
@@ -205489,7 +205922,7 @@ gSG
 gSG
 dhp
 ihN
-lxr
+xxL
 hCj
 iHq
 kGa
@@ -205602,8 +206035,8 @@ yeb
 ihN
 iHq
 nLG
-lxr
-lxr
+xxL
+xxL
 eVP
 dAn
 mgY
@@ -206784,7 +207217,7 @@ gSG
 gSG
 gye
 ihN
-lxr
+xxL
 iHq
 oOD
 laU
@@ -210107,7 +210540,7 @@ aOh
 uQS
 uQS
 rWr
-lxr
+xxL
 iHq
 iHq
 iHq
@@ -218559,7 +218992,7 @@ yeb
 tVk
 sNE
 kQU
-lxr
+xxL
 gMy
 jcc
 gSG
@@ -219082,7 +219515,7 @@ gye
 jsE
 gMy
 hSj
-lxr
+xxL
 iHq
 oOD
 aFt
@@ -223187,7 +223620,7 @@ cTV
 iHq
 iHq
 dRG
-lxr
+xxL
 iHq
 cJu
 iHq
@@ -236219,8 +236652,8 @@ fcy
 fFa
 eDE
 byX
-ePv
-fFa
+cas
+dgq
 byX
 fFa
 gAH
@@ -236730,7 +237163,7 @@ lTQ
 lTQ
 byX
 qnV
-fFa
+bPS
 fFa
 dar
 dar
@@ -236987,7 +237420,7 @@ gvi
 lTQ
 byX
 qer
-fFa
+nHh
 fFa
 fFa
 fFa
@@ -237244,7 +237677,7 @@ pyd
 lTQ
 byX
 snp
-fFa
+nHh
 buS
 pUg
 fFa
@@ -237501,13 +237934,13 @@ lTQ
 lTQ
 jFh
 uYa
-fFa
+wuz
 kbr
 lOV
 fFa
 jzw
 dar
-ojm
+jmO
 vli
 dar
 dar
@@ -237764,9 +238197,9 @@ vmR
 fFa
 mFU
 dar
-rej
 jmO
-xNa
+jmO
+jmO
 dar
 jmO
 jmO
@@ -238021,7 +238454,7 @@ fFa
 fFa
 nGZ
 dar
-dxv
+jmO
 jmO
 jmO
 xUQ
@@ -238278,7 +238711,7 @@ mFU
 nGZ
 dar
 dar
-aKn
+jmO
 ybt
 jmO
 dar
@@ -238537,7 +238970,7 @@ dar
 dar
 dar
 dar
-xNa
+jmO
 dar
 exB
 ybt
@@ -245206,7 +245639,7 @@ iHq
 iHq
 iHq
 neW
-cgg
+gLr
 iHq
 cQu
 kno
@@ -259164,9 +259597,9 @@ tXG
 vWT
 xwG
 qtW
-vJa
-vJa
-hGK
+oMx
+tJS
+uvA
 fRj
 vWT
 tXG
@@ -259423,7 +259856,7 @@ jVa
 vJa
 wsQ
 oPP
-vJa
+kqy
 qYL
 vWT
 muK
@@ -259677,9 +260110,9 @@ dUS
 pmo
 vWT
 rLu
-jqY
+nBi
 vJa
-vJa
+oMx
 mrp
 xza
 vWT
@@ -259936,7 +260369,7 @@ laW
 vWT
 vIq
 jqY
-mrp
+lCw
 oEL
 vWT
 vWT
@@ -260717,7 +261150,7 @@ eIo
 dSS
 dSS
 dSS
-dSS
+fip
 rhr
 ntq
 ntq
@@ -261216,7 +261649,7 @@ ntq
 ntq
 ntq
 eNE
-xJZ
+bXz
 vTb
 kdN
 kaP
@@ -261231,7 +261664,7 @@ hlF
 hlF
 hlF
 hlF
-hlF
+kCy
 scN
 ntq
 ntq
@@ -261473,7 +261906,7 @@ ntq
 ntq
 ntq
 eNE
-xJZ
+bXz
 xJZ
 ovK
 xRL
@@ -261729,7 +262162,7 @@ ntq
 ntq
 ntq
 ntq
-iee
+vgm
 qTD
 xJZ
 ckF
@@ -261745,7 +262178,7 @@ jAQ
 uwt
 cCB
 hlF
-hlF
+kCy
 scN
 ntq
 ntq
@@ -262259,7 +262692,7 @@ vWT
 bqC
 wJH
 hlF
-hlF
+kCy
 scN
 ntq
 ntq
@@ -262501,7 +262934,7 @@ ntq
 ntq
 ntq
 eNE
-xJZ
+bXz
 xJZ
 cjp
 wfW
@@ -262758,7 +263191,7 @@ ntq
 ntq
 ntq
 eNE
-xJZ
+bXz
 rzA
 eIB
 kaP
@@ -262767,13 +263200,13 @@ vYY
 xJZ
 xJZ
 eNE
-nJA
+vbY
 hzq
 hlF
 hlF
 hlF
 hlF
-hlF
+kCy
 scN
 ntq
 ntq
@@ -263024,7 +263457,7 @@ ewc
 xJZ
 eiL
 eiL
-nJA
+vbY
 hzq
 hlF
 hlF
@@ -263287,7 +263720,7 @@ eiL
 hzq
 hlF
 hlF
-hlF
+kCy
 scN
 ntq
 ntq
@@ -263801,7 +264234,7 @@ hKx
 hzq
 hlF
 wIo
-hlF
+kCy
 scN
 ntq
 ntq
@@ -264315,7 +264748,7 @@ eiL
 dLD
 xNb
 xNb
-xNb
+vqw
 hVI
 ntq
 ntq
@@ -268274,7 +268707,7 @@ ntq
 oAP
 jai
 rbC
-eyx
+xGm
 tPH
 eYs
 nMn
@@ -268788,7 +269221,7 @@ ntq
 oAP
 cHl
 brJ
-xGm
+eyx
 rdi
 eYs
 fzj
@@ -286186,7 +286619,7 @@ rOo
 xRA
 ctX
 ctX
-lxT
+dNs
 uYk
 uYk
 uYk
@@ -286787,7 +287220,7 @@ tad
 quh
 mov
 mov
-xeL
+cCE
 pwN
 jXv
 jXv
@@ -303130,7 +303563,7 @@ arh
 eJj
 cGf
 shs
-tJa
+xvX
 eJj
 iMw
 ntq
@@ -303644,7 +304077,7 @@ arh
 eJj
 vOZ
 elR
-rSp
+tJa
 eJj
 iMw
 ntq
@@ -307723,7 +308156,7 @@ cCQ
 cCQ
 cCQ
 cCQ
-cCQ
+cSH
 mFf
 kWr
 tew
@@ -307974,13 +308407,13 @@ cCQ
 bAO
 bAO
 bAO
-lAZ
-bjf
-bjf
-bjf
+cSH
+vSn
+kzx
+fqg
 bjf
 bLt
-sEI
+cSH
 cum
 haZ
 nCx
@@ -308231,14 +308664,14 @@ iHq
 ddI
 bvD
 kGa
-lAZ
+cSH
 aOz
-bjf
+gdy
 dyd
 cGo
 bjf
-sEI
-lCq
+cSH
+kzx
 lCq
 lCq
 cCQ
@@ -308489,15 +308922,15 @@ iHq
 iHq
 iHq
 nxv
-bjf
-rux
+vSn
+gdy
 gYN
 dej
 bjf
 fPn
-lCq
+fqg
 sUm
-lCq
+bjf
 keA
 wEd
 wEd
@@ -308745,16 +309178,16 @@ dwy
 iHq
 iHq
 kCo
-lAZ
+cSH
 aOz
-bjf
+gdy
 fFK
 bjf
 bjf
-cCQ
+cSH
 nGp
-lCq
-lCq
+bjf
+bjf
 cCQ
 wEd
 wEd
@@ -309002,13 +309435,13 @@ iHq
 gdT
 cno
 ekV
-lAZ
-bjf
-bjf
-bjf
+cSH
+vSn
+uhn
+rsv
 bjf
 bLt
-cCQ
+cSH
 mAd
 hcA
 dxT
@@ -320330,7 +320763,7 @@ lGq
 ctC
 wTQ
 kno
-eiL
+qGS
 ryz
 ryz
 eiL
@@ -320587,7 +321020,7 @@ lGq
 ctC
 wTQ
 eiL
-eiL
+vgm
 xJZ
 xJZ
 eiL
@@ -320595,8 +321028,8 @@ eiL
 eiL
 eiL
 eiL
-eiL
-eiL
+bcv
+bcv
 eiL
 aOT
 lbr
@@ -320843,7 +321276,7 @@ ntq
 lGq
 ctC
 wTQ
-eiL
+qGS
 bbi
 xJZ
 xJZ
@@ -321100,7 +321533,7 @@ ntq
 yfM
 ctC
 wTQ
-eiL
+vgm
 jMQ
 wWb
 xJZ
@@ -321357,7 +321790,7 @@ ntq
 vMH
 ctC
 wTQ
-eiL
+qGS
 muh
 xJZ
 xJZ
@@ -321615,7 +322048,7 @@ eiL
 eiL
 eiL
 eiL
-eiL
+vgm
 ett
 ett
 eiL
@@ -324701,7 +325134,7 @@ szW
 xJZ
 xJZ
 xJZ
-dkZ
+xJZ
 xJZ
 xJZ
 eiL
@@ -325470,16 +325903,16 @@ vMH
 lTQ
 szW
 kGn
-mTu
+eHx
 xJZ
 xJZ
-dkZ
+eHx
 kGn
 eiL
 eiL
 eiL
-eiL
-eiL
+rLM
+rLM
 eiL
 lTQ
 lTQ
@@ -371198,12 +371631,12 @@ tFB
 tFB
 tFB
 tFB
-eQD
-eQD
-eQD
-eQD
-eQD
-ify
+tFB
+tFB
+tFB
+tFB
+tFB
+tFB
 tFB
 tFB
 tFB
@@ -371455,12 +371888,12 @@ tFB
 tFB
 tFB
 tFB
-eQD
-bCc
-tAX
-pLj
-eQD
-ify
+tFB
+tFB
+tFB
+tFB
+tFB
+tFB
 tFB
 tFB
 tFB
@@ -371712,12 +372145,12 @@ tFB
 tFB
 tFB
 tFB
-eQD
-leG
-tqH
-yfG
-eQD
-ify
+tFB
+tFB
+tFB
+tFB
+tFB
+tFB
 tFB
 tFB
 tFB
@@ -371967,16 +372400,16 @@ tFB
 tFB
 tFB
 tFB
-tFB
-tFB
-eQD
-tsb
-vDQ
-vDQ
-eQD
+cCQ
+kLj
+kLj
+kLj
+cCQ
+kLj
+kLj
+kLj
+cCQ
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -372223,18 +372656,18 @@ tFB
 tFB
 tFB
 tFB
-tFB
-tFB
-tFB
-eQD
-wDJ
+cCQ
+obm
+jbr
+awR
+lVM
 vDQ
-iay
-eQD
+tYg
+lVM
+bVT
+cCQ
+cCQ
 ify
-tFB
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -372480,33 +372913,33 @@ tFB
 tFB
 tFB
 tFB
+obm
+uTG
+mzA
+mzA
+lVM
+mzA
+qaf
+lVM
+mzA
+mzA
 cCQ
-krG
-krG
-cCQ
-cCQ
-bzU
 cCQ
 cCQ
 cCQ
 cCQ
 cCQ
-ify
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
+cCQ
+cCQ
+aQM
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
 tFB
 tFB
 tFB
@@ -372738,33 +373171,33 @@ tFB
 tFB
 tFB
 obm
-lzw
-bEu
-jJQ
-qHd
-lVM
-dxZ
-rZV
+tYg
 lnC
+mmJ
 lVM
+pfk
+pfk
+lVM
+lnC
+mmJ
+wiG
 cCQ
+obm
+uqc
+jEX
+ujf
+mzA
+cCQ
+cCQ
+krG
+cCQ
+cCQ
+mko
+mko
+mko
+mko
+fPC
 ify
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -372995,33 +373428,33 @@ cCQ
 krG
 krG
 obm
-vGq
-dZz
+lVM
+lVM
+pfk
+lVM
+hlA
+lVM
+lVM
+pfk
 lVM
 lVM
 lVM
-dxZ
-idX
-obQ
-lVM
-krG
-krG
-krG
-krG
-krG
-krG
-krG
-krG
+obm
+nYT
+tYg
+tYg
+tYg
+iHq
+tYg
+vCE
+vCE
 cCQ
-cCQ
 okh
 okh
-okh
-okh
-kNs
+lfp
+cuI
+qRI
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -373247,39 +373680,39 @@ krG
 sRj
 eqb
 oGI
-ijw
+tZh
 eqb
 oGI
 tZh
 obm
 eiK
+pfk
 lVM
 lVM
+pfk
+pfk
 lVM
 lVM
+pfk
 lVM
-uNR
-uNR
-lVM
-krG
-avQ
-qLv
-uqc
+hRI
+obm
 mzA
-iHq
+lgE
 tYg
-vCE
-vCE
+tYg
+iHq
+dpT
+ocB
+cAr
 krG
-cAr
-cAr
-eyh
-pHc
-fWC
+wEd
+aiz
+wEd
 kNs
+lMe
+fPC
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -373504,39 +373937,39 @@ krG
 iHq
 iHq
 mzA
-mzA
+hCY
 iHq
 mzA
 hCY
-gVS
+obm
+pFv
 lVM
+pfk
+pfk
+cVx
+cVx
+pfk
+pfk
 lVM
-lVM
-lVM
-lVM
-lVM
-lVM
-lVM
-lVM
-krG
-aHn
-tYg
-tYg
-tYg
+pfk
+hRI
+obm
+mzA
+sHo
+mzA
+mzA
 iHq
-dpT
-vuH
-wHu
-krG
-kno
-uPV
-kno
-kno
-wDg
-kVm
+tYg
+uub
+dxQ
+cCQ
+sBE
+wEd
+wEd
+wEd
+wrE
+qRI
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -373761,39 +374194,39 @@ sEI
 aom
 iHq
 pnK
-rgX
+saS
 iHq
 pnK
 saS
 obm
 lVM
 lVM
-lVM
-rMf
+syQ
+jGG
+jGG
+jGG
 tef
-rMf
-tef
-rMf
+bnz
 lVM
-sxp
-mzA
-sHo
-mzA
-mzA
+lVM
+byD
+obm
+lgE
+lgE
+lgE
+lgE
+iHq
 iHq
 tYg
-uub
-dxQ
+dQp
 cCQ
-xFE
-kno
-kno
-kno
-foR
-kVm
+wEd
+wEd
+wEd
+wEd
+jff
+qRI
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -374022,35 +374455,35 @@ iHq
 iHq
 iHq
 iHq
+bDH
 lVM
-lVM
-lVM
-lVM
-rMf
-fEN
-kpJ
+pfk
+wnW
+pgt
+tYg
+tYg
 nDz
-xXP
+bnz
+pfk
 lVM
+pfk
+nSO
 iHq
-nSO
-nSO
-nSO
-nSO
+iHq
+iHq
+iHq
 iHq
 iHq
 iHq
 iHq
 buC
-kno
-kno
-kno
-kno
-foR
-kVm
+wEd
+wEd
+wEd
+wEd
+jff
+qRI
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -374279,17 +374712,19 @@ iHq
 iHq
 iHq
 iHq
+bDH
 lVM
-lVM
-lVM
-lVM
-rMf
-tNW
-wYs
+pfk
+wnW
+pgt
+tYg
+tYg
 foM
-hnU
+pfk
+pfk
 lVM
-iHq
+pfk
+nSO
 iHq
 iHq
 iHq
@@ -374299,15 +374734,13 @@ iHq
 iHq
 iHq
 nFS
-kno
-kno
-kno
-kno
-foR
-kVm
+wEd
+wEd
+wEd
+wEd
+jff
+qRI
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -374532,39 +374965,39 @@ sEI
 pCJ
 iHq
 oGI
-ijw
+tZh
 iHq
 oGI
 tZh
 obm
 lVM
 lVM
-lVM
-rMf
-uKz
+syQ
+lND
+lND
 lND
 dYG
-xXP
+bnz
 lVM
+lVM
+byD
+obm
+tYg
+lgE
+lgE
 iHq
-xmJ
-xmJ
-xmJ
-moJ
-aVi
-pWf
-kWl
-kWl
+iHq
+iHq
+iHq
+kCo
 cCQ
-hnx
-kno
-kno
-kno
-foR
-kVm
+wEd
+wEd
+wEd
+wEd
+jff
+qRI
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -374789,39 +375222,39 @@ krG
 iHq
 iHq
 mzA
-mzA
+hCY
 iHq
 mzA
 hCY
-gVS
-brP
-xyS
-brP
-rMf
-tef
-rMf
-tef
-rMf
-cEg
 obm
-xmJ
-xmJ
-xmJ
-ccX
+pFv
+lVM
+pfk
+pfk
+cVx
+cVx
+pfk
+pfk
+lVM
+pfk
+hRI
+obm
+lgE
+mzA
 pPa
-mCj
+lgE
 nSp
-xpK
-cCQ
 mZI
-kno
-kno
-bEh
-rYl
-kVm
+hup
+mZI
+cCQ
+oLb
+wEd
+wEd
+wEd
+eHk
+qRI
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -375046,39 +375479,39 @@ krG
 sRj
 hBR
 pnK
-rgX
+saS
 hBR
 pnK
 saS
 obm
-iKt
-iKt
-oRz
+lVM
+pfk
 lVM
 lVM
+pfk
+pfk
 lVM
 lVM
+pfk
 lVM
-ejg
+hRI
 obm
-lGB
-iOE
 xmJ
 meT
-pPa
-lmo
-bIV
+mzA
+lgE
+nSp
 uMw
-cCQ
+vTn
 eVp
-cEq
+cCQ
 laI
-dXY
-fWC
+wEd
+wEd
 xqC
+lMe
+jpf
 ify
-tFB
-tFB
 tFB
 tFB
 tFB
@@ -375308,33 +375741,33 @@ cCQ
 krG
 krG
 obm
-qQX
-iuc
-oRz
+lVM
+lVM
+pfk
+lVM
+hlA
+lVM
+lVM
+pfk
 lVM
 lVM
 lVM
-lVM
-dZz
-kaQ
-cCQ
-krG
-krG
-krG
-krG
-krG
-cCQ
-cCQ
-cCQ
+obm
+lgE
+mzA
+mzA
+lgE
+nSp
+jFo
+mkF
+utq
 cCQ
 scE
-scE
-scE
-scE
-xqC
-ify
-tFB
-tFB
+umC
+wLt
+lqt
+qRI
+mla
 tFB
 tFB
 tFB
@@ -375565,33 +375998,33 @@ tFB
 tFB
 tFB
 obm
-brP
-acJ
-brP
-mfm
-qHd
-qHd
-iiA
+tYg
 jbr
 awR
+lVM
+pfk
+pfk
+lVM
+jbr
+awR
+wiG
 cCQ
-uzE
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
+obm
+tYg
+lgE
+lgE
+tYg
+cCQ
+krG
+krG
+cCQ
+cCQ
+izU
+izU
+izU
+izU
+jpf
+ify
 tFB
 tFB
 tFB
@@ -375821,33 +376254,33 @@ tFB
 tFB
 tFB
 tFB
+obm
+uTG
+mzA
+mzA
+lVM
+mzA
+qaf
+lVM
+mzA
+mzA
+cCQ
+cCQ
+cCQ
 cCQ
 krG
 krG
-krG
 cCQ
 cCQ
-cCQ
-cCQ
-krG
-krG
-cCQ
-ify
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
+dCI
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
+pLJ
 tFB
 tFB
 tFB
@@ -376078,18 +376511,18 @@ tFB
 tFB
 tFB
 tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
+cCQ
+obm
+lnC
+mmJ
+lVM
+qyf
+tYg
+lVM
+xZC
+cCQ
+cCQ
+uzE
 tFB
 tFB
 tFB
@@ -376336,16 +376769,16 @@ tFB
 tFB
 tFB
 tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
+cCQ
+kLj
+kLj
+kLj
+cCQ
+kLj
+kLj
+kLj
+cCQ
+ify
 tFB
 tFB
 tFB
@@ -387112,9 +387545,9 @@ tFB
 klT
 loq
 uHE
-wLC
+ikA
 kdd
-qNL
+rxK
 rXG
 fih
 lDv
@@ -387367,12 +387800,12 @@ tFB
 tFB
 tFB
 klT
-puc
+lFK
 lRU
-wLC
-hwb
+ikA
+gnd
 hGg
-qNL
+jpL
 hHa
 lDv
 fof
@@ -387625,11 +388058,11 @@ tFB
 tFB
 gZL
 iFS
-wLC
-wLC
-hwb
-qNL
-qNL
+ikA
+ikA
+gnd
+qYc
+qhB
 oaw
 lDv
 gIN
@@ -387881,10 +388314,10 @@ tFB
 tFB
 tFB
 klT
+bqd
+bqd
 vSl
-vSl
-vSl
-qIp
+kIB
 uzi
 cwy
 qIp
@@ -388137,14 +388570,14 @@ tFB
 tFB
 tFB
 tFB
-fbY
+msY
+waN
+ikA
+kIL
+oZL
+rxK
 qNL
-qNL
-qNL
-qNL
-qNL
-qNL
-qNL
+mTi
 lDv
 pYN
 cXo
@@ -388162,7 +388595,7 @@ uyr
 uyr
 gZL
 ujU
-pOm
+gfR
 oPD
 dUn
 pOm
@@ -388394,14 +388827,14 @@ tFB
 tFB
 tFB
 tFB
-fbY
+msY
+jEb
+fMS
+pPV
+gnd
 qNL
-qNL
-qNL
-qNL
-qNL
-qNL
-qNL
+uRW
+nKn
 uyr
 lDv
 xib
@@ -388417,9 +388850,9 @@ unx
 unx
 gZL
 tZO
-qYc
-qYc
-qYc
+uPK
+gnd
+dYs
 qYc
 qYc
 qYc
@@ -388651,14 +389084,14 @@ tFB
 tFB
 tFB
 tFB
-fbY
+msY
 vJb
 vGK
 eSN
 hgT
-qNL
-qNL
-qNL
+rWn
+nTi
+ikA
 lDv
 hXn
 cri
@@ -388667,19 +389100,19 @@ uyr
 uyr
 uyr
 rTs
-sDD
-qYc
+uYc
+igV
 uyr
 uyr
 uyr
 klT
 oMp
-qYc
+xDe
 cPZ
+pUV
+uBk
+uBk
 cIk
-sbT
-cIk
-sbT
 cIk
 ttp
 qYc
@@ -388913,9 +389346,9 @@ puc
 wLC
 wLC
 umV
-qNL
-qNL
-oaw
+oZy
+neJ
+kQl
 rTs
 rDH
 rDH
@@ -388930,13 +389363,13 @@ mab
 mAL
 mAL
 gZL
-qYc
-qYc
-fLN
+ikA
+ikA
+gZL
+jfi
 aYA
-aYA
-aYA
-aYA
+euY
+aaX
 aYA
 mlK
 qYc
@@ -389170,9 +389603,9 @@ ybV
 bye
 ggU
 qXV
-eaA
-qNL
-hGg
+oZy
+neJ
+jpJ
 sXp
 mAL
 mAL
@@ -389187,15 +389620,15 @@ mAL
 mAL
 mAL
 oQZ
-qYc
-bId
+ikA
+jpJ
 lFK
-aYA
-aYA
-gEu
-aYA
-aYA
-oVh
+crv
+tCu
+tFH
+tFH
+iAg
+mlK
 bId
 fbY
 ify
@@ -389427,9 +389860,9 @@ puc
 wLC
 wLC
 qpV
-qNL
-qNL
-oaw
+oZy
+neJ
+kQl
 rTs
 gaB
 mAL
@@ -389444,14 +389877,14 @@ kPT
 mAL
 mAL
 gZL
-qYc
-qYc
-fLN
+ikA
+ikA
+gZL
+qom
+noW
 aYA
 aYA
-aYA
-aYA
-aYA
+hdQ
 mlK
 qYc
 fbY
@@ -389679,14 +390112,14 @@ tFB
 tFB
 tFB
 tFB
-fbY
+msY
 ucK
 dNi
 jMM
 fNW
-qNL
-qNL
-qNL
+rtI
+puB
+ikA
 uyr
 uyr
 hEJ
@@ -389695,19 +390128,19 @@ uyr
 uyr
 uyr
 rTs
-sDD
-qYc
+xIy
+vVE
 uyr
 uyr
 uyr
 klT
 sDD
-qYc
+fjh
 uPZ
+nDF
+vSX
+vSX
 fLJ
-qkX
-fLJ
-qkX
 fLJ
 uhH
 qYc
@@ -389936,14 +390369,14 @@ tFB
 tFB
 tFB
 tFB
-fbY
-qNL
-qNL
-qNL
-qNL
-qNL
-qNL
-qNL
+msY
+etF
+xdK
+ulN
+gnd
+igV
+jtT
+vVE
 uyr
 aKN
 qYc
@@ -389958,10 +390391,10 @@ uyr
 unx
 unx
 gZL
-gOQ
-qYc
-qYc
-qYc
+ikA
+uPK
+gnd
+dYs
 qYc
 qYc
 qYc
@@ -390193,14 +390626,14 @@ tFB
 tFB
 tFB
 tFB
-fbY
-qNL
-qNL
-qNL
-qNL
-qNL
-qNL
-qNL
+msY
+bAp
+wjL
+eYv
+oZL
+uor
+mTi
+qYc
 uyr
 xJq
 qYc
@@ -390221,9 +390654,9 @@ cLI
 hio
 qYc
 eWK
+dba
 pco
-pco
-qYc
+huV
 uyr
 klT
 ify
@@ -390452,12 +390885,12 @@ tFB
 tFB
 klT
 kmB
-fUC
-xFR
+wLC
+wLC
 oZc
 irM
-qNL
-oaw
+mTi
+qAn
 uyr
 uyr
 bcw
@@ -390708,13 +391141,13 @@ tFB
 tFB
 tFB
 gZL
-uGG
-ujL
+lFK
+hAN
 ujL
 mRH
 qin
-qNL
-qNL
+tFc
+qYc
 uyr
 eXd
 bId
@@ -390733,7 +391166,7 @@ unx
 iMZ
 tNC
 xFi
-mAL
+igV
 qzi
 uyr
 ify
@@ -390966,10 +391399,10 @@ tFB
 tFB
 klT
 gjE
-enA
+sQA
 enA
 muW
-rYP
+qin
 qNL
 uQc
 uyr
@@ -390989,7 +391422,7 @@ unx
 unx
 iMZ
 aYj
-mAL
+qVH
 xkF
 wih
 uyr
@@ -391992,7 +392425,7 @@ tFB
 tFB
 tFB
 tFB
-fbY
+msY
 hIu
 hIu
 gZL


### PR DESCRIPTION

## About The Pull Request
This PR removes a LOT of TG sprites, replacing them with darkpack re-sprites.

Touches up the chantry(some), both museums, the FBI's hideout, the main floor of the Dora, and fixes the asylum lock helper oversight, and updates the Jazz club

## Why It's Good For The Game
MAP. 

## Changelog
:cl:
map: Updates a LOT on san fran, please review the PR for details.
/:cl:
