### PR TITLE
[TM NEEDED] See adjective of examined people with guestbook names

### DIFF
--- a/code/__DEFINES/~darkpack/guestbook.dm
+++ b/code/__DEFINES/~darkpack/guestbook.dm
@@ -8,7 +8,9 @@
 /// We will not be known by others, even if they pass checks in any way otherwise
 #define GUESTBOOK_FORGETMENOT (1 << 3)
 
+/// Whether a guestbook entry of mob for guest exists
+#define GET_GUESTBOOK_ENTRY(mob, guest) mob?.mind?.guestbook?.get_known_name(mob, guest)
 /// Differs from GET_GUESTBOOK_NAME_TRUE as it returns the known name OR the whole mob for situations where we directly embed into a string for text macros.
-#define GET_GUESTBOOK_NAME(mob, guest) (mob?.mind?.guestbook?.get_known_name(mob, guest) || guest)
+#define GET_GUESTBOOK_NAME(mob, guest) (GET_GUESTBOOK_ENTRY(mob, guest) || guest)
 /// Macro to get a STRING (never a mob) of the name we refer to them as.
-#define GET_GUESTBOOK_NAME_TRUE(mob, guest) (mob?.mind?.guestbook?.get_known_name(mob, guest) || guest.name)
+#define GET_GUESTBOOK_NAME_TRUE(mob, guest) (GET_GUESTBOOK_ENTRY(mob, guest) || guest.name)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -71,6 +71,8 @@
 
 	// DARKPACK EDIT ADD START
 	var/known_name = face_name ? null : (examiner ? GET_GUESTBOOK_NAME(examiner, src) : null)
+	if(known_name && examiner != src && GET_GUESTBOOK_ENTRY(examiner, src)) // If this is a guestbook name, show original name too
+		known_name += ", [src]"
 	// DARKPACK EDIT ADD END
 
 	// Just go down the list of stuff we recorded


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When you examine someone with a guestbook entry, it appends their adjective that appears when you examine them normally.

Without guestbook:
<img width="1106" height="732" alt="image" src="https://github.com/user-attachments/assets/de32b02b-18b7-4a3f-b41a-b300ca1f6d28" />

With guestbook:
<img width="1210" height="731" alt="image" src="https://github.com/user-attachments/assets/e91ee5d9-4e37-48bf-8303-d5e37451fc60" />

Face obscured:
<img width="1037" height="762" alt="image" src="https://github.com/user-attachments/assets/7c6c1128-e57b-4345-8439-53c598c184e7" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When you add someone in your guestbook, you are no longer able to communicate their identity to someone else who may not have a guestbook set for the examined person. This fixes that by always providing the person's adjective when appropriate.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: you can now always see the adjective of an examined person (if you can see their face)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
